### PR TITLE
Resolve incorrect reference in build context error message

### DIFF
--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -197,7 +197,7 @@ class BuildContext:
             else:
                 raise atopile.errors.AtoError(
                     "Layout directories must contain exactly 1 layout,"
-                    f" but {len(layout_path)} found in {layout_base}"
+                    f" but {len(layout_candidates)} found in {layout_base}"
                 )
         else:
             raise atopile.errors.AtoError("Layout file not found")


### PR DESCRIPTION
It looks like the error message was meant to reference the other variable. Underlying problem (detecting `_autosave-*` and `~_autosave-*`) will still exist.