### PR TITLE
Revert "Bump @typescript-eslint/parser from 6.17.0 to 7.2.0 in /src/vscode-atopile"

### DIFF
--- a/src/vscode-atopile/package-lock.json
+++ b/src/vscode-atopile/package-lock.json
@@ -20,7 +20,7 @@
                 "@types/node": "16.x",
                 "@types/vscode": "1.78.0",
                 "@typescript-eslint/eslint-plugin": "^7.0.0",
-                "@typescript-eslint/parser": "^7.2.0",
+                "@typescript-eslint/parser": "^6.17.0",
                 "@vscode/test-electron": "^2.3.9",
                 "@vscode/vsce": "^2.24.0",
                 "eslint": "^8.57.0",
@@ -495,15 +495,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
-            "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.17.0.tgz",
+            "integrity": "sha512-C4bBaX2orvhK+LlwrY8oWGmSl4WolCfYm513gEccdWZj0CwGadbIADb0FtVEcI+WzUyjyoBj2JRP8g25E6IB8A==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "7.2.0",
-                "@typescript-eslint/types": "7.2.0",
-                "@typescript-eslint/typescript-estree": "7.2.0",
-                "@typescript-eslint/visitor-keys": "7.2.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -514,7 +514,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^8.56.0"
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
@@ -523,13 +523,13 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
-            "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+            "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.2.0",
-                "@typescript-eslint/visitor-keys": "7.2.0"
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0"
             },
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -649,9 +649,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
-            "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+            "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
             "dev": true,
             "engines": {
                 "node": "^16.0.0 || >=18.0.0"
@@ -662,13 +662,13 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
-            "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+            "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.2.0",
-                "@typescript-eslint/visitor-keys": "7.2.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -838,12 +838,12 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
-            "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+            "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
             "dev": true,
             "dependencies": {
-                "@typescript-eslint/types": "7.2.0",
+                "@typescript-eslint/types": "6.17.0",
                 "eslint-visitor-keys": "^3.4.1"
             },
             "engines": {
@@ -5276,26 +5276,26 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.2.0.tgz",
-            "integrity": "sha512-5FKsVcHTk6TafQKQbuIVkXq58Fnbkd2wDL4LB7AURN7RUOu1utVP+G8+6u3ZhEroW3DF6hyo3ZEXxgKgp4KeCg==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.17.0.tgz",
+            "integrity": "sha512-C4bBaX2orvhK+LlwrY8oWGmSl4WolCfYm513gEccdWZj0CwGadbIADb0FtVEcI+WzUyjyoBj2JRP8g25E6IB8A==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "7.2.0",
-                "@typescript-eslint/types": "7.2.0",
-                "@typescript-eslint/typescript-estree": "7.2.0",
-                "@typescript-eslint/visitor-keys": "7.2.0",
+                "@typescript-eslint/scope-manager": "6.17.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/typescript-estree": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.2.0.tgz",
-            "integrity": "sha512-Qh976RbQM/fYtjx9hs4XkayYujB/aPwglw2choHmf3zBjB4qOywWSdt9+KLRdHubGcoSwBnXUH2sR3hkyaERRg==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.17.0.tgz",
+            "integrity": "sha512-RX7a8lwgOi7am0k17NUO0+ZmMOX4PpjLtLRgLmT1d3lBYdWH4ssBUbwdmc5pdRX8rXon8v9x8vaoOSpkHfcXGA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "7.2.0",
-                "@typescript-eslint/visitor-keys": "7.2.0"
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0"
             }
         },
         "@typescript-eslint/type-utils": {
@@ -5363,19 +5363,19 @@
             }
         },
         "@typescript-eslint/types": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.2.0.tgz",
-            "integrity": "sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.17.0.tgz",
+            "integrity": "sha512-qRKs9tvc3a4RBcL/9PXtKSehI/q8wuU9xYJxe97WFxnzH8NWWtcW3ffNS+EWg8uPvIerhjsEZ+rHtDqOCiH57A==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.2.0.tgz",
-            "integrity": "sha512-cyxS5WQQCoBwSakpMrvMXuMDEbhOo9bNHHrNcEWis6XHx6KF518tkF1wBvKIn/tpq5ZpUYK7Bdklu8qY0MsFIA==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.17.0.tgz",
+            "integrity": "sha512-gVQe+SLdNPfjlJn5VNGhlOhrXz4cajwFd5kAgWtZ9dCZf4XJf8xmgCTLIqec7aha3JwgLI2CK6GY1043FRxZwg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "7.2.0",
-                "@typescript-eslint/visitor-keys": "7.2.0",
+                "@typescript-eslint/types": "6.17.0",
+                "@typescript-eslint/visitor-keys": "6.17.0",
                 "debug": "^4.3.4",
                 "globby": "^11.1.0",
                 "is-glob": "^4.0.3",
@@ -5482,12 +5482,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.2.0.tgz",
-            "integrity": "sha512-c6EIQRHhcpl6+tO8EMR+kjkkV+ugUNXOmeASA1rlzkd8EPIriavpWoiEz1HR/VLhbVIdhqnV6E7JZm00cBDx2A==",
+            "version": "6.17.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.17.0.tgz",
+            "integrity": "sha512-H6VwB/k3IuIeQOyYczyyKN8wH6ed8EwliaYHLxOIhyF0dYEIsN8+Bk3GE19qafeMKyZJJHP8+O1HiFhFLUNKSg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "7.2.0",
+                "@typescript-eslint/types": "6.17.0",
                 "eslint-visitor-keys": "^3.4.1"
             }
         },

--- a/src/vscode-atopile/package.json
+++ b/src/vscode-atopile/package.json
@@ -204,7 +204,7 @@
         "@types/node": "16.x",
         "@types/vscode": "1.78.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
-        "@typescript-eslint/parser": "^7.2.0",
+        "@typescript-eslint/parser": "^6.17.0",
         "@vscode/test-electron": "^2.3.9",
         "@vscode/vsce": "^2.24.0",
         "eslint": "^8.57.0",


### PR DESCRIPTION
Reverts atopile/atopile#244 due to the failed CI job: https://github.com/atopile/atopile/actions/runs/8351119738/job/22858890844