### PR TITLE
Assertions table is back! + unit formatting sucks less

### DIFF
--- a/tests/test_expressions/test_ranged_values.py
+++ b/tests/test_expressions/test_ranged_values.py
@@ -40,3 +40,17 @@ def test_arithmetic():
     assert 3 - RangedValue(1, 2) == RangedValue(-2, -1)
     assert 4 * RangedValue(1, 2) == RangedValue(4, 8)
     assert 5 / RangedValue(1, 2) == RangedValue(5 / 2, 5)
+
+
+def test_pretty_str():
+    str_rep = "mhmm, this isn't a ranged value"
+    assert RangedValue(3, 3, pint.Unit("V"), str_rep=str_rep).pretty_str() == str_rep
+    assert RangedValue(3, 3, pint.Unit("V")).pretty_str() == "3V"
+    assert RangedValue(3, 5, pint.Unit("V")).pretty_str() == "3 to 5 V"
+    assert RangedValue(3, 3.1, pint.Unit("V")).pretty_str() == "3.05V ± 50mV"
+
+    # Make sure combined units compact properly
+    v = RangedValue(3, 3, pint.Unit("V"))
+    r = RangedValue(1000, 1000, pint.Unit("Ω"))
+    i = v / r
+    assert i.pretty_str() == "3mA"


### PR DESCRIPTION
We've:
 - Re-added the assertions table (instead of logging only in case of failure)
 - Formatted the ranged values better; either as the source code dictates, or a little more intelligently if we're guessing otherwise

<img width="1252" alt="Screenshot 2024-04-29 at 22 45 44" src="https://github.com/atopile/atopile/assets/4241578/cdb558bf-7e1c-4e54-92ab-ea6c83cd4171">

Closes #329
