### PR TITLE
installs generics after running ato create automatically

### DIFF
--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -6,6 +6,7 @@ import textwrap
 import webbrowser
 from pathlib import Path
 from typing import Iterator, Optional
+from atopile.cli.install import install_core
 
 import caseconverter
 import click
@@ -159,6 +160,8 @@ def create(
             "[yellow]No changes to commit! Seems like the"
             " template you used mightn't be configurable?[/]"
         )
+    # install dependencies listed in the ato.yaml, typically just generics
+    install_core(to_install="", jlcpcb=False, upgrade=True, path=repo_obj.working_tree_dir)
 
     # Wew! New repo created!
     rich.print(f':sparkles: [green]Created new project "{name}"![/] :sparkles:')

--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -37,6 +37,7 @@ def install_core(to_install: str, jlcpcb: bool, upgrade: bool, path: Optional[Pa
     Install a dependency of for the project.
     """
     top_level_path = None
+    repo = None
     if not path:
         top_level_path = Path(repo.working_tree_dir)
         repo = Repo(".", search_parent_directories=True)

--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -28,12 +28,24 @@ log.setLevel(logging.INFO)
 @click.option("--jlcpcb", is_flag=True, help="JLCPCB component ID")
 @click.option("--upgrade", is_flag=True, help="Upgrade dependencies")
 @errors.muffle_fatalities
-def install(to_install: str, jlcpcb: bool, upgrade: bool):
+def install(to_install: str, jlcpcb: bool, upgrade: bool, path: Optional[Path] = None):
+    install_core(to_install, jlcpcb, upgrade, path)
+
+
+def install_core(to_install: str, jlcpcb: bool, upgrade: bool, path: Optional[Path] = None):
     """
     Install a dependency of for the project.
     """
-    repo = Repo(".", search_parent_directories=True)
-    top_level_path = Path(repo.working_tree_dir)
+    top_level_path = None
+    if not path:
+        top_level_path = Path(repo.working_tree_dir)
+        repo = Repo(".", search_parent_directories=True)
+
+    else:
+        top_level_path = Path(path)
+        repo = Repo(top_level_path, search_parent_directories=True)
+
+    log.info(f"Installing {to_install} in {top_level_path}")
 
     cfg = config.get_project_config_from_path(top_level_path)
     ctx = config.ProjectContext.from_config(cfg)


### PR DESCRIPTION
Small refactor of ato install, was having problems with click.

now at the very end of ato create we run a bare 'ato install'

<img width="791" alt="Screenshot 2024-01-31 at 8 33 31 PM" src="https://github.com/atopile/atopile/assets/8122613/97c11978-6d77-4dab-b462-de60fec49b3d">

There might be a better way to handle the paths here, but this seems to be functional.