### PR TITLE
Add module interfaces for Ethernet (4 pair), HDMI and I2S

### DIFF
--- a/src/faebryk/library/Ethernet.py
+++ b/src/faebryk/library/Ethernet.py
@@ -17,10 +17,7 @@ class GigabitEthernet(ModuleInterface):
     1000BASE-T Gigabit Ethernet Interface
     """
     # Ethernet pairs
-    pair0: F.DifferentialPair  # Ethernet_Pair0_P/N
-    pair1: F.DifferentialPair  # Ethernet_Pair1_P/N
-    pair2: F.DifferentialPair  # Ethernet_Pair2_P/N
-    pair3: F.DifferentialPair  # Ethernet_Pair3_P/N
+    pairs = L.list_field(4, F.DifferentialPair)
 
     # Status LEDs
     led_speed: F.ElectricLogic  # Speed LED
@@ -33,5 +30,3 @@ class GigabitEthernet(ModuleInterface):
             F.ElectricLogic.connect_all_module_references(self)
         )
 
-    def __preinit__(self) -> None:
-        pass

--- a/src/faebryk/library/Ethernet.py
+++ b/src/faebryk/library/Ethernet.py
@@ -8,6 +8,9 @@ from faebryk.libs.library import L
 
 logger = logging.getLogger(__name__)
 
+class Ethernet(ModuleInterface):
+    tx: F.DifferentialPair
+    rx: F.DifferentialPair
 
 class GigabitEthernet(ModuleInterface):
     """
@@ -18,7 +21,7 @@ class GigabitEthernet(ModuleInterface):
     pair1: F.DifferentialPair  # Ethernet_Pair1_P/N
     pair2: F.DifferentialPair  # Ethernet_Pair2_P/N
     pair3: F.DifferentialPair  # Ethernet_Pair3_P/N
-    
+
     # Status LEDs
     led_speed: F.ElectricLogic  # Speed LED
     led_link: F.ElectricLogic     # Link LED

--- a/src/faebryk/library/Ethernet.py
+++ b/src/faebryk/library/Ethernet.py
@@ -8,25 +8,26 @@ from faebryk.libs.library import L
 
 logger = logging.getLogger(__name__)
 
+
 class Ethernet(ModuleInterface):
     tx: F.DifferentialPair
     rx: F.DifferentialPair
+
 
 class GigabitEthernet(ModuleInterface):
     """
     1000BASE-T Gigabit Ethernet Interface
     """
+
     # Ethernet pairs
     pairs = L.list_field(4, F.DifferentialPair)
 
     # Status LEDs
     led_speed: F.ElectricLogic  # Speed LED
-    led_link: F.ElectricLogic     # Link LED
-
+    led_link: F.ElectricLogic  # Link LED
 
     @L.rt_field
     def single_electric_reference(self):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
-

--- a/src/faebryk/library/Ethernet.py
+++ b/src/faebryk/library/Ethernet.py
@@ -10,11 +10,6 @@ logger = logging.getLogger(__name__)
 
 
 class Ethernet(ModuleInterface):
-    tx: F.DifferentialPair
-    rx: F.DifferentialPair
-
-
-class GigabitEthernet(ModuleInterface):
     """
     1000BASE-T Gigabit Ethernet Interface
     """

--- a/src/faebryk/library/HDMI.py
+++ b/src/faebryk/library/HDMI.py
@@ -9,26 +9,28 @@ from faebryk.libs.library import L
 logger = logging.getLogger(__name__)
 
 
-class GigabitEthernet(ModuleInterface):
+class HDMI(ModuleInterface):
     """
-    1000BASE-T Gigabit Ethernet Interface
+    HDMI interface
     """
