### PR TITLE
Improve default net naming algorithm

### DIFF
--- a/src/faebryk/library/Net.py
+++ b/src/faebryk/library/Net.py
@@ -5,41 +5,12 @@ import logging
 
 import faebryk.library._F as F
 from faebryk.core.module import Module
-from faebryk.libs.library import L
 
 logger = logging.getLogger(__name__)
 
 
 class Net(Module):
     part_of: F.Electrical
-
-    @L.rt_field
-    def overriden_name(self):
-        class _(F.has_overriden_name.impl()):
-            def get_name(_self):
-                from faebryk.exporters.netlist.graph import (
-                    can_represent_kicad_footprint,
-                )
-
-                name = "-".join(
-                    sorted(
-                        (
-                            t := fp.get_trait(can_represent_kicad_footprint)
-                        ).get_name_and_value()[0]
-                        + "-"
-                        + t.get_pin_name(pad)
-                        for pad, fp in self.get_fps().items()
-                        if fp.has_trait(can_represent_kicad_footprint)
-                    )
-                )
-
-                # kicad can't handle long net names
-                if len(name) > 255:
-                    name = name[:200] + "..." + name[-52:]
-
-                return name
-
-        return _()
 
     def get_fps(self):
         return {

--- a/src/faebryk/libs/library/L.py
+++ b/src/faebryk/libs/library/L.py
@@ -4,6 +4,7 @@
 import logging
 
 from faebryk.core.module import Module  # noqa: F401
+from faebryk.core.moduleinterface import ModuleInterface  # noqa: F401
 from faebryk.core.node import (  # noqa: F401
     InitVar,
     Node,

--- a/test/exporters/netlist/test_graph.py
+++ b/test/exporters/netlist/test_graph.py
@@ -1,0 +1,129 @@
+from unittest.mock import Mock
+
+import pytest
+
+from faebryk.core.node import Node
+from faebryk.exporters.netlist.graph import (
+    _conflicts,
+    _lowest_common_ancestor,
+    _NetName,
+)
+from faebryk.library import Net as F
+
+
+@pytest.mark.parametrize(
+    "base_name,prefix,suffix,expected",
+    [
+        ("test", None, None, "test"),
+        ("test", "prefix1-prefix2", None, "prefix1-prefix2-test"),
+        ("test", None, 1, "test-1"),
+        ("test", "prefix", 2, "prefix-test-2"),
+        (None, "prefix", 1, "prefix-net-1"),
+        (None, None, None, "net"),
+    ],
+)
+def test_net_name(base_name, prefix, suffix, expected):
+    net = _NetName(base_name=base_name, prefix=prefix, suffix=suffix)
+    assert net.name == expected
+
+
+@pytest.fixture
+def node_hierarchy():
+    """Creates a mock node hierarchy for testing."""
+    root = Mock(spec=Node)
+    child1 = Mock(spec=Node)
+    child2 = Mock(spec=Node)
+    grandchild1 = Mock(spec=Node)
+    grandchild2 = Mock(spec=Node)
+
+    # Setup hierarchies
+    root.get_hierarchy = lambda: [(root, "root")]
+    child1.get_hierarchy = lambda: [(root, "root"), (child1, "child1")]
+    child2.get_hierarchy = lambda: [(root, "root"), (child2, "child2")]
+    grandchild1.get_hierarchy = lambda: [
+        (root, "root"),
+        (child1, "child1"),
+        (grandchild1, "grandchild1"),
+    ]
+    grandchild2.get_hierarchy = lambda: [
+        (root, "root"),
+        (child2, "child2"),
+        (grandchild2, "grandchild2"),
+    ]
+
+    return type(
+        "NodeHierarchy",
+        (),
+        {
+            "root": root,
+            "child1": child1,
+            "child2": child2,
+            "grandchild1": grandchild1,
+            "grandchild2": grandchild2,
+        },
+    )
+
+
+def test_lowest_common_ancestor_empty():
+    assert _lowest_common_ancestor([]) is None
+
+
+def test_lowest_common_ancestor_single_node(node_hierarchy):
+    result = _lowest_common_ancestor([node_hierarchy.child1])
+    assert result == (node_hierarchy.child1, "child1")
+
+
+def test_lowest_common_ancestor_common_parent(node_hierarchy):
+    result = _lowest_common_ancestor([node_hierarchy.child1, node_hierarchy.child2])
+    assert result == (node_hierarchy.root, "root")
+
+
+def test_lowest_common_ancestor_different_depths(node_hierarchy):
+    result = _lowest_common_ancestor(
+        [node_hierarchy.grandchild1, node_hierarchy.child2]
+    )
+    assert result == (node_hierarchy.root, "root")
+
+
+def test_lowest_common_ancestor_same_branch(node_hierarchy):
+    result = _lowest_common_ancestor(
+        [node_hierarchy.grandchild1, node_hierarchy.child1]
+    )
+    assert result == (node_hierarchy.child1, "child1")
+
+
+@pytest.fixture
+def mock_nets():
+    """Creates mock nets for conflict testing."""
+    return [Mock(spec=F.Net) for _ in range(4)]
+
+
+def test_conflicts_no_conflicts(mock_nets):
+    names = {
+        mock_nets[0]: _NetName(base_name="test1"),
+        mock_nets[1]: _NetName(base_name="test2"),
+    }
+    assert list(_conflicts(names)) == []
+
+
+def test_conflicts_with_single_conflict(mock_nets):
+    names = {
+        mock_nets[0]: _NetName(base_name="test"),
+        mock_nets[1]: _NetName(base_name="test"),
+    }
+    conflicts = list(_conflicts(names))
+    assert len(conflicts) == 1
+    assert len(conflicts[0]) == 2
+    assert all(net in conflicts[0] for net in [mock_nets[0], mock_nets[1]])
+
+
+def test_conflicts_with_multiple_conflicts(mock_nets):
+    names = {
+        mock_nets[0]: _NetName(base_name="test1"),
+        mock_nets[1]: _NetName(base_name="test1"),
+        mock_nets[2]: _NetName(base_name="test2"),
+        mock_nets[3]: _NetName(base_name="test2"),
+    }
+    conflicts = list(_conflicts(names))
+    assert len(conflicts) == 2
+    assert all(len(conflict) == 2 for conflict in conflicts)


### PR DESCRIPTION
Example names from the `mcu` example:
```
*6198-hv-0
*6198-hv-1
*6198-hv-2
*6198.led.led-net
*6198.mcu-net-0
*6198.mcu-net-1
*6198.mcu-net-2
*6198.mcu-net-3
*6198.mcu-net-4
*6198.mcu-net-5
*6198.mcu-net-6
*6198.mcu-net-7
*6198.mcu-net-8
*6198.mcu-signal-0
*6198.mcu-signal-1
*6198.mcu.boot_selector-net
*6198.mcu.clock_source-net
*6198.mcu.clock_source.crystal.footprint.pins[1].net-net
*6198.mcu.ldo-signal
*6198.mcu.ldo.footprint.pins[3].net-net
*6198.mcu.rp2040-net-0
*6198.mcu.rp2040-net-1
*6198.mcu.rp2040-net-2
*6198.mcu.rp2040-signal
*6198.usb_power-net-0
*6198.usb_power-net-1
*6198.usb_power-net-2
*6198.usb_power-net-3
*6198.usb_power-signal-0
*6198.usb_power-signal-1
factory_test_enable
io[0]
io[10]
io[11]
io[12]
io[13]
io[14]
io[15]
io[16]
io[17]
io[18]
io[19]
io[1]
io[20]
io[21]
io[22]
io[23]
io[24]
io[26]
io[27]
io[28]
io[29]
io[2]
io[3]
io[4]
io[5]
io[6]
io[7]
io[8]
io[9]
lv
xout
```