### PR TITLE
CLI: Skip ato builds

### DIFF
--- a/src/atopile/cli/build.py
+++ b/src/atopile/cli/build.py
@@ -54,7 +54,7 @@ def build(
             with accumulator.collect():
                 match build_ctx.build_type:
                     case BuildType.ATO:
-                        _do_ato_build(build_ctx)
+                        log.error("Building .ato modules is not currently supported")
                     case BuildType.PYTHON:
                         _do_python_build(build_ctx)
 


### PR DESCRIPTION
Temporary measure to get CI checks passing for Python projects, until we re-introduce `.ato` support.