### PR TITLE
Loosen overwritten constant complaint

### DIFF
--- a/src/atopile/expressions.py
+++ b/src/atopile/expressions.py
@@ -480,9 +480,10 @@ class Expression:
 
         # Create a new lambda function with the substitutions
         def _new_lambda(context):
-            assert not (
-                set(context) & set(constants)
-            ), "Constants are being overwritten"
+            if overwritten_vars := set(context) & set(constants):
+                if unequal_vars := {v for v in overwritten_vars if context[v] != constants[v]}:
+                    friendly_unequal_vars = "', '".join(unequal_vars)
+                    raise ValueError(f"Constants '{friendly_unequal_vars}' are being overwritten")
             new_context = {**context, **constants}
             for symbol, func in callables.items():
                 new_context[symbol] = func(new_context)


### PR DESCRIPTION
This assertion previously triggered when any constant was additionally set from the "context" variable, but that failed to consider that the constants were incorporated into the sub-context passed to the next lambda.

https://github.com/atopile/bikey-wagon/pull/4 builds with this change without forcing discrete values around! 🥳

Thank you @jarrod89 🙌