### PR TITLE
Make `ato` build again - Part V: The Emprire Strikes Back

### DIFF
--- a/src/atopile/_shim.py
+++ b/src/atopile/_shim.py
@@ -17,7 +17,7 @@ from atopile import address
 from faebryk.core.trait import TraitImpl, TraitNotFound
 from faebryk.libs.exceptions import DeprecatedException, downgrade
 from faebryk.libs.picker.picker import DescriptiveProperties
-from faebryk.libs.util import cast_assert, write_only_property
+from faebryk.libs.util import write_only_property
 
 log = logging.getLogger(__name__)
 
@@ -93,7 +93,7 @@ class has_ato_cmp_attrs(L.Module.TraitT.decless()):
         self.pinmap = {}
 
     def on_obj_set(self):
-        self.module = cast_assert(L.Module, self.obj)
+        self.module = self.get_obj(L.Module)
         self.module.add(F.can_attach_to_footprint_via_pinmap(self.pinmap))
         self.module.add(
             F.has_designator_prefix_defined(F.has_designator_prefix.Prefix.U)

--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -963,9 +963,7 @@ class Bob(BasicsMixin, PhysicalValuesMixin, SequenceMixin, AtoParserVisitor):  #
                         f"Implied units {value.units} are incompatible"
                         f" with explicit units {provided_unit}.",
                     )
-                param = self._ensure_param(target, assigned_name, provided_unit, ctx)
-            else:
-                param = self._get_or_promise_param(target, assigned_name, ctx)
+            param = self._ensure_param(target, assigned_name, value.units, ctx)
             self._param_assignments[param] = (value, ctx)
 
         elif assignable_ctx.string() or assignable_ctx.boolean_():


### PR DESCRIPTION
- Fix signal de-duplication
- Implement cumulative operators