### PR TITLE
Fix netlist generation for components that have no pins

### DIFF
--- a/src/atopile/kicad6.j2
+++ b/src/atopile/kicad6.j2
@@ -48,8 +48,8 @@
       (pins
       {%- for pin in libpart.pins %}
         (pin (num "{{ pin.num }}") (name "{{ pin.name }}") (type "{{ pin.type }}"))
-      {%- endfor %}
-    {%- endif %}))
+      {%- endfor %})
+    {%- endif %})
   {%- endfor %})
 {%- endif %}
 {%- if nl.nets %}


### PR DESCRIPTION
If a component has no pins, the generated netlist would include a spare `)` that made it invalid.