### PR TITLE
add description if available from non-database components

### DIFF
--- a/src/atopile/components.py
+++ b/src/atopile/components.py
@@ -309,7 +309,10 @@ def get_user_facing_value(addr: AddrStr) -> str:
         else:
             return "?"
 
-    return get_specd_value(addr)
+    try:
+        return instance_methods.get_data(addr, "description")
+    except KeyError:
+        return "?"
 
 
 # FIXME: this function's requirements might cause a circular dependency

--- a/src/atopile/components.py
+++ b/src/atopile/components.py
@@ -306,13 +306,10 @@ def get_user_facing_value(addr: AddrStr) -> str:
         db_data = _get_generic_from_db(addr)
         if db_data:
             return db_data.get("description", "")
-        else:
-            return "?"
 
-    try:
-        return instance_methods.get_data(addr, "description")
-    except KeyError:
-        return "?"
+    instance = instance_methods.get_instance(addr)
+    doc_string = instance.supers[0].obj_def.doc_string
+    return doc_string.split("\n")[0] or "?"
 
 
 # FIXME: this function's requirements might cause a circular dependency

--- a/tests/test_front_end/test_doc_strings.py
+++ b/tests/test_front_end/test_doc_strings.py
@@ -1,0 +1,96 @@
+import pytest
+
+from antlr4 import InputStream
+
+from atopile.front_end import DocStringVisitor
+from atopile.parse import make_parser
+from atopile.parser.AtopileParser import AtopileParser
+
+
+def test_doc_string():
+    src_code = '''
+module Test:
+    """
+    This is a test module
+    """
+    pass'''
+    input = InputStream(src_code)
+    input.name = "<inline>"
+    parser = make_parser(input)
+    block_def = parser.blockdef()
+    assert DocStringVisitor().get_doc_string(block_def) == "This is a test module"
+
+
+def test_no_doc_string():
+    src_code = '''
+module Test:
+    pass'''
+    input = InputStream(src_code)
+    input.name = "<inline>"
+    parser = make_parser(input)
+    block_def = parser.blockdef()
+    assert DocStringVisitor().get_doc_string(block_def) == ""
+
+
+def test_multiline_doc_string():
+    src_code = '''
+module Test:
+    """
+    This is a test module
+    with multiple lines
+    three, in fact!
+    """
+    pass'''
+
+    input = InputStream(src_code)
+    input.name = "<inline>"
+    parser = make_parser(input)
+    block_def = parser.blockdef()
+    assert DocStringVisitor().get_doc_string(block_def) == "This is a test module\nwith multiple lines\nthree, in fact!"
+
+
+def test_multiline_doc_string_first_line_on_quotes():
+    src_code = '''
+module Test:
+    """This is a test module
+    with multiple lines
+    three, in fact!
+    """
+    pass'''
+
+    input = InputStream(src_code)
+    input.name = "<inline>"
+    parser = make_parser(input)
+    block_def = parser.blockdef()
+    assert DocStringVisitor().get_doc_string(block_def) == "This is a test module\nwith multiple lines\nthree, in fact!"
+
+
+def test_multiline_doc_string_both_lines_on_quotes():
+    src_code = '''
+module Test:
+    """This is a test module
+    with multiple lines
+    three, in fact!"""
+    pass'''
+
+    input = InputStream(src_code)
+    input.name = "<inline>"
+    parser = make_parser(input)
+    block_def = parser.blockdef()
+    assert DocStringVisitor().get_doc_string(block_def) == "This is a test module\nwith multiple lines\nthree, in fact!"
+
+
+def test_multiline_doc_string_last_line_on_quotes():
+    src_code = '''
+module Test:
+    """
+    This is a test module
+    with multiple lines
+    three, in fact!"""
+    pass'''
+
+    input = InputStream(src_code)
+    input.name = "<inline>"
+    parser = make_parser(input)
+    block_def = parser.blockdef()
+    assert DocStringVisitor().get_doc_string(block_def) == "This is a test module\nwith multiple lines\nthree, in fact!"


### PR DESCRIPTION
Currently for local components, the comment field is blank in the BOM output, modifying to use 'description' if available. 