### PR TITLE
Skip writing empty BOM

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -115,12 +115,10 @@ muster = Muster()
 @muster.register("bom")
 def generate_bom(build_ctx: BuildContext, app: Module) -> None:
     """Generate a BOM for the project."""
-    children = app.get_children_modules(types=Module)
-    if children:
-        write_bom_jlcpcb(
-            children,
-            build_ctx.paths.output_base.with_suffix(".bom.csv"),
-        )
+    write_bom_jlcpcb(
+        app.get_children_modules(types=Module),
+        build_ctx.paths.output_base.with_suffix(".bom.csv"),
+    )
 
 
 @muster.register("mfg-data", default=False)

--- a/src/faebryk/exporters/bom/jlcpcb.py
+++ b/src/faebryk/exporters/bom/jlcpcb.py
@@ -53,16 +53,17 @@ def write_bom_jlcpcb(components: set[Module], path: Path) -> None:
         rows = [vars(line) for line in bomlines]
         rename_column(rows, "LCSC_Partnumber", "LCSC Part #")
 
-        writer = csv.DictWriter(
-            bom_csv,
-            fieldnames=list(rows[0].keys()),
-            delimiter=",",
-            quotechar='"',
-            quoting=csv.QUOTE_MINIMAL,
-            lineterminator="\n",
-        )
-        writer.writeheader()
-        writer.writerows(rows)
+        if rows:
+            writer = csv.DictWriter(
+                bom_csv,
+                fieldnames=list(rows[0].keys()),
+                delimiter=",",
+                quotechar='"',
+                quoting=csv.QUOTE_MINIMAL,
+                lineterminator="\n",
+            )
+            writer.writeheader()
+            writer.writerows(rows)
 
 
 def _compact_bomlines(bomlines: list[BOMLine]) -> list[BOMLine]:


### PR DESCRIPTION
Skip generating BOM if the app is empty. Otherwise we get an error for something like

```
component A:
    signal b
```