-    # Ethernet pairs
-    pair0: F.DifferentialPair  # Ethernet_Pair0_P/N
-    pair1: F.DifferentialPair  # Ethernet_Pair1_P/N
-    pair2: F.DifferentialPair  # Ethernet_Pair2_P/N
-    pair3: F.DifferentialPair  # Ethernet_Pair3_P/N
-    
-    # Status LEDs
-    led_speed: F.ElectricLogic  # Speed LED
-    led_link: F.ElectricLogic     # Link LED
-
+    data0: F.DifferentialPair
+    data1: F.DifferentialPair
+    data2: F.DifferentialPair
+    clock: F.DifferentialPair
+    i2c: F.I2C
+    cec: F.ElectricLogic
+    hotplug: F.ElectricLogic
+    power: F.ElectricPower
 
     @L.rt_field
     def single_electric_reference(self):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    # @staticmethod
+    # def define_max_frequency_capability(mode: SpeedMode):
+    #     return F.Range(I2C.SpeedMode.low_speed, mode)
 
     def __preinit__(self) -> None:
         pass

--- a/src/faebryk/library/HDMI.py
+++ b/src/faebryk/library/HDMI.py
@@ -13,14 +13,13 @@ class HDMI(ModuleInterface):
     """
     HDMI interface
     """
-    data0: F.DifferentialPair
-    data1: F.DifferentialPair
-    data2: F.DifferentialPair
+
+    power: F.ElectricPower
+    data = L.list_field(3, F.DifferentialPair)
     clock: F.DifferentialPair
     i2c: F.I2C
     cec: F.ElectricLogic
     hotplug: F.ElectricLogic
-    power: F.ElectricPower
 
     @L.rt_field
     def single_electric_reference(self):

--- a/src/faebryk/library/I2S.py
+++ b/src/faebryk/library/I2S.py
@@ -1,14 +1,12 @@
 # This file is part of the faebryk project
 # SPDX-License-Identifier: MIT
 import logging
-from enum import Enum
 
 import faebryk.library._F as F
 from faebryk.core.moduleinterface import ModuleInterface
+from faebryk.core.parameter import R
 from faebryk.libs.library import L
 from faebryk.libs.units import P
-from faebryk.core.parameter import R
-from faebryk.libs.util import cast_assert
 
 logger = logging.getLogger(__name__)
 

--- a/src/faebryk/library/I2S.py
+++ b/src/faebryk/library/I2S.py
@@ -1,0 +1,52 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+import logging
+from enum import Enum
+
+import faebryk.library._F as F
+from faebryk.core.moduleinterface import ModuleInterface
+from faebryk.libs.library import L
+from faebryk.libs.units import P
+from faebryk.core.parameter import R
+from faebryk.libs.util import cast_assert
+
+logger = logging.getLogger(__name__)
+
+
+class I2S(ModuleInterface):
+    sd: F.ElectricLogic    # Serial Data
+    ws: F.ElectricLogic    # Word Select (Left/Right Clock)
+    sck: F.ElectricLogic   # Serial Clock
+
+    sample_rate = L.p_field(units=P.hertz, domain=R.Domains.Numbers.NATURAL())
+    bit_depth = L.p_field(units=P.bit, domain=R.Domains.Numbers.NATURAL())
+
+    @L.rt_field
+    def single_electric_reference(self):
+        return F.has_single_electric_reference_defined(
+            F.ElectricLogic.connect_all_module_references(self)
+        )
+
+    class SampleRate(Enum):
+        rate_8k = 8 * P.khertz
+        rate_44k1 = 44.1 * P.khertz
+        rate_48k = 48 * P.khertz
+        rate_96k = 96 * P.khertz
+        rate_192k = 192 * P.khertz
+
+    class BitDepth(Enum):
+        depth_16 = 16
+        depth_24 = 24
+        depth_32 = 32
+
+    @staticmethod
+    def define_max_sample_rate_capability(rate: SampleRate):
+        return F.Range(I2S.SampleRate.rate_8k, rate)
+
+    def __preinit__(self) -> None:
+        self.sample_rate.add(
+            F.is_dynamic_by_connections(lambda mif: cast_assert(I2S, mif).sample_rate)
+        )
+        self.bit_depth.add(
+            F.is_dynamic_by_connections(lambda mif: cast_assert(I2S, mif).bit_depth)
+        )

