### PR TITLE
DX: Only automatically recompile files when explicitly enabled

### DIFF
--- a/src/atopile/parser/__init__.py
+++ b/src/atopile/parser/__init__.py
@@ -4,12 +4,12 @@ from pathlib import Path
 
 from git import Repo
 
-from faebryk.libs.util import is_editable_install, run_live
+from faebryk.libs.util import AUTO_RECOMPILE, is_editable_install, run_live
 
 logger = logging.getLogger(__name__)
 
 
-if is_editable_install():
+if is_editable_install() and AUTO_RECOMPILE.get():
 
     def has_uncommitted_changes(files: list[str | Path]) -> bool:
         """Check if any of the given files have uncommitted changes."""

--- a/src/faebryk/core/cpp/__init__.py
+++ b/src/faebryk/core/cpp/__init__.py
@@ -3,7 +3,13 @@
 
 import logging
 
-from faebryk.libs.util import ConfigFlag, at_exit, global_lock, is_editable_install
+from faebryk.libs.util import (
+    AUTO_RECOMPILE,
+    ConfigFlag,
+    at_exit,
+    global_lock,
+    is_editable_install,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +117,7 @@ def compile_and_load():
 
 
 # Re-export c++ with type hints provided by __init__.pyi
-if is_editable_install():
+if is_editable_install() and AUTO_RECOMPILE:
     logger.warning("faebryk is installed as editable package, compiling c++ code")
     compile_and_load()
     from faebryk_core_cpp_editable import *  # type: ignore # noqa: E402, F403

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -1405,6 +1405,13 @@ def try_set_attr(obj: object, attr: str, value: Any) -> bool:
     return False
 
 
+AUTO_RECOMPILE = ConfigFlag(
+    "AUTO_RECOMPILE",
+    default=False,
+    descr="Automatically recompile source files if they have changed",
+)
+
+
 # Check if installed as editable
 def is_editable_install():
     distro = Distribution.from_name("atopile")


### PR DESCRIPTION
The previous implicit behavior was causing issues with:
- invoking the CLI with `subprocess.run` from CI
- building a project that's not inside a git repo, using an editable install