### PR TITLE
Githash should be question marks for dirty git-hashes

### DIFF
--- a/src/atopile/manufacturing_data.py
+++ b/src/atopile/manufacturing_data.py
@@ -75,8 +75,12 @@ def generate_manufacturing_data(build_ctx: BuildContext) -> None:
     build_ctx.build_path.mkdir(parents=True, exist_ok=True)
 
     # Replace constants in the board file
-    current_githash = git.Repo(build_ctx.project_path).head.commit.hexsha
-    short_githash = current_githash[:7]
+    repo = git.Repo(build_ctx.project_path)
+    short_githash_length = 7
+    if repo.is_dirty():
+        short_githash = "dirty"
+    else:
+        short_githash = repo.head.commit.hexsha[:short_githash_length]
 
     modded_kicad_pcb = build_ctx.output_base.with_suffix(
         ".kicad_pcb"


### PR DESCRIPTION
# What?

Make the "{{GITHASH}}" stamp on the boards "dirty" if the repo is dirty at build time.

This should only happen locally


<img width="314" alt="Screenshot 2024-01-24 at 16 24 11" src="https://github.com/atopile/atopile/assets/4241578/a9d0bce8-bc18-4f1a-a37b-ce3972390bda">
