### PR TITLE
Core; Some micro-optimization of p_sets

### DIFF
--- a/src/faebryk/libs/picker/api/api.py
+++ b/src/faebryk/libs/picker/api/api.py
@@ -3,6 +3,7 @@
 
 import json
 import logging
+import time
 from dataclasses import dataclass
 
 import requests
@@ -87,6 +88,7 @@ class ApiClient:
     def _post(
         self, url: str, data: dict, timeout: float = DEFAULT_API_TIMEOUT_SECONDS
     ) -> requests.Response:
+        now = time.time()
         try:
             response = self._client.post(
                 f"{self.config.api_url}{url}", json=data, timeout=timeout
@@ -94,6 +96,8 @@ class ApiClient:
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
             raise ApiHTTPError(e) from e
+        finally:
+            logger.info(f"Backend query took {time.time() - now:.3f} seconds")
 
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug(

--- a/src/faebryk/libs/sets/quantity_sets.py
+++ b/src/faebryk/libs/sets/quantity_sets.py
@@ -22,6 +22,7 @@ from faebryk.libs.units import (
 from faebryk.libs.util import (
     cast_assert,
     not_none,
+    once,
     operator_type_check,
     round_str,
 )
@@ -178,10 +179,12 @@ class Quantity_Interval(Quantity_Set):
         return center, delta  # type: ignore
 
     @property
+    @once
     def min_elem(self) -> Quantity:
         return self.base_to_units(self._interval.min_elem)
 
     @property
+    @once
     def max_elem(self) -> Quantity:
         return self.base_to_units(self._interval.max_elem)
 
@@ -315,6 +318,7 @@ class Quantity_Interval(Quantity_Set):
     def __and__(self, other: "Quantity_Interval"):
         return self.op_intersect_interval(other)
 
+    @once
     def is_single_element(self) -> bool:
         return self.min_elem == self.max_elem  # type: ignore #TODO
 
@@ -403,12 +407,14 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self._intervals.is_empty()
 
     @property
+    @once
     def min_elem(self) -> Quantity:
         if self.is_empty():
             raise ValueError("empty interval cannot have min element")
         return self.base_to_units(self._intervals.min_elem)
 
     @property
+    @once
     def max_elem(self) -> Quantity:
         if self.is_empty():
             raise ValueError("empty interval cannot have max element")
@@ -533,12 +539,15 @@ class Quantity_Interval_Disjoint(Quantity_Set):
             return self._intervals.__contains__(item)
         return False
 
+    @once
     def __hash__(self) -> int:
         return hash((self._intervals, self.interval_units))
 
+    @once
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self})"
 
+    @once
     def __str__(self) -> str:
         def _format_interval(r: Numeric_Interval[NumericT]) -> str:
             if r._min == r._max:
@@ -655,6 +664,7 @@ class Quantity_Interval_Disjoint(Quantity_Set):
             raise ValueError("incompatible units")
         return self._intervals <= other_q._intervals
 
+    @once
     def is_single_element(self) -> bool:
         if self.is_empty():
             return False


### PR DESCRIPTION
Use `@once` in some expensive functions that are called often

> `FBRK_PICKER_API_URL=http://localhost:8000 python ./test/runtest.py  -k test_very_compl`

Before
```
                                           Timings                                                                                                        
                    ┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┓                                                                                       
                    ┃ Category           ┃ Subcategory ┃   Value ┃                                     
                    Unit ┃                                                                                                                       
                    ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━┩                                                                                       
                    │ construct          │             │  109.27 │                           
                    ms   │                                                                                                                     
                    │ resolve bus params │             │ 2646.83 │                           
                    ms   │                                                                                                                     
                    │ pre-solve          │             │ 1756.89 │                           
                    ms   │                                                                                                                     
                    │ pick               │             │ 5373.10 │                           
                    ms   │                                                                                                                     
                    └────────────────────┴─────────────┴─────────┴──────┘    
```

After
```
                    ┏━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━┓                                                                                       
                    ┃ Category           ┃ Subcategory ┃   Value ┃                                     
                    Unit ┃                                                                                                                       
                    ┡━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━┩                                                                                       
                    │ construct          │             │  114.30 │                           
                    ms   │                                                                                                                     
                    │ resolve bus params │             │ 2403.08 │                           
                    ms   │                                                                                                                     
                    │ pre-solve          │             │ 1741.68 │                           
                    ms   │                                                                                                                     
                    │ pick               │             │ 4606.07 │                           
                    ms   │                                                                                                                     
                    └────────────────────┴─────────────┴─────────┴──────┘     
```