### PR TITLE
uv sync --dev should install all dev dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
         - name: Run pytest
           id: pytest
           continue-on-error: true
-          run: uv run --no-editable --frozen --all-extras pytest -m "not not_in_ci"
+          run: uv run --dev --no-editable --frozen pytest -m "not not_in_ci"
 
         - name: Upload all test logs
           if: steps.pytest.outcome == 'failure'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,34 +85,29 @@ Homepage = "https://github.com/atopile/atopile"
 "Bug Tracker" = "https://github.com/atopile/atopile/issues"
 
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
-    "atopile[test]",
-    "debugpy",
     "antlr4-tools",
-    "pre-commit>=2.20,<4.0",
-    "pytest>=7.1.3,<9.0.0",
-    "viztracer~=0.16.3",
-    "pyinstrument~=4.7.1",
-    "gprof2dot~=2024.6.6",
-    "pytest-xdist~=3.6.1",
-    "dash~=2.18.1",
-    "dash_cytoscape~=1.0.2",
-    "nanobind~=2.2.0",
+    "atopile[test]",
     "coverage>=7.6.8",
-]
-
-test = [
-    "pytest>=7.1.3,<9.0.0",
-    "pytest-html",
-    "pytest-datafiles",
-    "pytest-asyncio!=0.23.3",
-    "requests",
-    "pytest-xdist~=3.6.1",
+    "dash_cytoscape~=1.0.2",
+    "dash~=2.18.1",
+    "debugpy",
+    "gprof2dot~=2024.6.6",
+    "mkdocs-drawio-file >= 1.5.2",
+    "mkdocs-material",
+    "mkdocs",
     "nanobind~=2.2.0",
+    "pre-commit>=2.20,<4.0",
+    "pyinstrument~=4.7.1",
+    "pytest-asyncio!=0.23.3",
+    "pytest-datafiles",
+    "pytest-html",
+    "pytest-xdist~=3.6.1",
+    "pytest>=7.1.3,<9.0.0",
+    "requests",
+    "viztracer~=0.16.3",
 ]
-
-docs = ["mkdocs", "mkdocs-material", "mkdocs-drawio-file >= 1.5.2"]
 
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "atopile"
-version = "0.2.70.dev344+g896869d5.d20241203"
+version = "0.2.70.dev356+g9a720cc6.d20241205"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },
@@ -120,7 +120,7 @@ dependencies = [
     { name = "watchfiles" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "antlr4-tools" },
     { name = "coverage" },
@@ -128,6 +128,9 @@ dev = [
     { name = "dash-cytoscape" },
     { name = "debugpy" },
     { name = "gprof2dot" },
+    { name = "mkdocs" },
+    { name = "mkdocs-drawio-file" },
+    { name = "mkdocs-material" },
     { name = "nanobind" },
     { name = "pre-commit" },
     { name = "pyinstrument" },
@@ -139,34 +142,15 @@ dev = [
     { name = "requests" },
     { name = "viztracer" },
 ]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-drawio-file" },
-    { name = "mkdocs-material" },
-]
-test = [
-    { name = "nanobind" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-datafiles" },
-    { name = "pytest-html" },
-    { name = "pytest-xdist" },
-    { name = "requests" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "==4.13.2" },
-    { name = "antlr4-tools", marker = "extra == 'dev'" },
     { name = "attrs", specifier = ">=23.2.0" },
     { name = "black", specifier = "~=24.4.2" },
     { name = "case-converter", specifier = ">=1.1.0" },
     { name = "cattrs", specifier = ">=23.2.3" },
-    { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.6.8" },
-    { name = "dash", marker = "extra == 'dev'", specifier = "~=2.18.1" },
-    { name = "dash-cytoscape", marker = "extra == 'dev'", specifier = "~=1.0.2" },
     { name = "dataclasses-json", specifier = "~=0.6.7" },
-    { name = "debugpy", marker = "extra == 'dev'" },
     { name = "deepdiff", specifier = ">=6.7.1" },
     { name = "deprecated", specifier = "~=1.2.14" },
     { name = "easyeda2kicad", git = "https://github.com/atopile/easyeda2kicad.py.git" },
@@ -175,18 +159,12 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.109.0" },
     { name = "freetype-py", specifier = "~=2.4.0" },
     { name = "gitpython", specifier = ">=3.1.41" },
-    { name = "gprof2dot", marker = "extra == 'dev'", specifier = "~=2024.6.6" },
     { name = "igraph", specifier = ">=0.11.3" },
     { name = "isort", specifier = "~=5.6.4" },
     { name = "jinja2", specifier = ">=3.1.3" },
     { name = "kicadcliwrapper", specifier = "~=1.0.0" },
     { name = "matplotlib", specifier = "~=3.7.1" },
-    { name = "mkdocs", marker = "extra == 'docs'" },
-    { name = "mkdocs-drawio-file", marker = "extra == 'docs'", specifier = ">=1.5.2" },
-    { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "more-itertools", specifier = "~=10.4.0" },
-    { name = "nanobind", marker = "extra == 'dev'", specifier = "~=2.2.0" },
-    { name = "nanobind", marker = "extra == 'test'", specifier = "~=2.2.0" },
     { name = "natsort", specifier = ">=8.4.0" },
     { name = "networkx", specifier = ">=3.2.1" },
     { name = "numpy", specifier = ">=1.24.3,<3.0.0" },
@@ -194,26 +172,12 @@ requires-dist = [
     { name = "pandas", specifier = ">=2.1.4" },
     { name = "patool", specifier = "~=2.3.0" },
     { name = "pint", git = "https://github.com/hgrecco/pint.git?rev=a8bcb6ee1d0d61278bf17e332bc1aa473672e273#a8bcb6ee1d0d61278bf17e332bc1aa473672e273" },
-    { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=2.20,<4.0" },
     { name = "psutil", specifier = "~=6.0.0" },
     { name = "pygls", specifier = ">=1.3.0" },
-    { name = "pyinstrument", marker = "extra == 'dev'", specifier = "~=4.7.1" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.1.3,<9.0.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.1.3,<9.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = "!=0.23.3" },
-    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = "!=0.23.3" },
-    { name = "pytest-datafiles", marker = "extra == 'dev'" },
-    { name = "pytest-datafiles", marker = "extra == 'test'" },
-    { name = "pytest-html", marker = "extra == 'dev'" },
-    { name = "pytest-html", marker = "extra == 'test'" },
-    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = "~=3.6.1" },
-    { name = "pytest-xdist", marker = "extra == 'test'", specifier = "~=3.6.1" },
     { name = "quart", specifier = ">=0.19.9" },
     { name = "quart-cors", specifier = ">=0.7.0" },
     { name = "quart-schema", extras = ["pydantic"], specifier = ">=0.20.0" },
     { name = "requests", specifier = "~=2.32.3" },
-    { name = "requests", marker = "extra == 'dev'" },
-    { name = "requests", marker = "extra == 'test'" },
     { name = "rich", specifier = "~=13.7.1" },
     { name = "ruamel-yaml", specifier = ">=0.18.5" },
     { name = "ruff", specifier = ">=0.6.4,<0.7.0" },
@@ -228,8 +192,31 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.6.3,<5.0.0" },
     { name = "urllib3", specifier = ">=2.2.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.25.0" },
-    { name = "viztracer", marker = "extra == 'dev'", specifier = "~=0.16.3" },
     { name = "watchfiles", specifier = ">=0.21.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "antlr4-tools" },
+    { name = "atopile", extras = ["test"] },
+    { name = "coverage", specifier = ">=7.6.8" },
+    { name = "dash", specifier = "~=2.18.1" },
+    { name = "dash-cytoscape", specifier = "~=1.0.2" },
+    { name = "debugpy" },
+    { name = "gprof2dot", specifier = "~=2024.6.6" },
+    { name = "mkdocs" },
+    { name = "mkdocs-drawio-file", specifier = ">=1.5.2" },
+    { name = "mkdocs-material" },
+    { name = "nanobind", specifier = "~=2.2.0" },
+    { name = "pre-commit", specifier = ">=2.20,<4.0" },
+    { name = "pyinstrument", specifier = "~=4.7.1" },
+    { name = "pytest", specifier = ">=7.1.3,<9.0.0" },
+    { name = "pytest-asyncio", specifier = "!=0.23.3" },
+    { name = "pytest-datafiles" },
+    { name = "pytest-html" },
+    { name = "pytest-xdist", specifier = "~=3.6.1" },
+    { name = "requests" },
+    { name = "viztracer", specifier = "~=0.16.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
Uses the `[dependency-groups]` to support `uv` properly
Remove test group. Who uses it? Couldn't find a good case )(for now)