### PR TITLE
Better fp-lib-table management

### DIFF
--- a/src/faebryk/libs/app/pcb.py
+++ b/src/faebryk/libs/app/pcb.py
@@ -122,7 +122,7 @@ def include_footprints(pcb_path: Path):
         )
 
     # TODO make more generic, this is very lcsc specific
-    fppath = pcb_path.parent / "lib" / "footprints/lcsc.pretty"
+    fppath = pcb_path.parent / "lib" / "footprints" / "lcsc.pretty"
     relative = True
     try:
         fppath_rel = fppath.resolve().relative_to(


### PR DESCRIPTION
Entries named `lcsc` in the `fp-lib-table` for each build config are now rewritten if they've drifted, and the entry points to the correct location (`lib/footprints/lcsc.pretty`, sibling to the PCB path).