### PR TITLE
Up-rev requirements for v0.3.1 release

### DIFF
--- a/examples/project/ato.yaml
+++ b/examples/project/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+ato-version: ^0.3.0
 
 paths:
   src: ./

--- a/test/common/resources/test-project/ato.yaml
+++ b/test/common/resources/test-project/ato.yaml
@@ -1,4 +1,4 @@
-ato-version: ^0.2.0
+ato-version: ^0.3.0
 builds:
   unconstructable:
     entry: unconstructable.py:App


### PR DESCRIPTION
Commit is tagged as `v0.3.1-dev0`

I would've made it `v0.3.0-dev0`, but that already exists
I would've made it `v0.3.0-dev1`, but `hatch-vcs` doesn't support it

Need to reinstall atopile after pulling this

`uv sync --dev` is sufficent