### PR TITLE
Switch `pytest` CI workflow to `uv`

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,24 +12,28 @@ jobs:
         # Required due to a bug in the checkout action
         # https://github.com/actions/checkout/issues/1471
         - run: git fetch --prune --unshallow --tags
-        - name: Set up Python
+        - name: Install uv
+          uses: astral-sh/setup-uv@v4
+          with:
+            version: 0.5.5
+            enable-cache: true
+            cache-dependency-glob: "pyproject.toml"  # TOOD: uv.lock
+        - name: "Set up Python"
           uses: actions/setup-python@v5
           with:
-            python-version: '3.12'
-            #cache: 'hatch'
+            python-version-file: "pyproject.toml"
         - name: Install dependencies
           run: |
-            python -m pip install hatch --upgrade pip
-            hatch env create test
+            uv sync --all-extras --dev
         - name: Lint with Ruff
-          run: hatch run ruff check --output-format=github .
+          run: uv run ruff check --output-format=github .
           #continue-on-error: true
         - name: Setup cmake
           uses: jwlawson/actions-setup-cmake@v2
         - name: Run pytest
           id: pytest
           continue-on-error: true
-          run: hatch run test:pytest -m "not not_in_ci"
+          run: uv run pytest -m "not not_in_ci"
         - name: Upload all test logs
           if: steps.pytest.outcome == 'failure'
           uses: actions/upload-artifact@v4


### PR DESCRIPTION
Switches from `hatch` to `uv` for installing dependencies in CI.  Cuts `pytest` workflows from ~3.5m to ~2m.

Future tasks:
- use `uv` for everything except the build backend
- commit `uv.lock`
- update docs