### PR TITLE
Fix: Tools: libadd fails when EasyEDA footprint has no 3D model

### DIFF
--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -56,6 +56,9 @@ WORKAROUND_THT_INCH_MM_SWAP_FIX = False
 
 
 def _fix_3d_model_offsets(ki_footprint):
+    if ki_footprint.output.model_3d is None:
+        return
+
     if WORKAROUND_SMD_3D_MODEL_FIX:
         if ki_footprint.input.info.fp_type == "smd":
             ki_footprint.output.model_3d.translation.x = 0


### PR DESCRIPTION
Skips applying 3d model offsets when 3d model data isn't available.
