### PR TITLE
Don't run regression testing by default

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -64,7 +64,7 @@ jobs:
       continue-on-error: true
       # Regular tests are run as part of the pytest workflow
       run: |
-        uv run --dev --no-editable --frozen pytest -m "not not_in_ci and regression" --timeout=900
+        uv run --dev --no-editable --frozen pytest -m "not not_in_ci and regression" --timeout=1200
       env:
         GH_TOKEN: ${{ github.token }}
         PYTEST_HISTORY_EMAIL: ${{ vars.PYTEST_HISTORY_EMAIL }}

--- a/.vscode/settings.shared.json
+++ b/.vscode/settings.shared.json
@@ -5,5 +5,7 @@
     "python.testing.pytestEnabled": true,
     "python.testing.cwd": "${workspaceFolder}",
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
-    "python.analysis.typeCheckingMode": "standard"
+    "python.analysis.typeCheckingMode": "standard",
+    // Currently doesn't work. See: https://github.com/microsoft/vscode-python/issues/21845
+    // "python.testing.pytestArgs": ["-m", ""]  // Reset the pytest args to nothing, devs see all
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,7 @@ addopts = [
     "--html=artifacts/test-report.html",
     "--self-contained-html",
     "--numprocesses=auto",
+    "-m", "not regression",
 ]
 filterwarnings = ["ignore:.*:DeprecationWarning"]
 testpaths = ["test"]
@@ -149,7 +150,7 @@ asyncio_default_fixture_loop_scope = "function"
 log_file_format = "%(asctime)s %(levelname)s %(name)s %(message)s"
 # log_file_level = "DEBUG"  # <-- you can set this in a PR if you want to debug tests in CI
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "slow: marks tests as slow",
     "not_in_ci: marks tests that should not be run in CI",
     "regression: marks tests that are used for deeper regression testing. May be slow and flaky.",
 ]


### PR DESCRIPTION
This currently sucks, because without the changes commented out in `settings.shared.json`, it doesn't collect marked-out-tests, and with them it, it won't run them

This should fix it:
https://github.com/microsoft/vscode-python/issues/21845