### PR TITLE
Improve error in case of a build that doesn't exist

### DIFF
--- a/src/atopile/cli/common.py
+++ b/src/atopile/cli/common.py
@@ -30,6 +30,7 @@ def project_options(f):
     @click.option("-t", "--target", multiple=True)
     @click.option("-o", "--option", multiple=True)
     @functools.wraps(f)
+    @errors.muffle_fatalities
     def wrapper(
         *args,
         entry: str,
@@ -117,7 +118,8 @@ def project_options(f):
         builds_to_build = build or config.builds.keys()
         build_ctxs: list[atopile.config.BuildContext] = []
         for _build in builds_to_build:
-            build_ctx = atopile.config.BuildContext.from_config(config, _build)
+            with errors.handle_ato_errors():
+                build_ctx = atopile.config.BuildContext.from_config(config, _build)
             if entry_addr_override is not None:
                 build_ctx.entry = entry_addr_override
             if target:

--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -49,9 +49,14 @@ class UserConfig:
     dependencies: list[str] = []
 
 
-def _sanitise_key(s: str) -> str:
-    """Sanitise a string to be a valid python identifier."""
-    return s.replace("-", "_")
+KEY_CONVERSIONS = {
+    "ato-version": "ato_version",
+}
+
+
+def _sanitise_key(key: str) -> str:
+    """Sanitize a key."""
+    return KEY_CONVERSIONS.get(key, key)
 
 
 def _sanitise_item(item: tuple[Any, Any]) -> tuple[Any, Any]:

--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -170,7 +170,13 @@ class BuildContext:
     @classmethod
     def from_config(cls, config: UserConfig, build_name: str) -> "BuildContext":
         """Create a BuildArgs object from a Config object."""
-        build_config = config.builds[build_name]
+        try:
+            build_config = config.builds[build_name]
+        except KeyError as ex:
+            raise atopile.errors.AtoError(
+                f"Build {build_name} not found for project {config.location}\n"
+                f"Available builds: {list(config.builds.keys())}"
+            ) from ex
 
         abs_entry = address.AddrStr(config.location / build_config.entry)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from atopile import config
 
 def test_sanitise_dict_keys():
     """Test that dict keys are sanitised."""
-    assert config._sanitise_dict_keys({"a-b": 1, "c-d": {"e-f": 2}}) == {
-        "a_b": 1,
-        "c_d": {"e_f": 2},
+    assert config._sanitise_dict_keys({"a-b": 1, "ato-version": {"e-f": 2}}) == {
+        "a-b": 1,
+        "ato_version": {"e-f": 2},
     }


### PR DESCRIPTION
## The error now looks like this:

<img width="1088" alt="Screenshot 2024-01-13 at 16 31 57" src="https://github.com/atopile/atopile/assets/4241578/0685a4c8-1456-4360-b8e2-493f96c11888">
