### PR TITLE
Trigger regression on adding a label to it's PR

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -3,7 +3,8 @@ name: regression
 on:
   push:
     branches: [main]  # Adjust this if your default branch has a different name
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:  # Add manual trigger capability
 
 jobs:


### PR DESCRIPTION
If [I'm reading this](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) right, workflow should now trigger on: opening, pushes or adding a label