### PR TITLE
Fix `pytest` CI stability

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,20 +29,10 @@ jobs:
         - name: Setup cmake
           uses: jwlawson/actions-setup-cmake@v2
 
-        - name: Build project
-          run: uv build --wheel
-
-        - name: Install project + dependencies
-          run: |
-            uv sync --no-install-project --all-extras
-            uv pip install --venv ./.venv dist/*.whl
-        - name: Lint with Ruff
-          run: uv run ruff check --output-format=github .
-          #continue-on-error: true
         - name: Run pytest
           id: pytest
           continue-on-error: true
-          run: uv run pytest -m "not not_in_ci"
+          run: uv run --no-editable --frozen --all-extras pytest -m "not not_in_ci"
 
         - name: Upload all test logs
           if: steps.pytest.outcome == 'failure'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -35,7 +35,7 @@ jobs:
         - name: Install project + dependencies
           run: |
             uv sync --no-install-project --all-extras
-            uv pip install dist/*.whl
+            uv pip install --venv ./.venv dist/*.whl
         - name: Lint with Ruff
           run: uv run ruff check --output-format=github .
           #continue-on-error: true


### PR DESCRIPTION
`pytest` was failing ~50% of the time in CI because there was a collision trying to build the core from multiple processes.

This fixes that, by ensuring that `pytest` is run from a non-editable install of atopile

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules
