### PR TITLE
Refactor config + project ingestion

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,11 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
+      # Required due to a bug in the checkout action
+      # https://github.com/actions/checkout/issues/1471
+      - run: git fetch --prune --unshallow --tags
 
       -
         name: Set up Python
@@ -61,9 +65,8 @@ jobs:
         include:
           - dockerfile: "Dockerfile.ci"
             image: "atopile-ci"
-          # FIXME: hush... soon my child
-          # - dockerfile: "kicad"
-          #   image: "atopile-kicad"
+          - dockerfile: "Dockerfile.kicad"
+            image: "atopile-kicad"
 
     # Sets the permissions granted to the `GITHUB_TOKEN`
     # for the actions in this job.
@@ -72,7 +75,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       -
         name: Download python-package
@@ -108,14 +111,14 @@ jobs:
         with:
           context: .
           file: dockerfiles/${{ matrix.dockerfile }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
   # vscode: TODO:
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v2
+  #     - uses: actions/checkout@v4
 
   #     - uses: actions/setup-node@v1
   #       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
       uses: actions/setup-python@v2

--- a/dockerfiles/Dockerfile.ci
+++ b/dockerfiles/Dockerfile.ci
@@ -4,4 +4,4 @@ FROM python:latest
 
 COPY dist/atopile-*.tar.gz /tmp/atopile.tar.gz
 
-RUN pip install /tmp/atopile.tar.gz"[dev,test,docs]"
+RUN pip install "/tmp/atopile.tar.gz[dev,test,docs]"

--- a/dockerfiles/Dockerfile.kicad
+++ b/dockerfiles/Dockerfile.kicad
@@ -1,0 +1,31 @@
+# a minimal Dockerfile for CI
+FROM kicad/kicad:7.0.10
+
+# We use root for this container, despite the permission-turds
+# since it's all Github actions currently supports.
+# In the future we might consider creating a distinct github-actions
+# container to reconcile this with other more standard CI systems.
+USER root
+
+COPY --chown=kicad:kicad dist/atopile-*.tar.gz /tmp/atopile.tar.gz
+
+RUN sudo apt-get update \
+    && sudo apt-get install -y \
+        python3-pip \
+        python3-venv \
+
+    # Create a user-owned venv for atopile
+    # Ubuntu doesn't seem to support pip-installing modules globally
+    && sudo mkdir -p /opt/atopile \
+    && sudo chown -R kicad:kicad /opt/atopile \
+    && python3 -m venv /opt/atopile \
+    && . /opt/atopile/bin/activate \
+    # Install atopile
+    && pip3 install --upgrade pip \
+    && pip3 install "/tmp/atopile.tar.gz[dev,test,docs]" \
+    # Add the ato CLI to something on PATH
+    && sudo cp /opt/atopile/bin/ato /usr/local/bin/ato
+
+# We need to set the github workspace as a safe directory according
+# to git so we can get version information like the githash from it
+ENTRYPOINT [ "bash", "-c", "git config --global --add safe.directory /github/workspace && ato install && ato build" ]

--- a/src/atopile/cli/cli.py
+++ b/src/atopile/cli/cli.py
@@ -24,16 +24,23 @@ logging.basicConfig(
 # cli root
 @click.version_option()
 @click.group()
-@click.option("--debugpy", is_flag=True)
-def cli(debugpy: bool):
+@click.option("--debug", is_flag=True)
+@click.option("-v", "--verbose", count=True)
+def cli(debug: bool, verbose: int):
     """Base CLI group."""
     # we process debugpy first, so we can attach the debugger ASAP into the process
-    if debugpy:
-        import debugpy as debugpy_mod  # pylint: disable=import-outside-toplevel
+    if debug:
+        import debugpy  # pylint: disable=import-outside-toplevel
         debug_port = 5678
-        debugpy_mod.listen(("localhost", debug_port))
+        debugpy.listen(("localhost", debug_port))
         logging.info("Starting debugpy on port %s", debug_port)
-        debugpy_mod.wait_for_client()
+        debugpy.wait_for_client()
+
+    # set the log level
+    if verbose == 1:
+        logging.root.setLevel(logging.DEBUG)
+    elif verbose > 1:
+        logging.root.setLevel(logging.NOTSET)
 
 
 cli.add_command(build.build)

--- a/src/atopile/cli/common.py
+++ b/src/atopile/cli/common.py
@@ -10,15 +10,12 @@ from typing import Iterable
 
 import click
 from omegaconf import OmegaConf
-from omegaconf.errors import InterpolationToMissingValueError, ConfigKeyError
+from omegaconf.errors import ConfigKeyError
 
+import atopile.config
 from atopile import address, errors, version
 from atopile.address import AddrStr
-from atopile.config import (
-    Config,
-    get_project_config_from_addr,
-    get_project_config_from_path,
-)
+from atopile.config import get_project_config_from_path
 
 log = logging.getLogger(__name__)
 
@@ -29,19 +26,20 @@ def project_options(f):
     """
 
     @click.argument("entry", required=False, default=None)
-    @click.option("-b", "--build", default=None)
-    @click.option("-c", "--config", multiple=True)
+    @click.option("-b", "--build", multiple=True)
     @click.option("-t", "--target", multiple=True)
+    @click.option("-o", "--option", multiple=True)
     @functools.wraps(f)
     def wrapper(
         *args,
         entry: str,
-        build: str,
-        config: Iterable[str],
+        build: Iterable[str],
         target: Iterable[str],
+        option: Iterable[str],
         **kwargs,
     ):
         """Wrap a CLI command to ingest common config options to build a project."""
+
         # basic the entry address if provided, otherwise leave it as None
         if entry is not None:
             entry = AddrStr(entry)
@@ -61,45 +59,37 @@ def project_options(f):
             )
 
         try:
-            project_config = get_project_config_from_addr(str(entry_arg_file_path))
+            project_config = atopile.config.get_project_config_from_addr(str(entry_arg_file_path))
         except FileNotFoundError as ex:
             # FIXME: this raises an exception when the entry is not in a project
             raise click.BadParameter(
                 f"Could not find project from path {str(entry_arg_file_path)}. Is this file path within a project?"
             ) from ex
 
-        log.info("Using project %s", project_config.paths.project)
-        # layer on selected targets
-        if target:
-            project_config.selected_build.targets = list(target)
+        # Make sure I an all my sub-configs have appropriate versions
+        check_compiler_versions(project_config)
 
-        # set the build config
-        if build is not None:
-            if build not in project_config.builds:
-                raise click.BadParameter(
-                    f'Could not find build-config "{build}". Available build configs are: {", ".join(project_config.builds.keys())}.'
-                )
-            selected_build_name = build
-            log.info("Selected build: %s", selected_build_name)
+        log.info("Using project %s", project_config.location)
 
         # add custom config overrides
-        if config:
-            cli_conf = OmegaConf.from_dotlist(config)
+        if option:
+            try:
+                config: atopile.config.UserConfig = OmegaConf.merge(
+                    project_config,
+                    OmegaConf.from_dotlist(option)
+                )
+            except ConfigKeyError as ex:
+                raise click.BadParameter(f"Invalid config key {ex.key}") from ex
+
         else:
-            cli_conf = OmegaConf.create()
+            config: atopile.config.UserConfig = project_config
 
-        # finally smoosh them all back together like a delicious cake
-        # FIXME: why are we smooshing this -> does this need to be mutable?
-        try:
-            config = OmegaConf.merge(project_config, cli_conf)
-        except ConfigKeyError as ex:
-            raise click.BadParameter(f"Invalid config key {ex.key}") from ex
-
-        # layer on the selected addrs config
+        # if we set an entry-point, we now need to deal with that
+        entry_addr_override = None
         if entry:
             if entry_arg_file_path.is_file():
                 if entry_section := address.get_entry_section(entry):
-                    config.selected_build.abs_entry = address.from_parts(
+                    entry_addr_override = address.from_parts(
                         str(entry_arg_file_path.absolute()),
                         entry_section,
                     )
@@ -109,8 +99,10 @@ def project_options(f):
                         " the node within it you want to build.",
                         param_hint="entry",
                     )
+
             elif entry_arg_file_path.is_dir():
-                pass  # ignore this case, we'll use the entry point in the ato.yaml
+                pass
+
             elif not entry_arg_file_path.exists():
                 raise click.BadParameter(
                     "The entry you have specified does not exist.",
@@ -121,24 +113,29 @@ def project_options(f):
                     f"Unexpected entry path type {entry_arg_file_path} - this should never happen!"
                 )
 
-        # ensure we have an entry-point
-        try:
-            config.selected_build.abs_entry
-        except InterpolationToMissingValueError as ex:
-            raise click.BadParameter("No entry point to build from!") from ex
+        # Make build contexts
+        builds_to_build = build or config.builds.keys()
+        build_ctxs: list[atopile.config.BuildContext] = []
+        for _build in builds_to_build:
+            build_ctx = atopile.config.BuildContext.from_config(config, _build)
+            if entry_addr_override is not None:
+                build_ctx.entry = entry_addr_override
+            if target:
+                build_ctx.targets = list(target)
+            build_ctxs.append(build_ctx)
 
-        # do the thing
-        return f(*args, **kwargs, config=config)
+        # Do the thing
+        return f(*args, **kwargs, build_ctxs=build_ctxs)
 
     return wrapper
 
 
-def check_compiler_versions(config: Config):
+def check_compiler_versions(config: atopile.config.UserConfig):
     """Check that the compiler version is compatible with the version used to build the project."""
     with errors.handle_ato_errors():
         dependency_cfgs = (
             errors.downgrade(get_project_config_from_path, FileNotFoundError)(p)
-            for p in Path(config.paths.abs_module_path).glob("*")
+            for p in Path(config.location).glob("*")
         )
 
         for cltr, cfg in errors.iter_through_errors(
@@ -158,5 +155,5 @@ def check_compiler_versions(config: Config):
 
                 if not version.match_compiler_compatability(built_with_version):
                     raise version.VersionMismatchError(
-                        f"{cfg.paths.project} can't be built with this version of atopile."
+                        "Can't be built with this version of atopile."
                     )

--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -4,71 +4,48 @@
 
 import collections.abc
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 import yaml
 from attrs import Factory, define
 from omegaconf import MISSING, OmegaConf
 
 from atopile import address
+import atopile.errors
 
-USER_CONFIG_PATH = Path("~/.atopile/config.yaml").expanduser().resolve().absolute()
 CONFIG_FILENAME = "ato.yaml"
 ATO_DIR_NAME = ".ato"
 MODULE_DIR_NAME = "modules"
+BUILD_DIR_NAME = "build"
 
 
 @define
-class Paths:
+class UserPaths:
     """Config grouping for all the paths in a project."""
 
-    project: Path = MISSING  # should be the absolute path to the project root
-
     src: Path = "./"
-    abs_src: Path = "${.project}/${.src}"
-
-    build: Path = "build"
-    abs_build: Path = "${.project}/${.build}"
-
-    footprints: Path = "elec/lib/lib.pretty"
-    abs_footprints: Path = "${.project}/${.footprints}"
-
-    kicad_project: Path = "elec/layout"
-    abs_kicad_project: Path = "${.project}/${.kicad_project}"
-
-    abs_module_path: Path = "${.project}/" + f"{ATO_DIR_NAME}/{MODULE_DIR_NAME}"
-
-    abs_selected_build_path: Path = "${.abs_build}/${selected_build_name}"
+    layout: Path = "elec/layout"
 
 
 @define
-class BuildConfig:
+class UserBuildConfig:
     """Config for a build."""
 
     entry: str = MISSING
-    abs_entry: str = "${paths.abs_src}/${.entry}"
-
     targets: list[str] = ["*"]
 
 
 @define
-class Config:
+class UserConfig:
     """
     The config object for atopile.
-    NOTE: this is the config for both the project, and the user.
-    Project settings take precedent over user settings.
     """
 
+    location: Path = MISSING
+
     ato_version: str = "0.1.0"
-
-    paths: Paths = Factory(Paths)
-
-    builds: dict[str, BuildConfig] = Factory(lambda: {"default": BuildConfig()})
-    default_build: BuildConfig = "${.builds[default]}"
-
-    selected_build_name: str = "default"
-    selected_build: BuildConfig = "${.builds[${.selected_build_name}]}"
-
+    paths: UserPaths = Factory(UserPaths)
+    builds: dict[str, UserBuildConfig] = Factory(dict)
     dependencies: list[str] = []
 
 
@@ -92,28 +69,21 @@ def _sanitise_dict_keys(d: collections.abc.Mapping) -> collections.abc.Mapping:
     return dict(_sanitise_item(item) for item in d.items())
 
 
-def make_config(project_config: Path, build: Optional[str] = None) -> Config:
+def make_config(project_config: Path) -> UserConfig:
     """
     Make a config object for a project.
 
     The typing on this is a little white lie... because they're really OmegaConf objects.
     """
-    structure = Config()
-    structure.paths.project = project_config.parent # pylint: disable=assigning-non-slot
-    if build is not None:
-        structure.selected_build_name = build
-
-    if USER_CONFIG_PATH.exists():
-        user_config = OmegaConf.load(USER_CONFIG_PATH)
-    else:
-        user_config = OmegaConf.create()  # empty config
+    structure = UserConfig()
 
     with project_config.open() as f:
         config_data = yaml.safe_load(f)
 
+    structure.location = project_config.parent.expanduser().resolve().absolute()
+
     return OmegaConf.merge(
         OmegaConf.structured(structure),  # structure
-        user_config,  # user config
         OmegaConf.create(_sanitise_dict_keys(config_data)),  # project config
     )
 
@@ -134,7 +104,7 @@ def get_project_dir_from_path(path: Path) -> Path:
 _loaded_configs: dict[Path, str] = {}
 
 
-def get_project_config_from_path(path: Path) -> Config:
+def get_project_config_from_path(path: Path) -> UserConfig:
     """
     Get the project config from an address.
     """
@@ -145,8 +115,90 @@ def get_project_config_from_path(path: Path) -> Config:
     return _loaded_configs[project_config_file]
 
 
-def get_project_config_from_addr(addr: str) -> Config:
+def get_project_config_from_addr(addr: str) -> UserConfig:
     """
     Get the project config from an address.
     """
     return get_project_config_from_path(Path(address.get_file(addr)))
+
+
+# FIXME: we need factory constructors for these classes
+@define
+class ProjectContext:
+    """A class to hold the arguments to a project."""
+
+    layout_path: Path  # eg. path/to/project/layouts/default/default.kicad_pcb
+    project_path: Path  # abs path to the project directory
+    src_path: Path  # abs path to the source directory
+    module_path: Path  # abs path to the module directory
+
+    @classmethod
+    def from_config(cls, config: UserConfig) -> "ProjectContext":
+        """Create a BuildArgs object from a Config object."""
+
+        return ProjectContext(
+            layout_path=Path(config.location) / config.paths.layout,
+            project_path=Path(config.location),
+            src_path=Path(config.location) / config.paths.src,
+            module_path=Path(config.location) / ATO_DIR_NAME / MODULE_DIR_NAME,
+        )
+
+    @classmethod
+    def from_path(cls, path: Path) -> "ProjectContext":
+        """Create a BuildArgs object from a Config object."""
+        return cls.from_config(get_project_config_from_path(path))
+
+
+@define
+class BuildContext:
+    """A class to hold the arguments to a build."""
+
+    name: str
+
+    entry: address.AddrStr  # eg. "path/to/project/src/entry-name.ato:module.path"
+    targets: list[str]
+    layout_path: Path  # eg. path/to/project/layouts/default/default.kicad_pcb
+
+    layout_path: Path  # eg. path/to/project/layouts/default/default.kicad_pcb
+    project_path: Path  # abs path to the project directory
+    src_path: Path  # abs path to the source directory
+    module_path: Path  # abs path to the module directory
+    build_path: Path  # eg. path/to/project/build/<build-name>
+
+    output_base: Path  # eg. path/to/project/build/<build-name>/entry-name
+
+    @classmethod
+    def from_config(cls, config: UserConfig, build_name: str) -> "BuildContext":
+        """Create a BuildArgs object from a Config object."""
+        build_config = config.builds[build_name]
+
+        abs_entry = address.AddrStr(config.location / build_config.entry)
+
+        build_path = Path(config.location) / BUILD_DIR_NAME
+
+        layout_base = config.location / config.paths.layout / build_name
+        if layout_base.with_suffix(".kicad_pcb").exists():
+            layout_path = layout_base.with_suffix(".kicad_pcb")
+        elif layout_base.is_dir():
+            layout_candidates = list(layout_base.glob("*.kicad_pcb"))
+            if len(layout_candidates) == 1:
+                layout_path = layout_candidates[0]
+            else:
+                raise atopile.errors.AtoError(
+                    "Layout directories must contain exactly 1 layout,"
+                    f" but {len(layout_path)} found in {layout_base}"
+                )
+        else:
+            raise atopile.errors.AtoError("Layout file not found")
+
+        return BuildContext(
+            name=build_name,
+            entry=abs_entry,
+            targets=build_config.targets,
+            layout_path=layout_path,
+            project_path=Path(config.location),
+            src_path=Path(config.location) / config.paths.src,
+            module_path=Path(config.location) / ATO_DIR_NAME / MODULE_DIR_NAME,
+            build_path=build_path,
+            output_base=build_path / build_name,
+        )

--- a/src/atopile/manufacturing_data.py
+++ b/src/atopile/manufacturing_data.py
@@ -1,0 +1,143 @@
+"""
+This script largely controls the KiCAD CLI to generate
+gerbers/drill files/etc... required to make circuit boards
+"""
+
+import logging
+import re
+import subprocess
+import sys
+import zipfile
+from os import PathLike
+from pathlib import Path
+from time import time
+from typing import Optional
+
+import git
+
+import atopile.errors
+from atopile.config import BuildContext
+
+log = logging.getLogger(__name__)
+
+
+def find_kicad_cli() -> PathLike:
+    """Figure out what to call for the KiCAD CLI."""
+    if sys.platform.startswith("darwin"):
+        kicad_cli_candidates = list(Path("/Applications/KiCad/").glob("**/kicad-cli"))
+        # FIXME: handle multiple candidates
+        return kicad_cli_candidates[0]
+    elif sys.platform.startswith("linux"):
+        return "kicad-cli"  # assume it's on the PATH
+
+
+def run(*args, timeout_time: Optional[float] = 10, **kwargs) -> None:
+    """Run a subprocess"""
+    process = subprocess.Popen(
+        *args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        **kwargs
+    )
+
+    def _do_logging():
+        outs, errs = process.communicate(timeout=0.1)
+        for line in outs.splitlines():
+            log.info(line)
+        for line in errs.splitlines():
+            log.error(line)
+
+    start_time = time()
+    while timeout_time is not None and time() - start_time < timeout_time:
+        if process.poll() is not None:
+            break
+        try:
+            _do_logging()
+        except subprocess.TimeoutExpired:
+            continue
+    else:
+        process.kill()
+
+    exit_code = process.wait()
+    _do_logging()
+
+    if exit_code != 0:
+        raise atopile.errors.AtoError(
+            f"Command {args} failed with exit code {exit_code}"
+        )
+
+
+def generate_manufacturing_data(build_ctx: BuildContext) -> None:
+    """Generate manufacturing data for the project."""
+
+    # Ensure the build directory exists
+    build_ctx.build_path.mkdir(parents=True, exist_ok=True)
+
+    # Replace constants in the board file
+    current_githash = git.Repo(build_ctx.project_path).head.commit.hexsha
+    short_githash = current_githash[:7]
+
+    modded_kicad_pcb = build_ctx.output_base.with_suffix(
+        ".kicad_pcb"
+    )
+    githash_kw = re.compile(re.escape("{{GITHASH}}"))
+    with build_ctx.layout_path.open("r") as f_src, modded_kicad_pcb.open("w") as f_dst:
+        for line in f_src:
+            f_dst.write(githash_kw.sub(short_githash, line))
+
+    # Setup for Gerbers
+    gerber_dir = build_ctx.output_base.with_name(f"{build_ctx.output_base.name}-gerbers-{short_githash}")
+    gerber_dir.mkdir(exist_ok=True, parents=True)
+    gerber_dir_str = str(gerber_dir)
+    if not gerber_dir_str.endswith("/"):
+        gerber_dir_str += "/"
+
+    kicad_cli = find_kicad_cli()
+
+    # Generate Gerbers
+    run([
+        kicad_cli,
+        "pcb",
+        "export",
+        "gerbers",
+        "-o",
+        gerber_dir_str,
+        str(modded_kicad_pcb),
+    ])
+    run([
+        kicad_cli,
+        "pcb",
+        "export",
+        "drill",
+        "-o",
+        gerber_dir_str,
+        str(modded_kicad_pcb),
+    ])
+
+    # Zip Gerbers
+    zip_path = gerber_dir.with_suffix(".zip")
+    with zipfile.ZipFile(zip_path, "w") as zip_file:
+        for file in gerber_dir.glob("*"):
+            zip_file.write(file)
+
+    # Position files need some massaging for JLCPCB
+    # We just need to replace the first row
+    pos_path = build_ctx.output_base.with_suffix(".pos.csv")
+    run([
+        kicad_cli,
+        "pcb",
+        "export",
+        "pos",
+        "--format",
+        "csv",
+        "--units",
+        "mm",
+        "--use-drill-file-origin",
+        "-o",
+        str(pos_path),
+        str(modded_kicad_pcb),
+    ])
+    pos_contents = pos_path.read_text().splitlines()
+    pos_contents[0] = "Designator,Value,Package,Mid X,Mid Y,Rotation,Layer"
+    pos_path.write_text("\n".join(pos_contents))


### PR DESCRIPTION
## Why?

- Support multiple boards for the same project
- Make CI on the user-side easier

See: https://toil.kitemaker.co/2hAmxC-atopile/dSlNKj-atopile/items/48

## What?

- Add `mfg-data` target which controls the KiCAD CLI
- Supports multiple builds with varying entry-points
- Add a `-v` / `--verbose` option to the CLI, allowing users to say `-v` or `-vv` for increaing logging verbosity. This replaces `--debug`
- `--debug` option now starts a `debugpy` session and waits for connection
- Add `atopile-kicad` container which installs both, and has an easy-to-use entry point for CI 
- Build targets now receive a `BuildContext` object containing data they'd otherwise need to infer or derive from the config/cli/etc... individually

## Validation

I used the logic-card project to smoke the changes: https://github.com/Timot05/logic-card/pull/1/checks

## Related PRs

https://github.com/atopile/project-template/pull/4