### PR TITLE
Picker: Add heuristics for speedup

### DIFF
--- a/src/faebryk/library/LDO.py
+++ b/src/faebryk/library/LDO.py
@@ -111,7 +111,7 @@ class LDO(Module):
             mapping={
                 self.power_in.hv: ["Vin", "Vi", "in"],
                 self.power_out.hv: ["Vout", "Vo", "out", "output"],
-                self.power_in.lv: ["GND", "V-"],
+                self.power_in.lv: ["GND", "V-", "ADJ/GND"],
                 self.enable.enable.signal: ["EN", "Enable"],
             },
             accept_prefix=False,

--- a/src/faebryk/libs/picker/api/api.py
+++ b/src/faebryk/libs/picker/api/api.py
@@ -21,6 +21,7 @@ from faebryk.libs.util import (
     ConfigFlagString,
     Serializable,
     SerializableJSONEncoder,
+    once,
 )
 
 logger = logging.getLogger(__name__)
@@ -232,14 +233,14 @@ class ApiClient:
         kw["extra"] = json.dumps(kw["extra"])
         return Component(**kw)
 
-    @functools.lru_cache(maxsize=None)
+    @once
     def fetch_part_by_lcsc(self, lcsc: int) -> list["Component"]:
         response = self._get(f"/v0/component/lcsc/{lcsc}")
         return [
             self.ComponentFromResponse(part) for part in response.json()["components"]
         ]
 
-    @functools.lru_cache(maxsize=None)
+    @once
     def fetch_part_by_mfr(self, mfr: str, mfr_pn: str) -> list["Component"]:
         response = self._get(f"/v0/component/mfr/{mfr}/{mfr_pn}")
         return [
@@ -252,6 +253,7 @@ class ApiClient:
             self.ComponentFromResponse(part) for part in response.json()["components"]
         ]
 
+    @once
     def fetch_parts(self, params: BaseParams) -> list["Component"]:
         assert params.endpoint
         return self.query_parts(params.endpoint, params)

--- a/src/faebryk/libs/picker/api/api.py
+++ b/src/faebryk/libs/picker/api/api.py
@@ -51,17 +51,17 @@ class ApiHTTPError(ApiError):
         return f"{super().__str__()}: {status_code} {detail}"
 
 
-def get_package_candidates(module: Module) -> list["PackageCandidate"]:
+def get_package_candidates(module: Module) -> frozenset["PackageCandidate"]:
     import faebryk.library._F as F
 
     if module.has_trait(F.has_package_requirement):
-        return [
+        return frozenset(
             PackageCandidate(package)
             for package in module.get_trait(
                 F.has_package_requirement
             ).get_package_candidates()
-        ]
-    return []
+        )
+    return frozenset()
 
 
 @dataclass_json
@@ -73,7 +73,7 @@ class PackageCandidate:
 @dataclass_json
 @dataclass(frozen=True, kw_only=True)
 class BaseParams(Serializable):
-    package_candidates: list[PackageCandidate]
+    package_candidates: frozenset[PackageCandidate]
     qty: int
     endpoint: str | None = None
 

--- a/src/faebryk/libs/picker/api/common.py
+++ b/src/faebryk/libs/picker/api/common.py
@@ -25,7 +25,7 @@ from faebryk.libs.picker.lcsc import (
 from faebryk.libs.picker.picker import (
     PickError,
 )
-from faebryk.libs.util import cast_assert, not_none, once
+from faebryk.libs.util import cast_assert, not_none
 
 if TYPE_CHECKING:
     from faebryk.libs.picker.jlcpcb.jlcpcb import Component, MappingParameterDB
@@ -214,21 +214,12 @@ def pick_atomically(candidates: list[tuple[Module, "Component"]], solver: Solver
         )
         for module, part in candidates
     ]
-    ok = check_compatible_parameters(module_candidate_params, solver)
-    if not ok:
+    if not check_compatible_parameters(module_candidate_params, solver):
         return False
     for m, part, mapping in module_candidate_params:
         try_attach(m, [part], mapping, qty=1)
 
     return True
