### PR TITLE
Improve robustness of simultaneous descent in layout module - fixes #237

### DIFF
--- a/src/atopile/instance_methods.py
+++ b/src/atopile/instance_methods.py
@@ -37,6 +37,30 @@ def all_descendants(addr: str) -> Iterable[str]:
     yield addr
 
 
+def _common_children(*instances: Instance) -> Iterable[tuple[Instance]]:
+    """
+    Return the common children of two addresses
+    """
+    if len(instances) == 1:
+        instances = tuple(instances[0])
+    for child in instances[0].children:
+        if all(child in i.children for i in instances[1:]):
+            yield from _common_children(i.children[child] for i in instances)
+            yield tuple(i.children[child] for i in instances)
+
+
+def common_children(*addrs: AddrStr) -> Iterable[AddrStr]:
+    """
+    Return the common children of two addresses
+    """
+    if len(addrs) == 1:
+        addrs = tuple(addrs[0])
+    yield from (
+        (inst.addr for inst in instances)
+        for instances in _common_children(lofty.get_instance(addr) for addr in addrs)
+    )
+
+
 def _make_dumb_matcher(pass_list: Iterable[str]) -> Callable[[str], bool]:
     """
     Return a filter that checks if the addr is in the pass_list

--- a/src/atopile/layout.py
+++ b/src/atopile/layout.py
@@ -12,7 +12,7 @@ import logging
 import uuid
 from collections import defaultdict
 
-from atopile import address, config, errors
+from atopile import address, config, errors, instance_methods
 from atopile.instance_methods import (
     all_descendants,
     find_matching_super,
@@ -82,19 +82,15 @@ def generate_module_map(build_ctx: config.BuildContext) -> None:
         # FIXME: this currently relies on the `all_descendants` iterator returning the
         # children in the same order. This is pretty fragile and should be fixed.
         uuid_map = {}
-        for inst_addr, layout_addr in zip(
-            all_descendants(module_instance), all_descendants(module_super_ctx.entry)
+        for inst_addr, layout_addr in instance_methods.common_children(
+            module_instance, module_super_ctx.entry
         ):
             if not match_components(inst_addr):
                 # Skip non-components
                 continue
 
-            if address.get_name(inst_addr) != address.get_name(layout_addr):
-                errors.AtoError(
-                    "Mismatched names in layout and instance addresses,"
-                    " skipping component in auto-layout generation"
-                ).log(log, logging.WARNING)
-                continue
+            # This should be enforced by the `common_children` function
+            assert address.get_name(inst_addr) == address.get_name(layout_addr)
 
             uuid_map[generate_comp_uid(inst_addr)] = generate_comp_uid(layout_addr)
 

--- a/tests/test_instance_methods.py
+++ b/tests/test_instance_methods.py
@@ -1,0 +1,23 @@
+from atopile import instance_methods
+import pytest
+from unittest.mock import MagicMock
+
+
+def test_common_children():
+    a = MagicMock()
+    a.children = {
+        "a": MagicMock(children={"a": MagicMock(children={})}),
+        "b": MagicMock(children={}),
+        "c": MagicMock(children={}),
+    }
+
+    children = list(instance_methods._common_children(a, a))
+    r_aa, r_a, r_b, r_c = children
+
+    assert r_a == (a.children["a"], a.children["a"])
+    assert r_aa == (a.children["a"].children["a"], a.children["a"].children["a"])
+    assert r_b == (a.children["b"], a.children["b"])
+    assert r_c == (a.children["c"], a.children["c"])
+
+    b = MagicMock(children={"a": MagicMock(children={})})
+    assert list(instance_methods._common_children(a, b)) == [(a.children["a"], b.children["a"])]


### PR DESCRIPTION
## TODO:

- [x] validation on a layout