### PR TITLE
Search parent directories for Git root

### DIFF
--- a/src/atopile/manufacturing_data.py
+++ b/src/atopile/manufacturing_data.py
@@ -81,7 +81,7 @@ def generate_manufacturing_data(build_ctx: config.BuildContext) -> None:
     build_ctx.build_path.mkdir(parents=True, exist_ok=True)
 
     # Replace constants in the board file
-    repo = git.Repo(config.get_project_context().project_path)
+    repo = git.Repo(config.get_project_context().project_path, search_parent_directories=True)
     short_githash_length = 7
     if repo.is_dirty():
         short_githash = "dirty"


### PR DESCRIPTION
By default [GitPython](https://gitpython.readthedocs.io/en/stable/index.html) does not search parent directories for the Git root.

See [Changelog — GitPython 3.1.42 documentation](https://gitpython.readthedocs.io/en/stable/changes.html#id80)

> Repo(path) will not automatically search upstream anymore and find any git directory on its way up. If you need that behaviour, you can turn it back on using the new search_parent_directories=True flag when constructing a Repo object.

This change means that if an atopile project is in a sub-directory of a main project, when `ato build` is run in that sub-directory, ato will be able to obtain the Git hash by searching up the directory tree.
