### PR TITLE
Windows path fix

### DIFF
--- a/src/atopile/cli/configure.py
+++ b/src/atopile/cli/configure.py
@@ -109,7 +109,7 @@ def install_kicad_plugin() -> None:
     """Install the kicad plugin."""
     # Find the path to kicad's plugin directory
     plugin_loader = f"""
-        plugin_path = "{Path(__file__).parent.parent}"
+        plugin_path = r"{Path(__file__).parent.parent}"
         import sys
         import importlib
 


### PR DESCRIPTION
Tiny PR - 1 character

The kicad plugin script `atopile.py` plugin_path is created with backslashes, this is no bueno for windows.

Switching to raw string fixed for windows, should work on unix.

Will this happen elsewhere?