### PR TITLE
Picker: Make picking more explicit

### DIFF
--- a/src/faebryk/library/Capacitor.py
+++ b/src/faebryk/library/Capacitor.py
@@ -46,6 +46,8 @@ class Capacitor(Module):
         F.has_designator_prefix.Prefix.C
     )
 
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.Capacitor)
+
     @L.rt_field
     def can_bridge(self):
         return F.can_bridge_defined(*self.unnamed)

--- a/src/faebryk/library/Diode.py
+++ b/src/faebryk/library/Diode.py
@@ -45,6 +45,8 @@ class Diode(Module):
     anode: F.Electrical
     cathode: F.Electrical
 
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.Diode)
+
     @L.rt_field
     def can_bridge(self):
         return F.can_bridge_defined(self.anode, self.cathode)

--- a/src/faebryk/library/Inductor.py
+++ b/src/faebryk/library/Inductor.py
@@ -34,6 +34,8 @@ class Inductor(Module):
         tolerance_guess=10 * P.percent,
     )
 
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.Inductor)
+
     @L.rt_field
     def can_bridge(self):
         return F.can_bridge_defined(*self.unnamed)

--- a/src/faebryk/library/LDO.py
+++ b/src/faebryk/library/LDO.py
@@ -63,6 +63,8 @@ class LDO(Module):
     power_in: F.ElectricPower
     power_out = L.d_field(lambda: F.ElectricPower().make_source())
 
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.LDO)
+
     def __preinit__(self):
         self.max_input_voltage.constrain_ge(self.power_in.voltage)
         self.power_out.voltage.constrain_subset(self.output_voltage)

--- a/src/faebryk/library/LED.py
+++ b/src/faebryk/library/LED.py
@@ -45,6 +45,8 @@ class LED(F.Diode):
     max_brightness = L.p_field(units=P.candela)
     color = L.p_field(domain=L.Domains.ENUM(Color))
 
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.LED)
+
     def __preinit__(self):
         self.current.alias_is(self.brightness / self.max_brightness * self.max_current)
         self.brightness.constrain_le(self.max_brightness)

--- a/src/faebryk/library/MOSFET.py
+++ b/src/faebryk/library/MOSFET.py
@@ -33,6 +33,8 @@ class MOSFET(Module):
         F.has_designator_prefix.Prefix.Q
     )
 
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.MOSFET)
+
     # TODO pretty confusing
     @L.rt_field
     def can_bridge(self):

--- a/src/faebryk/library/Mounting_Hole.py
+++ b/src/faebryk/library/Mounting_Hole.py
@@ -8,7 +8,6 @@ import faebryk.library._F as F
 from faebryk.core.module import Module
 from faebryk.libs.iso_metric_screw_thread import Iso262_MetricScrewThreadSizes
 from faebryk.libs.library import L
-from faebryk.libs.picker.picker import has_part_picked_remove
 
 logger = logging.getLogger(__name__)
 
@@ -48,5 +47,3 @@ class Mounting_Hole(Module):
                 pin_names=[],
             )
         )
-
-    no_part: has_part_picked_remove

--- a/src/faebryk/library/MultiCapacitor.py
+++ b/src/faebryk/library/MultiCapacitor.py
@@ -6,7 +6,6 @@ import logging
 import faebryk.library._F as F  # noqa: F401
 from faebryk.core.parameter import Add, ParameterOperatable
 from faebryk.libs.library import L  # noqa: F401
-from faebryk.libs.picker.picker import skip_self_pick
 from faebryk.libs.units import Quantity
 from faebryk.libs.util import times  # noqa: F401
 
@@ -30,7 +29,8 @@ class MultiCapacitor(F.Capacitor):
         super().__init__()
         self._count = count
 
-    skip_self: skip_self_pick
+    # Not pickable
+    pickable = None
 
     @L.rt_field
     def capacitors(self) -> list[F.Capacitor]:

