### PR TITLE
Fix pushgroup bug and ref designators

### DIFF
--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -1,9 +1,9 @@
-import logging
 import json
+import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
+
 import pcbnew
-from typing import Union
 
 LOG_FILE = Path("~/.atopile/kicad-plugin.log").expanduser().absolute()
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
@@ -62,14 +62,18 @@ def flip_dict(d: dict) -> dict:
     return {v: k for k, v in d.items()}
 
 
-def sync_track(source_board: pcbnew.BOARD, track: pcbnew.PCB_TRACK, target: pcbnew.BOARD) -> pcbnew.PCB_TRACK:
+def sync_track(
+    source_board: pcbnew.BOARD,
+    track: pcbnew.PCB_TRACK,
+    target_board: pcbnew.BOARD
+) -> pcbnew.PCB_TRACK:
     """Sync a track to the target board."""
     new_track: pcbnew.PCB_TRACK = track.Duplicate().Cast()
-    new_track.SetParent(target)
+    new_track.SetParent(target_board)
     new_track.SetStart(track.GetStart())
     new_track.SetEnd(track.GetEnd())
     new_track.SetLayer(track.GetLayer())
-    target.Add(new_track)
+    target_board.Add(new_track)
     source_board.Remove(new_track)
     return new_track
 
@@ -98,38 +102,31 @@ def sync_footprints(
     return missing_uuids
 
 
-def find_anchor_footprint(layout: Union[pcbnew.BOARD,pcbnew.PCB_GROUP]) -> pcbnew.FOOTPRINT:
+def find_anchor_footprint(fps: Iterable[pcbnew.FOOTPRINT]) -> pcbnew.FOOTPRINT:
     """Return anchor footprint with largest pin count in board or group: tiebreaker size"""
-    if isinstance(layout,pcbnew.PCB_GROUP):
-        max_padcount = 0
-        max_area = 0
-        anchor_fp = None
-        items = layout.GetItems()
-        fps = [item for item in items if isinstance(item, pcbnew.FOOTPRINT)]
-        for fp in fps:
-            if fp.GetPadCount() > max_padcount or (fp.GetPadCount()==max_padcount and fp.GetArea()>max_area):
-                anchor_fp = fp
-                max_padcount = fp.GetPadCount()
-                max_area = fp.GetArea()
-        return anchor_fp
-    elif isinstance(layout,pcbnew.BOARD):
-        max_padcount = 0
-        max_area = 0
-        anchor_fp = None
-        fps = layout.GetFootprints()
-        for fp in fps:
-            if fp.GetPadCount() > max_padcount or (fp.GetPadCount()==max_padcount and fp.GetArea()>max_area):
-                anchor_fp = fp
-                max_padcount = fp.GetPadCount()
-                max_area = fp.GetArea()
-        return anchor_fp
-    return None
+    # fps = layout.GetFootprints()
+    # fps = [item for item in layout.GetItems() if isinstance(item, pcbnew.FOOTPRINT)]
+    max_padcount = 0
+    max_area = 0
+    anchor_fp = None
+    for fp in fps:
+        if fp.GetPadCount() > max_padcount or (fp.GetPadCount()==max_padcount and fp.GetArea()>max_area):
+            anchor_fp = fp
+            max_padcount = fp.GetPadCount()
+            max_area = fp.GetArea()
+    return anchor_fp
 
 
-def calculate_translation(source: Union[pcbnew.BOARD,pcbnew.PCB_GROUP], target: Union[pcbnew.BOARD,pcbnew.PCB_GROUP]) -> pcbnew.VECTOR2I:
-    source_anchor_fp = find_anchor_footprint(source)
+def get_group_footprints(group: pcbnew.PCB_GROUP) -> list[pcbnew.FOOTPRINT]:
+    """Return a list of footprints in a group."""
+    return [item for item in group.GetItems() if isinstance(item, pcbnew.FOOTPRINT)]
+
+
+def calculate_translation(source_fps: Iterable[pcbnew.FOOTPRINT], target_fps: Iterable[pcbnew.FOOTPRINT]) -> pcbnew.VECTOR2I:
+    """Calculate the translation vector between two groups of footprints."""
+    source_anchor_fp = find_anchor_footprint(source_fps)
     source_offset = source_anchor_fp.GetPosition()
-    target_anchor_fp = find_anchor_footprint(target)
+    target_anchor_fp = find_anchor_footprint(target_fps)
     target_offset = target_anchor_fp.GetPosition()
-    total_offset = target_offset-source_offset
+    total_offset = target_offset - source_offset
     return total_offset

--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -74,17 +74,6 @@ def sync_track(source_board: pcbnew.BOARD, track: pcbnew.PCB_TRACK, target: pcbn
     return new_track
 
 
-def sync_ref_des(source_fp: pcbnew.FOOTPRINT, target_fp: pcbnew.FOOTPRINT):
-    target_fp.Reference().SetPos0(source_fp.Reference().GetPos0())
-    target_fp.Reference().SetAttributes(source_fp.Reference().GetAttributes())
-#     source_ref = source_fp.Reference()
-#     target_ref = target_fp.Reference()
-#     target_ref.SetPos0(source_ref.GetPos0()) #-Pos0 is relative, -Position is absolute
-#     target_ref.SetTextAngleDegrees(source_ref.GetTextAngleDegrees())
-#     target_ref.SetTextWidth(source_ref.GetTextWidth())
-#     target_ref.SetTextHeight(source_ref.GetTextHeight())
-
-
 def sync_footprints(
     source: pcbnew.BOARD, target: pcbnew.BOARD, uuid_map: dict[str, str]
 ) -> list[str]:
@@ -100,10 +89,12 @@ def sync_footprints(
         except KeyError:
             missing_uuids.append(s_uuid)
             continue
-        sync_ref_des(source_fp,target_fp)
         target_fp.SetPosition(source_fp.GetPosition())
         target_fp.SetOrientation(source_fp.GetOrientation())
         target_fp.SetLayer(source_fp.GetLayer())
+        # Ref Designators
+        target_fp.Reference().SetAttributes(source_fp.Reference().GetAttributes())
+        target_fp.Reference().SetPos0(source_fp.Reference().GetPos0())
     return missing_uuids
 
 

--- a/src/atopile/kicad_plugin/common.py
+++ b/src/atopile/kicad_plugin/common.py
@@ -74,6 +74,17 @@ def sync_track(source_board: pcbnew.BOARD, track: pcbnew.PCB_TRACK, target: pcbn
     return new_track
 
 
+def sync_ref_des(source_fp: pcbnew.FOOTPRINT, target_fp: pcbnew.FOOTPRINT):
+    target_fp.Reference().SetPos0(source_fp.Reference().GetPos0())
+    target_fp.Reference().SetAttributes(source_fp.Reference().GetAttributes())
+#     source_ref = source_fp.Reference()
+#     target_ref = target_fp.Reference()
+#     target_ref.SetPos0(source_ref.GetPos0()) #-Pos0 is relative, -Position is absolute
+#     target_ref.SetTextAngleDegrees(source_ref.GetTextAngleDegrees())
+#     target_ref.SetTextWidth(source_ref.GetTextWidth())
+#     target_ref.SetTextHeight(source_ref.GetTextHeight())
+
+
 def sync_footprints(
     source: pcbnew.BOARD, target: pcbnew.BOARD, uuid_map: dict[str, str]
 ) -> list[str]:
@@ -89,6 +100,7 @@ def sync_footprints(
         except KeyError:
             missing_uuids.append(s_uuid)
             continue
+        sync_ref_des(source_fp,target_fp)
         target_fp.SetPosition(source_fp.GetPosition())
         target_fp.SetOrientation(source_fp.GetOrientation())
         target_fp.SetLayer(source_fp.GetLayer())

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -57,7 +57,7 @@ class PullGroup(pcbnew.ActionPlugin):
             )
 
             for track in source_board.GetTracks():
-                item = sync_track(track, target_board)
+                item = sync_track(source_board, track, target_board)
                 g.AddItem(item)
 
             # Shift entire target group by offset as last operation

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -50,7 +50,7 @@ class PullGroup(pcbnew.ActionPlugin):
             source_board: pcbnew.BOARD = pcbnew.LoadBoard(str(layout_path))
             
             # Calculate offset before moving footprints
-            offset = calculate_translation(source=source_board, target_group=g)
+            offset = calculate_translation(source=source_board,target=g)
 
             sync_footprints(
                 source_board, target_board, flip_dict(known_layouts[g_name]["uuid_map"])

--- a/src/atopile/kicad_plugin/pullgroup.py
+++ b/src/atopile/kicad_plugin/pullgroup.py
@@ -3,7 +3,14 @@ from pathlib import Path
 
 import pcbnew
 
-from .common import get_layout_map, sync_footprints, flip_dict, sync_track, calculate_translation
+from .common import (
+    calculate_translation,
+    flip_dict,
+    get_group_footprints,
+    get_layout_map,
+    sync_footprints,
+    sync_track,
+)
 
 log = logging.getLogger(__name__)
 
@@ -48,9 +55,9 @@ class PullGroup(pcbnew.ActionPlugin):
 
             # Load the layout and sync
             source_board: pcbnew.BOARD = pcbnew.LoadBoard(str(layout_path))
-            
+
             # Calculate offset before moving footprints
-            offset = calculate_translation(source=source_board,target=g)
+            offset = calculate_translation(source_fps=source_board.GetFootprints(), target_fps=get_group_footprints(g))
 
             sync_footprints(
                 source_board, target_board, flip_dict(known_layouts[g_name]["uuid_map"])

--- a/src/atopile/kicad_plugin/pushgroup.py
+++ b/src/atopile/kicad_plugin/pushgroup.py
@@ -21,6 +21,7 @@ class PushGroup(pcbnew.ActionPlugin):
         source_board: pcbnew.BOARD = pcbnew.GetBoard()
         board_path = source_board.GetFileName()
         known_layouts = get_layout_map(board_path)
+        target_board = None
 
         # Push Selected Groups
         for g in source_board.Groups():
@@ -65,6 +66,7 @@ class PushGroup(pcbnew.ActionPlugin):
             [track.Move(offset) for track in target_board.GetTracks()]
 
         # Save the target board
-        target_board.Save(target_board.GetFileName())
+        if target_board: target_board.Save(target_board.GetFileName())
+        else: raise RuntimeWarning("Cannot push group. No groups selected")
 
 PushGroup().register()


### PR DESCRIPTION
Fixes pushgroup bug in `sync_tracks`
- After duplicating track from source board, ghost track remains on source board/group
- Doesnt happen in pull because source board is closed and not saved
- Exponentially adds tacks to source and target after multiple pushes
- Solved by removing ghost track from source board after duplication

Overloaded `find_anchor_footprint` function to allow board/group interchangability for both push/pull

Fix #213
- Copies over reference designator relative position to footprint
- Copies attributes(thickness, width, height, rotation)