--- a/src/faebryk/library/I2S.py
+++ b/src/faebryk/library/I2S.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 class I2S(ModuleInterface):
-    sd: F.ElectricLogic    # Serial Data
-    ws: F.ElectricLogic    # Word Select (Left/Right Clock)
-    sck: F.ElectricLogic   # Serial Clock
+    sd: F.ElectricLogic  # Serial Data
+    ws: F.ElectricLogic  # Word Select (Left/Right Clock)
+    sck: F.ElectricLogic  # Serial Clock
 
     sample_rate = L.p_field(units=P.hertz, domain=R.Domains.Numbers.NATURAL())
     bit_depth = L.p_field(units=P.bit, domain=R.Domains.Numbers.NATURAL())
@@ -25,28 +25,4 @@ class I2S(ModuleInterface):
     def single_electric_reference(self):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
-        )
-
-    class SampleRate(Enum):
-        rate_8k = 8 * P.khertz
-        rate_44k1 = 44.1 * P.khertz
-        rate_48k = 48 * P.khertz
-        rate_96k = 96 * P.khertz
-        rate_192k = 192 * P.khertz
-
-    class BitDepth(Enum):
-        depth_16 = 16
-        depth_24 = 24
-        depth_32 = 32
-
-    @staticmethod
-    def define_max_sample_rate_capability(rate: SampleRate):
-        return F.Range(I2S.SampleRate.rate_8k, rate)
-
-    def __preinit__(self) -> None:
-        self.sample_rate.add(
-            F.is_dynamic_by_connections(lambda mif: cast_assert(I2S, mif).sample_rate)
-        )
-        self.bit_depth.add(
-            F.is_dynamic_by_connections(lambda mif: cast_assert(I2S, mif).bit_depth)
         )

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -156,14 +156,15 @@ from faebryk.library.FilterElectricalLC import FilterElectricalLC
 from faebryk.library.FilterElectricalRC import FilterElectricalRC
 from faebryk.library.PowerMux import PowerMux
 from faebryk.library.Shenzhen_Kinghelm_Elec_KH_BNC75_3511 import Shenzhen_Kinghelm_Elec_KH_BNC75_3511
-from faebryk.library.Ethernet import Ethernet
 from faebryk.library.RS485HalfDuplex import RS485HalfDuplex
 from faebryk.library.USB_Type_C_Receptacle_16_pin import USB_Type_C_Receptacle_16_pin
 from faebryk.library.USB_Type_C_Receptacle_24_pin import USB_Type_C_Receptacle_24_pin
 from faebryk.library.Diodes_Incorporated_AP2552W6_7 import Diodes_Incorporated_AP2552W6_7
 from faebryk.library.ElectricLogicGate import ElectricLogicGate
+from faebryk.library.Ethernet import Ethernet
 from faebryk.library.GenericBusProtection import GenericBusProtection
 from faebryk.library.I2C import I2C
+from faebryk.library.I2S import I2S
 from faebryk.library.JTAG import JTAG
 from faebryk.library.LDO import LDO
 from faebryk.library.MultiSPI import MultiSPI
@@ -188,6 +189,7 @@ from faebryk.library.ElectricLogicGates import ElectricLogicGates
 from faebryk.library.Logic74xx import Logic74xx
 from faebryk.library.BH1750FVI_TR import BH1750FVI_TR
 from faebryk.library.EEPROM import EEPROM
+from faebryk.library.HDMI import HDMI
 from faebryk.library.INA228 import INA228
 from faebryk.library.ISO1540 import ISO1540
 from faebryk.library.M24C08_FMN6TP import M24C08_FMN6TP


### PR DESCRIPTION
Lib: Add i2s, Gigabit Ethernet and HDMI interfaces

# Description

Adding interfaces used in NONOS project for CM4, should be generally useful!

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
