### PR TITLE
CI: Update workflow triggers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,8 @@ on:
      - main
     tags:
       - 'v*'
+    paths:
+      - '.github/workflows/cd.yml'
 
 jobs:
   python-build:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - '**'
+  push:
+    paths:
+      - '.github/workflows/pre-commit.yml'
 
 jobs:
   pre-commit:

--- a/.github/workflows/project-regression.yml
+++ b/.github/workflows/project-regression.yml
@@ -6,6 +6,9 @@ on:
   # pull_request:
   #   branches: [main]  # This will run on PRs targeting your main branch
   workflow_dispatch:  # Add manual trigger capability
+  push:
+    paths:
+      - '.github/workflows/project-regression.yml'
 
 jobs:
   regression_tests:

--- a/.github/workflows/vsx.yml
+++ b/.github/workflows/vsx.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+    paths:
+      - '.github/workflows/vsx.yml'
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - '.github/workflows/website.yml'
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,7 +7,9 @@ on:
   pull_request:
   push:
     branches:
-     - master
+     - main
+    paths:
+      - '.github/workflows/wheels.yml'
   release:
     types:
   #    - created


### PR DESCRIPTION
Runs `Continuous Delivery` workflow on PRs (minus publishing of built package), and all workflows when the workflow definition changes. This reduces the circumstances where CI checks can be invisibly broken in a PR.