--- a/src/faebryk/library/PANASONIC_AQY212EHAX.py
+++ b/src/faebryk/library/PANASONIC_AQY212EHAX.py
@@ -6,7 +6,7 @@ import logging
 import faebryk.library._F as F  # noqa: F401
 from faebryk.core.module import Module
 from faebryk.libs.library import L  # noqa: F401
-from faebryk.libs.picker.picker import DescriptiveProperties, has_part_picked_remove
+from faebryk.libs.picker.picker import DescriptiveProperties
 from faebryk.libs.units import P  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -57,8 +57,8 @@ class PANASONIC_AQY212EHAX(Module):
         # ------------------------------------
         #           connections
         # ------------------------------------
-        self.led.add(has_part_picked_remove())
-        self.switch.add(has_part_picked_remove())
+        self.led.del_trait(F.is_pickable)
+        self.switch.del_trait(F.is_pickable)
 
         # ------------------------------------
         #          parametrization

--- a/src/faebryk/library/PowerSwitchStatic.py
+++ b/src/faebryk/library/PowerSwitchStatic.py
@@ -1,7 +1,6 @@
 # This file is part of the faebryk project
 # SPDX-License-Identifier: MIT
 import faebryk.library._F as F
-from faebryk.libs.picker.picker import has_part_picked_remove
 
 
 class PowerSwitchStatic(F.PowerSwitch):
