### PR TITLE
CI: Make KiCad footprint data available for regression tests

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -43,6 +43,22 @@ jobs:
     - name: Setup cmake
       uses: jwlawson/actions-setup-cmake@v2
 
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    # TODO: remove dependency on global fp-lib-table
+    - name: Prepare test environment
+      run: |
+        mkdir -p ~/.config/kicad/8.0/
+        aws s3 cp "s3://${{ secrets.TEST_DATASET_BUCKET }}/kicad-8.0-fp-lib-table" ~/.config/kicad/8.0/fp-lib-table
+
+        mkdir -p /usr/share/kicad/
+        aws s3 cp "s3://${{ secrets.TEST_DATASET_BUCKET }}/kicad-8.0-footprints.tar.gz" - | tar -xz -C /usr/share/kicad/
+
     - name: Run pytest
       id: pytest
       continue-on-error: true


### PR DESCRIPTION
Copies KiCad footprint library files into the runner.

TODO: remove dependence on the global footprint library