### PR TITLE
Expressions: Tolerance printing fixes

### DIFF
--- a/src/atopile/expressions.py
+++ b/src/atopile/expressions.py
@@ -134,14 +134,18 @@ class RangedValue:
 
         if max_decimals is None:
             nom = str(val.nominal)
-            tol = str(val.tolerance)
-            pct = str(val.tolerance_pct)
+            if val.tolerance != 0:
+                nom += f' +/- {str(val.tolerance)}'
+                if val.tolerance_pct is not None:
+                    nom += f' ({str(val.tolerance_pct)}%)'
         else:
             nom = _custom_float_format(val.nominal, max_decimals)
-            tol = _custom_float_format(val.tolerance, max_decimals)
-            pct = _custom_float_format(val.tolerance_pct, max_decimals)
+            if val.tolerance != 0:
+                nom += f' +/- {_custom_float_format(val.tolerance, max_decimals)}'
+                if val.tolerance_pct is not None:
+                    nom += f' ({_custom_float_format(val.tolerance_pct, max_decimals)}%)'
 
-        return f"{nom} +/- {tol} ({pct}%) {val.best_usr_unit}"
+        return f"{nom} {val.best_usr_unit}"
 
     def __str__(self) -> str:
         return self.pretty_str()

--- a/src/atopile/expressions.py
+++ b/src/atopile/expressions.py
@@ -135,7 +135,7 @@ class RangedValue:
         if max_decimals is None:
             nom = str(val.nominal)
             tol = str(val.tolerance)
-            pct = str(val.tolerance)
+            pct = str(val.tolerance_pct)
         else:
             nom = _custom_float_format(val.nominal, max_decimals)
             tol = _custom_float_format(val.tolerance, max_decimals)


### PR DESCRIPTION
Two things fixed here:

If `max_decimals` was not given, the percentage shown was incorrect. 03a3a1c5f320c9195d3c96d2ea96058d1423badb

More importantly, there was a crash when printing a zero ohm resistor (`tolerance_pct is None`) which is now fixed. 513fc9c6152af3d6d570d0ad25f41e6a32e0ba88

Now, the values without tolerances defined don't have this "+/- 0 (0%)" after the value, but the behavior still seems correct for values with tolerances:
<img width="155" alt="Screenshot 2024-03-02 at 12 55 23 PM" src="https://github.com/atopile/atopile/assets/1424353/30757ccd-8523-4e8b-9d5f-948e4f84523b">