@@ -11,7 +10,7 @@ class PowerSwitchStatic(F.PowerSwitch):
     This is useful when transforming an F.ElectricLogic to an F.ElectricPower
     """
 
-    picked: has_part_picked_remove
+    picked: F.has_part_removed
 
     def __init__(self, normally_closed: bool) -> None:
         super().__init__(normally_closed=normally_closed)

--- a/src/faebryk/library/Resistor.py
+++ b/src/faebryk/library/Resistor.py
@@ -19,6 +19,8 @@ class Resistor(Module):
         F.has_designator_prefix.Prefix.R
     )
 
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.Resistor)
+
     @L.rt_field
     def can_bridge(self):
         return F.can_bridge_defined(*self.unnamed)
@@ -40,7 +42,7 @@ class Resistor(Module):
         # def do_replace():
         #     self.resistance.constrain_subset(0.0 * P.ohm)
         #     self.unnamed[0].connect(self.unnamed[1])
-        #     self.add(has_part_picked_remove())
+        #     self.add(F.has_part_removed())
         #
         # self.resistance.operation_is_superset(0.0 * P.ohm).if_then_else(
         #     lambda: do_replace(),

--- a/src/faebryk/library/TVS.py
+++ b/src/faebryk/library/TVS.py
@@ -12,3 +12,5 @@ logger = logging.getLogger(__name__)
 
 class TVS(F.Diode):
     reverse_breakdown_voltage = L.p_field(units=P.V)
+
+    pickable = L.f_field(F.is_pickable_by_type)(F.is_pickable_by_type.Type.TVS)

--- a/src/faebryk/library/USB2_0_ESD_Protection.py
+++ b/src/faebryk/library/USB2_0_ESD_Protection.py
@@ -6,7 +6,6 @@ import logging
 import faebryk.library._F as F
 from faebryk.core.module import Module
 from faebryk.libs.library import L
-from faebryk.libs.picker.picker import has_part_picked_remove
 from faebryk.libs.units import P
 
 logger = logging.getLogger(__name__)
@@ -26,7 +25,7 @@ class USB2_0_ESD_Protection(Module):
     vbus_esd_protection = L.p_field(domain=L.Domains.BOOL())
     data_esd_protection = L.p_field(domain=L.Domains.BOOL())
 
-    no_pick: has_part_picked_remove
+    no_pick: F.has_part_removed
 
     # ----------------------------------------
     #                 traits

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -31,6 +31,7 @@ from faebryk.library.Signal import Signal
 from faebryk.library.has_footprint import has_footprint
 from faebryk.library.Mechanical import Mechanical
 from faebryk.library.has_overriden_name import has_overriden_name
+from faebryk.library.is_pickable import is_pickable
 from faebryk.library.has_linked_pad import has_linked_pad
 from faebryk.library.has_reference import has_reference
 from faebryk.library.is_app_root import is_app_root
@@ -39,6 +40,7 @@ from faebryk.library.can_bridge import can_bridge
 from faebryk.library.can_specialize import can_specialize
 from faebryk.library.has_datasheet import has_datasheet
 from faebryk.library.has_designator import has_designator
+from faebryk.library.has_part_picked import has_part_picked
 from faebryk.library.has_descriptive_properties import has_descriptive_properties
 from faebryk.library.has_simple_value_representation import has_simple_value_representation
 from faebryk.library.has_capacitance import has_capacitance
@@ -50,7 +52,7 @@ from faebryk.library.is_optional import is_optional
 from faebryk.library.has_reference_layout import has_reference_layout
 from faebryk.library.has_resistance import has_resistance
 from faebryk.library.has_single_connection import has_single_connection
-from faebryk.library.is_pickable import is_pickable
+from faebryk.library.is_not_pickable import is_not_pickable
 from faebryk.library.is_representable_by_single_value import is_representable_by_single_value
 from faebryk.library.has_designator_prefix_defined import has_designator_prefix_defined
 from faebryk.library.has_pcb_position_defined import has_pcb_position_defined
@@ -65,12 +67,15 @@ from faebryk.library.Filter import Filter
 from faebryk.library.Logic import Logic
 from faebryk.library.Footprint import Footprint
 from faebryk.library.has_overriden_name_defined import has_overriden_name_defined
+from faebryk.library.is_pickable_by_part_number import is_pickable_by_part_number
+from faebryk.library.is_pickable_by_supplier_id import is_pickable_by_supplier_id
+from faebryk.library.is_pickable_by_type import is_pickable_by_type
 from faebryk.library.has_linked_pad_defined import has_linked_pad_defined
 from faebryk.library.Symbol import Symbol
 from faebryk.library.can_bridge_defined import can_bridge_defined
 from faebryk.library.has_datasheet_defined import has_datasheet_defined
 from faebryk.library.has_designator_defined import has_designator_defined
-from faebryk.library.has_descriptive_properties_defined import has_descriptive_properties_defined
+from faebryk.library.has_part_removed import has_part_removed
 from faebryk.library.has_simple_value_representation_based_on_params import has_simple_value_representation_based_on_params
 from faebryk.library.has_simple_value_representation_based_on_params_chain import has_simple_value_representation_based_on_params_chain
 from faebryk.library.has_simple_value_representation_defined import has_simple_value_representation_defined
@@ -85,6 +90,7 @@ from faebryk.library.can_attach_to_footprint import can_attach_to_footprint
 from faebryk.library.can_attach_via_pinmap import can_attach_via_pinmap
 from faebryk.library.has_footprint_impl import has_footprint_impl
 from faebryk.library.has_kicad_footprint import has_kicad_footprint
+from faebryk.library.has_descriptive_properties_defined import has_descriptive_properties_defined
 from faebryk.library.Pad import Pad
 from faebryk.library.has_symbol_layout import has_symbol_layout
 from faebryk.library.Button import Button

--- a/src/faebryk/library/has_descriptive_properties_defined.py
+++ b/src/faebryk/library/has_descriptive_properties_defined.py
@@ -5,6 +5,7 @@
 from typing import Mapping
 
 import faebryk.library._F as F
+from faebryk.core.module import Module
 from faebryk.core.node import Node
 from faebryk.core.trait import TraitImpl
 from faebryk.libs.picker.picker import DescriptiveProperties
@@ -31,3 +32,27 @@ class has_descriptive_properties_defined(F.has_descriptive_properties.impl()):
 
         old.properties.update(self.properties)
         return False
+
+    def on_obj_set(self):
+        super().on_obj_set()
+        obj = self.get_obj(type=Module)
+
+        # TODO: deprecate using DescriptiveProperties directly and then get rid of this
+        if (
+            DescriptiveProperties.partno in self.properties
+            and DescriptiveProperties.manufacturer in self.properties
+        ):
+            obj.add(
+                F.is_pickable_by_part_number(
+                    self.properties[DescriptiveProperties.manufacturer],
+                    self.properties[DescriptiveProperties.partno],
+                )
+            )
+
+        if "LCSC" in self.properties:
+            obj.add(
+                F.is_pickable_by_supplier_id(
+                    self.properties["LCSC"],
+                    supplier=F.is_pickable_by_supplier_id.Supplier.LCSC,
+                )
+            )

--- a/src/faebryk/library/has_explicit_part.py
+++ b/src/faebryk/library/has_explicit_part.py
@@ -44,25 +44,20 @@ class has_explicit_part(Module.TraitT.decless()):
 
     @override
     def on_obj_set(self):
-        # TODO later get rid oof this when we deprecate using DescriptiveProperties
-        # directly
-
-        from faebryk.libs.picker.picker import DescriptiveProperties
-
         super().on_obj_set()
         obj = self.get_obj(type=Module)
 
-        properties = {}
-
         if hasattr(self, "mfr"):
             assert self.partno
-            properties[DescriptiveProperties.manufacturer] = self.mfr
-            properties[DescriptiveProperties.partno] = self.partno
+            obj.add(F.is_pickable_by_part_number(self.mfr, self.partno))
         if hasattr(self, "supplier_partno"):
             assert self.supplier_id == "lcsc"
-            properties["LCSC"] = self.supplier_partno
+            obj.add(
+                F.is_pickable_by_supplier_id(
+                    self.supplier_partno,
+                    supplier=F.is_pickable_by_supplier_id.Supplier.LCSC,
+                )
+            )
 
         if self.pinmap:
             obj.add(F.can_attach_to_footprint_via_pinmap(self.pinmap))
-
-        obj.add(F.has_descriptive_properties_defined(properties))

--- a/src/faebryk/library/has_part_picked.py
+++ b/src/faebryk/library/has_part_picked.py
@@ -1,0 +1,34 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import logging
+from typing import TYPE_CHECKING
+
+from faebryk.core.module import Module
+from faebryk.libs.util import not_none
+
+if TYPE_CHECKING:
+    from faebryk.libs.picker.picker import Part
+
+logger = logging.getLogger(__name__)
+
+
+class has_part_picked(Module.TraitT.decless()):
+    def __init__(self, part: "Part | None") -> None:
+        """
+        None = remove part from netlist
+        """
+        super().__init__()
+        if type(self) is has_part_picked and part is None:
+            raise ValueError("Use has_part_picked.remove()")
+        self.part = part
+
+    def get_part(self) -> "Part":
+        return not_none(self.part)
+
+    def try_get_part(self) -> "Part | None":
+        return self.part
+
+    @property
+    def removed(self) -> bool:
+        return self.part is None

--- a/src/faebryk/library/has_part_removed.py
+++ b/src/faebryk/library/has_part_removed.py
@@ -1,0 +1,13 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import logging
+
+import faebryk.library._F as F
+
+logger = logging.getLogger(__name__)
+
+
+class has_part_removed(F.has_part_picked):
+    def __init__(self):
+        super().__init__(None)

--- a/src/faebryk/library/is_not_pickable.py
+++ b/src/faebryk/library/is_not_pickable.py
@@ -1,0 +1,15 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import logging
+
+from faebryk.core.module import Module
+
+logger = logging.getLogger(__name__)
+
+
+class is_not_pickable(Module.TraitT.decless()):
+    """
+    Mark module explicitly as not pickable.
+    e.g MountingHoles that have static footprint and no parameters.
+    """

--- a/src/faebryk/library/is_pickable.py
+++ b/src/faebryk/library/is_pickable.py
@@ -4,5 +4,5 @@
 from faebryk.core.module import Module
 
 
-class is_pickable(Module.TraitT.decless()):
+class is_pickable(Module.TraitT):
     pass

--- a/src/faebryk/library/is_pickable_by_part_number.py
+++ b/src/faebryk/library/is_pickable_by_part_number.py
@@ -1,0 +1,18 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import faebryk.library._F as F
+
+
+class is_pickable_by_part_number(F.is_pickable.decless()):
+    # TODO: make manufacturer an enum
+    def __init__(self, manufacturer: str, partno: str):
+        super().__init__()
+        self._manufacturer = manufacturer
+        self._partno = partno
+
+    def get_manufacturer(self) -> str:
+        return self._manufacturer
+
+    def get_partno(self) -> str:
+        return self._partno

--- a/src/faebryk/library/is_pickable_by_supplier_id.py
+++ b/src/faebryk/library/is_pickable_by_supplier_id.py
@@ -1,0 +1,22 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+from enum import Enum, auto
+
+import faebryk.library._F as F
+
+
+class is_pickable_by_supplier_id(F.is_pickable.decless()):
+    class Supplier(Enum):
+        LCSC = auto()
+
+    def __init__(self, supplier_part_id: str, supplier: Supplier = Supplier.LCSC):
+        super().__init__()
+        self._supplier_part_id = supplier_part_id
+        self._supplier = supplier
+
+    def get_supplier_part_id(self) -> str:
+        return self._supplier_part_id
+
+    def get_supplier(self) -> Supplier:
+        return self._supplier

--- a/src/faebryk/library/is_pickable_by_type.py
+++ b/src/faebryk/library/is_pickable_by_type.py
@@ -1,0 +1,25 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+from enum import Enum, auto
+
+import faebryk.library._F as F
+
+
+class is_pickable_by_type(F.is_pickable.decless()):
+    class Type(Enum):
+        Resistor = auto()
+        Capacitor = auto()
+        Inductor = auto()
+        TVS = auto()
+        LED = auto()
+        Diode = auto()
+        LDO = auto()
+        MOSFET = auto()
+
+    def __init__(self, pick_type: Type):
+        super().__init__()
+        self._pick_type = pick_type
+
+    def get_pick_type(self) -> Type:
+        return self._pick_type

--- a/src/faebryk/libs/app/erc.py
+++ b/src/faebryk/libs/app/erc.py
@@ -9,7 +9,6 @@ import faebryk.library._F as F
 from faebryk.core.graph import Graph, GraphFunctions
 from faebryk.core.module import Module
 from faebryk.core.moduleinterface import ModuleInterface
-from faebryk.libs.picker.picker import has_part_picked
 from faebryk.libs.units import P
 from faebryk.libs.util import groupby
 
@@ -128,8 +127,8 @@ def simple_erc(G: Graph, voltage_limit=1e5 * P.V):
         assert isinstance(comp, (F.Resistor, F.Capacitor, F.Fuse))
         # TODO make prettier
         if (
-            comp.has_trait(has_part_picked)
-            and comp.get_trait(has_part_picked).get_part().partno == "REMOVE"
+            comp.has_trait(F.has_part_picked)
+            and comp.get_trait(F.has_part_picked).removed
         ):
             continue
         if comp.unnamed[0].is_connected_to(comp.unnamed[1]):

--- a/src/faebryk/libs/app/picking.py
+++ b/src/faebryk/libs/app/picking.py
@@ -7,7 +7,6 @@ import faebryk.library._F as F
 from faebryk.core.graph import Graph, GraphFunctions
 from faebryk.exporters.pcb.kicad.pcb import NO_LCSC_DISPLAY
 from faebryk.exporters.pcb.kicad.transformer import PCB_Transformer
-from faebryk.libs.picker.picker import has_part_picked
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ def load_descriptive_properties(G: Graph):
     )
 
     for node, trait in nodes:
-        if node.has_trait(has_part_picked):
+        if node.has_trait(F.has_part_picked):
             continue
         if (
             node.has_trait(F.has_descriptive_properties)

--- a/src/faebryk/libs/picker/api/models.py
+++ b/src/faebryk/libs/picker/api/models.py
@@ -15,7 +15,7 @@ from faebryk.core.parameter import Parameter
 from faebryk.libs.exceptions import UserException, downgrade
 from faebryk.libs.picker.lcsc import LCSC_Part
 from faebryk.libs.picker.lcsc import attach as lcsc_attach
-from faebryk.libs.picker.picker import DescriptiveProperties, has_part_picked_defined
+from faebryk.libs.picker.picker import DescriptiveProperties
 from faebryk.libs.sets.sets import P_Set
 from faebryk.libs.util import Serializable, SerializableJSONEncoder
 
@@ -240,7 +240,7 @@ class Component:
             )
         )
 
-        module.add(has_part_picked_defined(LCSC_Part(self.lcsc_display)))
+        module.add(F.has_part_picked(LCSC_Part(self.lcsc_display)))
 
         for name, literal in self.attribute_literals.items():
             if not hasattr(module, name):

--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -30,7 +30,6 @@ from faebryk.libs.library.L import Range, RangeWithGaps, Single
 from faebryk.libs.picker.lcsc import LCSC_Part
 from faebryk.libs.picker.picker import (
     PickerOption,
-    has_part_picked,
     pick_module_by_params,
     pick_part_recursively,
 )
@@ -637,8 +636,8 @@ def test_simple_pick():
         ],
     )
 
-    assert led.has_trait(has_part_picked)
-    assert led.get_trait(has_part_picked).get_part().partno == "C72043"
+    assert led.has_trait(F.has_part_picked)
+    assert led.get_trait(F.has_part_picked).get_part().partno == "C72043"
 
 
 def test_simple_negative_pick():
@@ -673,8 +672,8 @@ def test_simple_negative_pick():
         ],
     )
 
-    assert led.has_trait(has_part_picked)
-    assert led.get_trait(has_part_picked).get_part().partno == "C72041"
+    assert led.has_trait(F.has_part_picked)
+    assert led.get_trait(F.has_part_picked).get_part().partno == "C72041"
 
 
 def test_jlcpcb_pick_resistor():
@@ -684,8 +683,8 @@ def test_jlcpcb_pick_resistor():
     solver = DefaultSolver()
     pick_part_recursively(resistor, solver)
 
-    assert resistor.has_trait(has_part_picked)
-    print(resistor.get_trait(has_part_picked).get_part())
+    assert resistor.has_trait(F.has_part_picked)
+    print(resistor.get_trait(F.has_part_picked).get_part())
 
 
 def test_jlcpcb_pick_capacitor():
@@ -696,8 +695,8 @@ def test_jlcpcb_pick_capacitor():
     solver = DefaultSolver()
     pick_part_recursively(capacitor, solver)
 
-    assert capacitor.has_trait(has_part_picked)
-    print(capacitor.get_trait(has_part_picked).get_part())
+    assert capacitor.has_trait(F.has_part_picked)
+    print(capacitor.get_trait(F.has_part_picked).get_part())
 
 
 def test_jlcpcb_pick_led():
@@ -708,8 +707,8 @@ def test_jlcpcb_pick_led():
     solver = DefaultSolver()
     pick_part_recursively(led, solver)
 
-    assert led.has_trait(has_part_picked)
-    print(led.get_trait(has_part_picked).get_part())
+    assert led.has_trait(F.has_part_picked)
+    print(led.get_trait(F.has_part_picked).get_part())
 
 
 @pytest.mark.xfail(reason="Need picker backtracking")
@@ -723,6 +722,6 @@ def test_jlcpcb_pick_powered_led():
 
     pick_part_recursively(led, solver)
 
-    picked_parts = [mod for mod in children_mods if mod.has_trait(has_part_picked)]
+    picked_parts = [mod for mod in children_mods if mod.has_trait(F.has_part_picked)]
     assert len(picked_parts) == 2
-    print([(p, p.get_trait(has_part_picked).get_part()) for p in picked_parts])
+    print([(p, p.get_trait(F.has_part_picked).get_part()) for p in picked_parts])

--- a/test/core/test_traits.py
+++ b/test/core/test_traits.py
@@ -209,3 +209,53 @@ def test_trait_impl_exception():
 
     t1 = obj.add(trait1impl())
     assert obj.get_trait(trait1impl) is t1
+
+
+def test_trait_decless_basic():
+    class T1(Trait.decless()):
+        def __init__(self, data: str) -> None:
+            super().__init__()
+            self.data = data
+
+    n = Node()
+    n.add(T1("test"))
+
+    assert n.has_trait(T1)
+    assert n.get_trait(T1).data == "test"
+
+
+def test_trait_decless_inherit():
+    class T1(Trait.decless()):
+        def __init__(self, data: str) -> None:
+            super().__init__()
+            self.data = data
+
+    class T2(T1):
+        def __init__(self, data: str, more_data: str) -> None:
+            super().__init__(data)
+            self.more_data = more_data
+
+    n = Node()
+    n.add(T2("test", "more"))
+
+    assert n.has_trait(T1)
+    assert n.get_trait(T1).data == "test"
+    assert n.has_trait(T2)
+    assert n.get_trait(T2).more_data == "more"
+
+
+def test_trait_decless_inherit_2():
+    class T1(Trait):
+        pass
+
+    class T2(T1.decless()):
+        def __init__(self, data: str) -> None:
+            super().__init__()
+            self.data = data
+
+    n = Node()
+    n.add(T2("test"))
+
+    assert n.has_trait(T1)
+    assert n.has_trait(T2)
+    assert n.get_trait(T2).data == "test"

--- a/test/front_end/test_front_end_pick.py
+++ b/test/front_end/test_front_end_pick.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+import faebryk.library._F as F
+from atopile.datatypes import Ref
+from atopile.front_end import Bob
+from atopile.parse import parse_text_as_file
+from faebryk.core.solver.defaultsolver import DefaultSolver
+from faebryk.libs.library import L
+from faebryk.libs.picker.picker import pick_part_recursively
+
+
+@pytest.fixture
+def bob() -> Bob:
+    return Bob()
+
+
+@pytest.fixture
+def repo_root() -> Path:
+    repo_root = Path(__file__)
+    while not (repo_root / "pyproject.toml").exists():
+        repo_root = repo_root.parent
+    return repo_root
+
+
+def test_ato_pick(bob: Bob, repo_root: Path):
+    bob.search_paths.append(repo_root / "examples" / ".ato" / "modules")
+
+    text = dedent(
+        """
+        from "generics/resistors.ato" import Resistor
+
+        component ResistorB from Resistor:
+            footprint = "R0805"
+
+        module A:
+            r1 = new ResistorB
+        """
+    )
+
+    tree = parse_text_as_file(text)
+    node = bob.build_ast(tree, Ref(["A"]))
+
+    assert isinstance(node, L.Module)
+
+    r1 = Bob.get_node_attr(node, "r1")
+    assert isinstance(r1, F.Resistor)
+    assert r1.get_trait(F.has_package_requirement).get_package_candidates() == ["0805"]
+
+    pick_part_recursively(r1, DefaultSolver())
+
+    assert r1.has_trait(F.has_part_picked)


### PR DESCRIPTION
- remove skip self pick (default behavior)
- `is_pickable` traits
- dont use descriptive properties anymore for picking
- test decless trait inheritance
- picker tests for non pick

