### PR TITLE
Return early in case of missing semver tags

### DIFF
--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -158,6 +158,7 @@ def install_dependency(
             "No semver tags found for this module. Using latest default branch :hot_pepper:.",
             extra={"markup": True},
         )
+        return None
 
     # If the repo is dirty, throw an error
     if repo.is_dirty():


### PR DESCRIPTION
## Fixes: https://github.com/atopile/atopile/issues/9

## Smoked it with the same command in the issue:
<img width="582" alt="Screenshot 2024-01-16 at 10 44 21" src="https://github.com/atopile/atopile/assets/4241578/b86aab61-88fa-48d3-8d1e-0fa470c32890">
