### PR TITLE
Zone copy with net

### DIFF
--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -100,7 +100,6 @@ def update_zone_net(source_zone: pcbnew.ZONE, source_board: pcbnew.BOARD, target
                 new_netinfo = target_fp.Pads()[matched_pad_index].GetNet()
                 target_zone.SetNet(new_netinfo)
                 return
-                # raise ValueError(f'{new_netinfo.GetNetname()}')
 
     # TODO: Verify that this will always set net to no net
     target_zone.SetNetCode(0)

--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -98,9 +98,12 @@ def update_zone_net(source_zone: pcbnew.ZONE, source_board: pcbnew.BOARD, target
             target_fp = target_uuids.get(target_fp_uuid,None)
             if target_fp:
                 new_netinfo = target_fp.Pads()[matched_pad_index].GetNet()
+                target_zone.SetNet(new_netinfo)
+                return
                 # raise ValueError(f'{new_netinfo.GetNetname()}')
 
-    target_zone.SetNet(new_netinfo)
+    # TODO: Verify that this will always set net to no net
+    target_zone.SetNetCode(0)
 
 
 def sync_zone(zone: pcbnew.ZONE, target: pcbnew.BOARD) -> pcbnew.ZONE:

--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -78,6 +78,40 @@ def sync_track(
     return new_track
 
 
+#TODO: There must be a better way to update net of fill
+def update_zone_net(source_zone: pcbnew.ZONE, source_board: pcbnew.BOARD, target_zone: pcbnew.ZONE, target_board:pcbnew.BOARD, uuid_map: dict[str, str]):
+    '''Finds a pin connected to original zone, pulls pin net name from new board net'''
+    source_netname = source_zone.GetNetname()
+    matched_fp = None
+    matched_pad_index = None
+    for fp in source_board.GetFootprints():
+        for index, pad in enumerate(fp.Pads()):
+            if pad.GetNetname() == source_netname:
+                matched_fp = fp
+                matched_pad_index = index
+
+    if matched_fp and matched_pad_index:
+        matched_fp_uuid = get_footprint_uuid(matched_fp)
+        target_fp_uuid = uuid_map.get(matched_fp_uuid,None)
+        if target_fp_uuid:
+            target_uuids = footprints_by_uuid(target_board)
+            target_fp = target_uuids.get(target_fp_uuid,None)
+            if target_fp:
+                new_netinfo = target_fp.Pads()[matched_pad_index].GetNet()
+                # raise ValueError(f'{new_netinfo.GetNetname()}')
+
+    target_zone.SetNet(new_netinfo)
+
+
+def sync_zone(zone: pcbnew.ZONE, target: pcbnew.BOARD) -> pcbnew.ZONE:
+    """Sync a zone to the target board."""
+    new_zone: pcbnew.ZONE = zone.Duplicate().Cast()
+    new_zone.SetParent(target)
+    new_zone.SetLayer(zone.GetLayer())
+    target.Add(new_zone)
+    return new_zone
+
+
 def sync_footprints(
     source: pcbnew.BOARD, target: pcbnew.BOARD, uuid_map: dict[str, str]
 ) -> list[str]:

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -71,9 +71,11 @@ class PullGroup(pcbnew.ActionPlugin):
 
             for zone in source_board.Zones():
                 new_zone = sync_zone(zone,target_board)
-                update_zone_net(zone,source_board,new_zone,target_board,flip_dict(known_layouts[g_name]["uuid_map"]))
+                update_zone_net(zone, source_board, new_zone, target_board, flip_dict(known_layouts[g_name]["uuid_map"]))
                 g.AddItem(new_zone)
 
+            # Shift entire target group by offset as last operation
+            g.Move(offset)
 
         pcbnew.Refresh()
 

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -10,6 +10,8 @@ from .common import (
     get_layout_map,
     sync_footprints,
     sync_track,
+    sync_zone,
+    update_zone_net,
 )
 
 log = logging.getLogger(__name__)
@@ -66,6 +68,11 @@ class PullGroup(pcbnew.ActionPlugin):
             for track in source_board.GetTracks():
                 item = sync_track(source_board, track, target_board)
                 g.AddItem(item)
+
+            for zone in source_board.Zones():
+                new_zone = sync_zone(zone,target_board)
+                update_zone_net(zone,source_board,new_zone,target_board,flip_dict(known_layouts[g_name]["uuid_map"]))
+                g.AddItem(new_zone)
 
             # Shift entire target group by offset as last operation
             g.Move(offset)

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -74,8 +74,6 @@ class PullGroup(pcbnew.ActionPlugin):
                 update_zone_net(zone,source_board,new_zone,target_board,flip_dict(known_layouts[g_name]["uuid_map"]))
                 g.AddItem(new_zone)
 
-            # Shift entire target group by offset as last operation
-            g.Move(offset)
 
         pcbnew.Refresh()
 


### PR DESCRIPTION
Fix #216 

**This deserves a thorough squiz**, seems hacky but setting zone net was tricky. **There must be a cleaner way to map source netname to target netname.**

- Duplicates source zone to target board
- Updates the net of the zone to new net name on target board
  - Finds net name of source zone
  - iterates thru source footprint pads until netname match is found
  - uses matched footprint uuid and uuid map to find target footprint
  - uses matched pad index of matched footprint to get new net information
  - Sets zone net to target net info
  - Sets zone to netcode 0 if no match found (no net)