### PR TITLE
Fix un-unit'ed bilateral tolerances

### DIFF
--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -428,7 +428,7 @@ class HandlesPrimaries(AtopileParserVisitor):
             # If the nominal has no unit, then we take the unit's tolerance for the nominal
             if nominal_quantity.unit == pint.Unit(""):
                 value = RangedValue(
-                    val_a=nominal_quantity.min_val - tol_quantity.min_val,
+                    val_a=nominal_quantity.min_val + tol_quantity.min_val,
                     val_b=nominal_quantity.max_val + tol_quantity.max_val,
                     unit=tol_quantity.unit,
                     str_rep=parse_utils.reconstruct(ctx),

--- a/tests/test_front_end/test_atoms.py
+++ b/tests/test_front_end/test_atoms.py
@@ -63,10 +63,19 @@ def test_bound_quantity(src, expected):
         ("-6mV ± 7mV", RangedValue(-13, 1, "millivolt")),
 
         # Mix units
-        ("-6V ± 7V", RangedValue(-13, 1, "V")),
+        ("-6V ± 7000mV", RangedValue(-13, 1, "V")),
 
         # One unit
         ("6V ± 2", RangedValue(4, 8, "V")),
+        ("54 ± 34V", RangedValue(20, 88, "V")),
+
+        # Zeros
+        ("0V ± 5V", RangedValue(-5, 5, "V")),
+        ("0V ± 0V", RangedValue(0, 0, "V")),
+
+        # ppm and %
+        ("5V ± 10ppm", RangedValue(4.99995, 5.00005, "V")),
+        ("5V ± 1%", RangedValue(4.95, 5.05, "V")),
     )
 )
 def test_bilateral_quantity(src, expected):


### PR DESCRIPTION
Before this, `50 +/- 10V` was incorrectly read as `60V to 60V`.