### PR TITLE
CI: Fix project CI dockerfile build

### DIFF
--- a/dockerfiles/Dockerfile.kicad
+++ b/dockerfiles/Dockerfile.kicad
@@ -30,6 +30,10 @@ EORUN
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.5 /uv /bin/uv
 
+# TODO: remove (@https://github.com/astral-sh/uv/issues/6381)
+# @python3.13
+RUN uv python install 3.12
+
 COPY --chown=kicad:kicad dist/atopile-*.whl /tmp/
 
 RUN uv tool install /tmp/atopile-*.whl


### PR DESCRIPTION
Restores explicit python version specification for the `atopile-kicad` container. This should become unnecessary at some point, pending `uv` support for automatically inferring python version from the wheel metadata.

Alternatives considered:
- create a project `.python-version` file, duplicating the `pyproject.toml` requirement specification, to copy into the container
- copy the project source files into the container and install with `uv sync` or similar
- install from `sdist` rather than `wheel`