### PR TITLE
Fix: Support EasyEDA symbols with multiple units

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "sexpdata==1.0.2",
     "black~=24.4.2",
     "typing-extensions>=4.6.3,<5.0.0",
-    "easyeda2kicad~=0.8.0",
+    "easyeda2kicad @ git+https://github.com/atopile/easyeda2kicad.py.git",
     "shapely~=2.0.1",
     "freetype-py~=2.4.0",
     "kicadcliwrapper~=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [
     "cattrs>=23.2.3",
     "click>=8.1.7",
     "DeepDiff>=6.7.1",
-    "easyeda2ato>=0.2.7",
     "eseries>=1.2.1",
     "fake-useragent>=1.4.0",
     "fastapi>=0.109.0",

--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -226,7 +226,8 @@ def attach(component: Module, partno: str, get_model: bool = True):
             # TODO make this a trait
             pins = [
                 (pin.settings.spice_pin_number, pin.name.text)
-                for pin in easyeda_symbol.pins
+                for unit in easyeda_symbol.units
+                for pin in unit.pins
             ]
             try:
                 pinmap = component.get_trait(F.has_pin_association_heuristic).get_pins(


### PR DESCRIPTION
# Fix: Support EasyEDA symbols with multiple units

# Description

Switches to our fork of easyeda2kicad, which includes enhancements not yet available upstream.