### PR TITLE
Add list of link names to viewer links

### DIFF
--- a/src/atopile/viewer/src/App.tsx
+++ b/src/atopile/viewer/src/App.tsx
@@ -190,7 +190,8 @@ const AtopileViewer = () => {
                         data: {
                             source: edge['source'],
                             target: edge['target'],
-                            name: edge['name']
+                            name: edge['name'],
+                            preview_names: edge['preview_names'],
                         }
                     });
                 }

--- a/src/atopile/viewer/src/CustomEdge.tsx
+++ b/src/atopile/viewer/src/CustomEdge.tsx
@@ -50,7 +50,6 @@ export default function CustomEdge({
         targetY,
         targetPosition,
     });
-    console.log(data);
 
     return (
         <>

--- a/src/atopile/viewer/src/CustomEdge.tsx
+++ b/src/atopile/viewer/src/CustomEdge.tsx
@@ -50,6 +50,7 @@ export default function CustomEdge({
         targetY,
         targetPosition,
     });
+    console.log(data);
 
     return (
         <>
@@ -65,11 +66,38 @@ export default function CustomEdge({
                         fontSize: 12,
                         fontWeight: 700,
                         pointerEvents: 'all',
+                        fontSize: '8px',
                     }}
                     className="nodrag nopan"
                 >
                     <div className="customedge">
-                        {data.name}
+                        <ul style={{
+                            listStyleType: 'none',
+                            padding: '2px',
+                            margin: 0,
+                            overflow: 'hidden',
+                            whiteSpace: 'nowrap',
+                            textOverflow: 'ellipsis',
+                            maxWidth: '100px'}}>
+                            {data.preview_names.slice(0, 4).map((name, index) => (
+                            <li key={index} style={{
+                                overflow: 'hidden',
+                                whiteSpace: 'nowrap',
+                                textOverflow: 'ellipsis',
+                                maxWidth: '200px'  // This maxWidth applies to each li
+                              }}>{name}</li>
+                            ))}
+                            {data.preview_names.length > 4 && (
+                            <li style={{
+                                overflow: 'hidden',
+                                whiteSpace: 'nowrap',
+                                textOverflow: 'ellipsis',
+                                maxWidth: '200px'
+                                }}>
+                                ...
+                            </li>
+                        )}
+                        </ul>
                     </div>
                 </div>
             </EdgeLabelRenderer>

--- a/src/atopile/viewer_utils.py
+++ b/src/atopile/viewer_utils.py
@@ -154,7 +154,8 @@ def get_harnesses(addr: AddrStr) -> list[dict]:
         {
             "source": "block_name",
             "target": "block_name",
-            "name": "harness_name",
+            "name": "name_1/name_2/...",
+            "preview_names": ["name_1", "name_2",...],
             "links": [
                 {
                     "source": "port_name",
@@ -193,15 +194,25 @@ def get_harnesses(addr: AddrStr) -> list[dict]:
     harness_return_dict: DefaultDict[str, list] = defaultdict(list)
 
     for source_block, target_block in harness_list:
-        instance_of_set = set()
+        preview_name_set = set()
         for link in harness_list[(source_block, target_block)]:
-            instance_of_set.add(link['instance_of'])
-        name = "/".join(sorted(instance_of_set))
+            if link['type'] == "signal":
+                preview_name_set.add(f"{link['source']} ~ {link['target']}")
+            # special case for pairs as they could be anything
+            elif link['type'] == "interface" and link['instance_of'] == "Pair":
+                preview_name_set.add(f"{link['source']} ~ {link['target']}")
+            # for interfaces
+            else:
+                preview_name_set.add(link['instance_of'])
+
+        preview_names = sorted(preview_name_set)
+        name = "/".join(preview_names)
         key = f"{source_block}_{target_block}"
         harness_return_dict[key] = {
             "source": source_block,
             "target": target_block,
-            "name": name, # name needs improvement
+            "name": name,
+            "preview_names": preview_names,
             "links": harness_list[(source_block, target_block)]
         }
 


### PR DESCRIPTION
Provide more clarity on what links without having to click on them:

<img width="715" alt="Screenshot 2024-04-28 at 23 09 49" src="https://github.com/atopile/atopile/assets/9785003/a887d401-d95d-4f11-8c61-8cef294840fc">