-
-
-@once
-def cached_api_call[T: BaseParams](
-    api_method: Callable[[T], list["Component"]],
-    param: T,
-):
-    return api_method(param)
 
 
 def find_component_by_params[T: BaseParams](
@@ -251,8 +242,7 @@ def find_component_by_params[T: BaseParams](
         p.get_name(): p.get_last_known_deduced_superset(solver) for p in known_params
     }
 
-    parts = cached_api_call(
-        api_method,
+    parts = api_method(
         param_cls(package_candidates=fps, qty=qty, **cmp_params),  # type: ignore
     )
 

--- a/src/faebryk/libs/picker/api/picker_lib.py
+++ b/src/faebryk/libs/picker/api/picker_lib.py
@@ -26,6 +26,12 @@ from faebryk.libs.picker.api.common import (
     find_component_by_params,
 )
 from faebryk.libs.picker.jlcpcb.jlcpcb import Component
+from faebryk.libs.picker.lcsc import (
+    LCSC_NoDataException,
+    LCSC_PinmapException,
+    attach,
+    check_attachable,
+)
 from faebryk.libs.picker.picker import DescriptiveProperties, PickError
 from faebryk.libs.util import Tree
 
@@ -94,6 +100,9 @@ TYPE_SPECIFIC_LOOKUP: dict[type[Module], type[BaseParams]] = {
 
 def _find_module_by_api(module: Module, solver: Solver) -> list[Component]:
     assert module.has_trait(F.is_pickable)
+    # Error can propagate through,
+    # because we expect all pickable modules to be attachable
+    check_attachable(module)
 
     if module.has_trait(F.has_descriptive_properties):
         props = module.get_trait(F.has_descriptive_properties).get_properties()
@@ -103,7 +112,29 @@ def _find_module_by_api(module: Module, solver: Solver) -> list[Component]:
             return _find_by_mfr(module, solver)
 
     params_t = TYPE_SPECIFIC_LOOKUP[type(module)]
-    return find_component_by_params(client.fetch_parts, params_t, module, solver, qty)
+    candidates = find_component_by_params(
+        client.fetch_parts, params_t, module, solver, qty
+    )
+
+    # Filter parts with weird pinmaps
+    it = iter(candidates)
+    filtered_candidates = []
+    for c in it:
+        try:
+            attach(module, c.partno, check_only=True, get_model=False)
+            filtered_candidates.append(c)
+            # If we found one that's ok, just continue since likely enough
+            filtered_candidates.extend(it)
+            break
+        except LCSC_NoDataException:
+            if len(candidates) == 1:
+                raise
+        except LCSC_PinmapException:
+            # if all filtered by pinmap something is fishy
+            if not filtered_candidates and candidates[-1] is c:
+                raise
+
+    return filtered_candidates
 
 
 def api_get_candidates(
@@ -115,6 +146,7 @@ def api_get_candidates(
 
     while candidates:
         # TODO use parallel (endpoint)
+        # TODO deduplicate parts with same literals
         new_parts = {m: _find_module_by_api(m, solver) for m in modules}
         parts.update({m: p for m, p in new_parts.items() if p})
         empty = {m for m, p in new_parts.items() if not p}

--- a/src/faebryk/libs/picker/jlcpcb/jlcpcb.py
+++ b/src/faebryk/libs/picker/jlcpcb/jlcpcb.py
@@ -345,9 +345,8 @@ class Component(Model):
             p = getattr(module, name.param_name)
             assert isinstance(p, Parameter)
             if value is None:
-                p.constrain_superset(p.domain.unbounded(p))
-            else:
-                p.alias_is(value)
+                value = p.domain.unbounded(p)
+            p.alias_is(value)
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(

--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -213,22 +213,29 @@ def get_datasheet_url(part: EeSymbol):
         return None
 
 
-def attach(component: Module, partno: str, get_model: bool = True):
+def check_attachable(component: Module):
+    if not component.has_trait(F.has_footprint):
+        if not component.has_trait(F.can_attach_to_footprint):
+            if not component.has_trait(F.has_pin_association_heuristic):
+                raise LCSC_PinmapException(
+                    "",
+                    f"Need either F.can_attach_to_footprint or "
+                    "F.has_pin_association_heuristic"
+                    f" for {component}",
+                )
+
+
+def attach(
+    component: Module, partno: str, get_model: bool = True, check_only: bool = False
+):
     ki_footprint, ki_model, easyeda_footprint, easyeda_model, easyeda_symbol = (
         download_easyeda_info(partno, get_model=get_model)
     )
 
     # symbol
+    # TODO maybe check it?
     if not component.has_trait(F.has_footprint):
         if not component.has_trait(F.can_attach_to_footprint):
-            if not component.has_trait(F.has_pin_association_heuristic):
-                raise LCSCException(
-                    partno,
-                    f"Need either F.can_attach_to_footprint or "
-                    "F.has_pin_association_heuristic"
-                    f" for {component} with partno {partno}",
-                )
-
             # TODO make this a trait
             pins = [
                 (pin.settings.spice_pin_number, pin.name.text)
@@ -241,10 +248,15 @@ def attach(component: Module, partno: str, get_model: bool = True):
                 )
             except F.has_pin_association_heuristic.PinMatchException as e:
                 raise LCSC_PinmapException(partno, f"Failed to get pinmap: {e}") from e
+            if check_only:
+                return
             component.add(F.can_attach_to_footprint_via_pinmap(pinmap))
 
             sym = F.Symbol.with_component(component, pinmap)
             sym.add(F.Symbol.has_kicad_symbol(f"lcsc:{easyeda_footprint.info.name}"))
+
+        if check_only:
+            return
 
         # footprint
         fp = F.KicadFootprint(
@@ -252,6 +264,9 @@ def attach(component: Module, partno: str, get_model: bool = True):
             [p.number for p in easyeda_footprint.pads],
         )
         component.get_trait(F.can_attach_to_footprint).attach(fp)
+
+    if check_only:
+        return
 
     component.add(F.has_descriptive_properties_defined({"LCSC": partno}))
 

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -773,7 +773,6 @@ class LazyMixin:
 
 class Lazy(LazyMixin):
     def __init_subclass__(cls) -> None:
-        print("SUBCLASS", cls)
         super().__init_subclass__()
         lazy_construct(cls)
 


### PR DESCRIPTION
- Pick single candidate modules first
- Try non-singles in one go 
- only consider attachable modules/parts
- cache/deduplicate api requests
