### PR TITLE
More robust footprint inference for generic components

### DIFF
--- a/src/atopile/components.py
+++ b/src/atopile/components.py
@@ -364,6 +364,9 @@ def get_footprint(addr: AddrStr) -> str:
             # strip .kicad_mod from the end of the footprint if it's there
             if footprint.endswith(".kicad_mod"):
                 footprint = footprint.removesuffix(".kicad_mod")
+
+            if len(footprint) == 1:
+                footprint = footprint + db_data.get("package", "")
         except KeyError as ex:
             raise errors.AtoInfraError(
                 "db component for $addr has no footprint",


### PR DESCRIPTION
I was seeing a generic inductor get resolved to a component with `"footprint": {"kicad": "L"}`, this is a hack to try to recover from these cases.