### PR TITLE
Syntax highlight hack as github doesn't support ato syntax yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ What's your story in electronics? What would you like us to build? Come talk on 
 ### Simple examples:
 
 #### Votlage divider
-```ato
+```VHDL
 import Resistor from "generics/resistors.ato"
 
 module VoltageDivider:
@@ -57,7 +57,7 @@ module VoltageDivider:
 ```
 
 #### RP2040 Blinky Circuit
-```ato
+```VHDL
 import RP2040Kit from "rp2040/rp2040_kit.ato"
 import LEDIndicator from "generics/leds.ato"
 import LDOReg3V3 from "regulators/regulators.ato"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ What's your story in electronics? What would you like us to build? Come talk on 
 ### Simple examples:
 
 #### Votlage divider
-```VHDL
+```python
 import Resistor from "generics/resistors.ato"
 
 module VoltageDivider:
@@ -57,7 +57,7 @@ module VoltageDivider:
 ```
 
 #### RP2040 Blinky Circuit
-```VHDL
+```python
 import RP2040Kit from "rp2040/rp2040_kit.ato"
 import LEDIndicator from "generics/leds.ato"
 import LDOReg3V3 from "regulators/regulators.ato"


### PR DESCRIPTION
Github doesn't yet support ato, but based on your code syntax it appears to be more heavily based on python. 

This change simply switching to the python syntax. But later on if you are more established and github adds support, you can switch from python to ato syntax highlights

```python
import Resistor from "generics/resistors.ato"

module VoltageDivider:
    signal top
    signal out
    signal bottom

    r_top = new Resistor
    r_top.footprint = "R0402"
    r_top.value = 100kohm +/- 10%

    r_bottom = new Resistor
    r_bottom.footprint = "R0402"
    r_top.value = 200kohm +/- 10%

    top ~ r_top.p1; r_top.p2 ~ out
    out ~ r_bottom.p1; r_bottom.p2 ~ bottom



import RP2040Kit from "rp2040/rp2040_kit.ato"
import LEDIndicator from "generics/leds.ato"
import LDOReg3V3 from "regulators/regulators.ato"
import USBCConn from "usb-connectors/usb-connectors.ato"

module Blinky:
    micro_controller = new RP2040Kit
    led_indicator = new LEDIndicator
    voltage_regulator = new LDOReg3V3
    usb_c_connector = new USBCConn

    usb_c_connector.power ~ voltage_regulator.power_in
    voltage_regulator.power_out ~ micro_controller.power
    micro_controller.gpio13 ~ led_indicator.input
    micro_controller.power.gnd ~ led_indicator.gnd

    led_indicator.resistor.value = 100ohm +/- 10%
```