### PR TITLE
Ensure the message is str

### DIFF
--- a/src/atopile/errors.py
+++ b/src/atopile/errors.py
@@ -150,7 +150,7 @@ def format_error(ex: AtoError, debug: bool = False) -> str:
         message += f"{source_info}\n"
 
     # Replace the address in the string, if we have it attached
-    fmt_message = textwrap.indent(ex.message, "--> ")
+    fmt_message = textwrap.indent(str(ex.message), "--> ")
     if ex.addr:
         if debug:
             addr = ex.addr


### PR DESCRIPTION
Seems like at least in one place the error raised is returning objects which are not str : Example:  atopile/parse.py line101 raise AtoFileNotFoundError(src_path) src_path here is actually Path