### PR TITLE
Pull group plugin movement fix

### DIFF
--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -83,17 +83,6 @@ def update_zone_net(source_zone: pcbnew.ZONE, source_board: pcbnew.BOARD, target
                 matched_pad_index = index
 
     if matched_fp and matched_pad_index:
-        
-
-def sync_zone(zone: pcbnew.ZONE, target: pcbnew.BOARD) -> pcbnew.ZONE:
-    """Sync a zone to the target board."""
-    new_zone: pcbnew.ZONE = zone.Duplicate().Cast()
-    new_zone.SetParent(target)
-    new_zone.SetLayer(zone.GetLayer())
-    target.Add(new_zone)
-
-    
-    return new_zone
 
 def sync_footprints(
     source: pcbnew.BOARD, target: pcbnew.BOARD, uuid_map: dict[str, str]

--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -60,6 +60,7 @@ def flip_dict(d: dict) -> dict:
     """Return a dict with keys and values swapped."""
     return {v: k for k, v in d.items()}
 
+
 def sync_track(track: pcbnew.PCB_TRACK, target: pcbnew.BOARD) -> pcbnew.PCB_TRACK:
     """Sync a track to the target board."""
     new_track: pcbnew.PCB_TRACK = track.Duplicate().Cast()
@@ -69,6 +70,7 @@ def sync_track(track: pcbnew.PCB_TRACK, target: pcbnew.BOARD) -> pcbnew.PCB_TRAC
     new_track.SetLayer(track.GetLayer())
     target.Add(new_track)
     return new_track
+
 
 def sync_footprints(
     source: pcbnew.BOARD, target: pcbnew.BOARD, uuid_map: dict[str, str]
@@ -90,6 +92,7 @@ def sync_footprints(
         target_fp.SetLayer(source_fp.GetLayer())
     return missing_uuids
 
+
 def find_anchor_footprint_group(group: pcbnew.PCB_GROUP) -> pcbnew.FOOTPRINT:
     """Return anchor footprint with largest pin count in group: tiebreaker size"""
     max_padcount = 0
@@ -104,6 +107,7 @@ def find_anchor_footprint_group(group: pcbnew.PCB_GROUP) -> pcbnew.FOOTPRINT:
             max_area = fp.GetArea()
     return anchor_fp
 
+
 def find_anchor_footprint_board(board: pcbnew.BOARD) -> pcbnew.FOOTPRINT:
     """Return anchor footprint with largest pin count in board: tiebreaker size"""
     max_padcount = 0
@@ -116,6 +120,7 @@ def find_anchor_footprint_board(board: pcbnew.BOARD) -> pcbnew.FOOTPRINT:
             max_padcount = fp.GetPadCount()
             max_area = fp.GetArea()
     return anchor_fp
+
 
 def calculate_translation(source: pcbnew.BOARD, target_group: pcbnew.PCB_GROUP) -> pcbnew.VECTOR2I:
     source_anchor_fp = find_anchor_footprint_board(source)

--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -60,7 +60,6 @@ def flip_dict(d: dict) -> dict:
     """Return a dict with keys and values swapped."""
     return {v: k for k, v in d.items()}
 
-
 def sync_track(track: pcbnew.PCB_TRACK, target: pcbnew.BOARD) -> pcbnew.PCB_TRACK:
     """Sync a track to the target board."""
     new_track: pcbnew.PCB_TRACK = track.Duplicate().Cast()
@@ -70,19 +69,6 @@ def sync_track(track: pcbnew.PCB_TRACK, target: pcbnew.BOARD) -> pcbnew.PCB_TRAC
     new_track.SetLayer(track.GetLayer())
     target.Add(new_track)
     return new_track
-
-#TODO: There must be a better way to update net of fill
-def update_zone_net(source_zone: pcbnew.ZONE, source_board: pcbnew.BOARD, target_board:pcbnew.BOARD):
-    source_netname = source_zone.GetNetname()
-    matched_fp = None
-    matched_pad_index = None
-    for fp in source_board.GetFootprints():
-        for index, pad in enumerate(fp.Pads()):
-            if pad.GetNetname() == source_netname:
-                matched_fp = fp
-                matched_pad_index = index
-
-    if matched_fp and matched_pad_index:
 
 def sync_footprints(
     source: pcbnew.BOARD, target: pcbnew.BOARD, uuid_map: dict[str, str]

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -45,7 +45,7 @@ class PullGroup(pcbnew.ActionPlugin):
             for item in g.GetItems():
                 if not isinstance(item, pcbnew.FOOTPRINT):
                     target_board.Remove(item)
-            
+
             # Load the layout and sync
             source_board: pcbnew.BOARD = pcbnew.LoadBoard(str(layout_path))
             

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pcbnew
 
-from .common import get_layout_map, sync_footprints, flip_dict, sync_track, sync_zone, calculate_translation
+from .common import get_layout_map, sync_footprints, flip_dict, sync_track, calculate_translation
 
 log = logging.getLogger(__name__)
 
@@ -58,10 +58,6 @@ class PullGroup(pcbnew.ActionPlugin):
 
             for track in source_board.GetTracks():
                 item = sync_track(track, target_board)
-                g.AddItem(item)
-
-            for fill in source_board.Zones():
-                item = sync_zone(fill,target_board)
                 g.AddItem(item)
 
             # Shift entire target group by offset as last operation


### PR DESCRIPTION
Keeps groups static when using pull group kicad plugin
- Calculates anchor component in group based on pin count (component area tie breaker)
- Calculates source vector from origin
- Calculates target vector from origin
- Applied target_vector - source_vector translation to entire group after all layout info is updated to source positions