### PR TITLE
Add tools to override net names

### DIFF
--- a/src/atopile/_shim.py
+++ b/src/atopile/_shim.py
@@ -192,6 +192,9 @@ class GlobalShims(L.Module):
             "See: https://github.com/atopile/atopile/issues/755"
         )
 
+    def override_net_name(self, name: str):
+        self.add(F.has_net_name(name, level=F.has_net_name.Level.EXPECTED))
+
 
 def _handle_footprint_shim(module: L.Module, value: str):
     from atopile.front_end import DeprecatedException

--- a/src/faebryk/core/node.py
+++ b/src/faebryk/core/node.py
@@ -783,3 +783,26 @@ class Node(CNode):
         yield self.get_full_name()
 
     __rich_repr__.angular = True
+
+    def deepest_common_parent(self, *others: "Node") -> tuple["Node", str] | None:
+        """
+        Finds the deepest common parent of the given nodes, or None if no common
+        parent exists
+        """
+        nodes = [self, *others]
+        if not nodes:
+            return None
+
+        # Get hierarchies for all nodes
+        hierarchies = [list(n.get_hierarchy()) for n in nodes]
+        min_length = min(len(h) for h in hierarchies)
+
+        # Find the last matching ancestor
+        last_match = None
+        for i in range(min_length):
+            ref_node, ref_name = hierarchies[0][i]
+            if any(h[i][0] is not ref_node for h in hierarchies[1:]):
+                break
+            last_match = (ref_node, ref_name)
+
+        return last_match

--- a/src/faebryk/core/node.py
+++ b/src/faebryk/core/node.py
@@ -784,10 +784,10 @@ class Node(CNode):
 
     __rich_repr__.angular = True
 
-    def deepest_common_parent(self, *others: "Node") -> tuple["Node", str] | None:
+    def nearest_common_ancestor(self, *others: "Node") -> tuple["Node", str] | None:
         """
-        Finds the deepest common parent of the given nodes, or None if no common
-        parent exists
+        Finds the nearest common ancestor of the given nodes, or None if no common
+        ancestor exists
         """
         nodes = [self, *others]
         if not nodes:

--- a/src/faebryk/exporters/netlist/graph.py
+++ b/src/faebryk/exporters/netlist/graph.py
@@ -277,8 +277,11 @@ def generate_net_names(nets: list[F.Net]) -> None:
 
         names[net] = _NetName()
         if implicit_name_candidates:
+            # Type ignored on this because they typing on both max and defaultdict.get
+            # is poor. This is actually correct, and supposed to return None sometimes
             names[net].base_name = max(
-                implicit_name_candidates, key=implicit_name_candidates.get
+                implicit_name_candidates,
+                key=implicit_name_candidates.get,  # type: ignore
             )
 
     # Resolve as many conflict as possible by prefixing on the lowest common node's full name # noqa: E501  # pre-existing

--- a/src/faebryk/exporters/netlist/graph.py
+++ b/src/faebryk/exporters/netlist/graph.py
@@ -284,7 +284,7 @@ def generate_net_names(nets: list[F.Net]) -> None:
     # Resolve as many conflict as possible by prefixing on the lowest common node's full name # noqa: E501  # pre-existing
     for conflict_nets in _conflicts(names):
         for net in conflict_nets:
-            if lcn := L.Node.deepest_common_parent(*net.get_connected_interfaces()):
+            if lcn := L.Node.nearest_common_ancestor(*net.get_connected_interfaces()):
                 names[net].prefix = lcn[0].get_full_name()
 
     # Resolve remaining conflicts by suffixing on a number

--- a/src/faebryk/exporters/netlist/graph.py
+++ b/src/faebryk/exporters/netlist/graph.py
@@ -5,9 +5,10 @@ import logging
 from abc import abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Generator, Iterable
+from typing import Generator, Iterable, Mapping
 
 import faebryk.library._F as F
+from atopile.errors import UserException
 from faebryk.core.graph import Graph, GraphFunctions
 from faebryk.core.module import Module
 from faebryk.core.moduleinterface import ModuleInterface
@@ -176,47 +177,26 @@ class _NetName:
         )
 
 
-def _lowest_common_ancestor(nodes: Iterable[L.Node]) -> tuple[L.Node, str] | None:
-    """
-    Finds the deepest common ancestor of the given nodes.
-
-    Args:
-        nodes: Iterable of Node objects to find common ancestor for
-
-    Returns:
-        Tuple of (node, name) for the deepest common ancestor,
-        or None if no common ancestor exists
-    """
-    nodes = list(nodes)  # Convert iterable to list to ensure multiple iterations
-    if not nodes:
-        return None
-
-    # Get hierarchies for all nodes
-    hierarchies = [list(n.get_hierarchy()) for n in nodes]
-    min_length = min(len(h) for h in hierarchies)
-
-    # Find the last matching ancestor
-    last_match = None
-    for i in range(min_length):
-        ref_node, ref_name = hierarchies[0][i]
-        if any(h[i][0] is not ref_node for h in hierarchies[1:]):
-            break
-        last_match = (ref_node, ref_name)
-
-    return last_match
-
-
-def _conflicts(names: dict[F.Net, _NetName]) -> Generator[Iterable[F.Net], None, None]:
+def _conflicts(
+    names: Mapping[F.Net, _NetName],
+) -> Generator[Iterable[F.Net], None, None]:
     for items in groupby(names.items(), lambda it: it[1].name).values():
         if len(items) > 1:
             yield [net for net, _ in items]
 
 
-def _shit_name(name: str) -> bool:
+def _shit_name(name: str | None) -> bool:
+    if name is None:
+        return True
+
+    # By the time we're here, we have a bunch of pads with the name net attached
+    if name == "net":
+        return True
+
     if name in {"p1", "p2"}:
         return True
 
-    if "unnamed" in name:
+    if name.startswith("unnamed"):
         return True
 
     return False
@@ -228,7 +208,7 @@ def generate_net_names(nets: list[F.Net]) -> None:
     """
 
     # Ignore nets with names already
-    nets = filter(lambda n: not n.has_trait(F.has_overriden_name), nets)
+    unnamed_nets = [n for n in nets if not n.has_trait(F.has_overriden_name)]
 
     names = FuncDict[F.Net, _NetName]()
 
@@ -236,35 +216,75 @@ def generate_net_names(nets: list[F.Net]) -> None:
     def _decay(depth: int) -> float:
         return 1 / (depth + 1)
 
-    for net in nets:
-        name_candidates = defaultdict(float)
+    # FIXME: overriden names will be modified if multiple nets are in conflict
+    # FIXME: the errors for this deserve vast improvement. Attaching an origin trait
+    # to has_net_name is a start, but we need a generic way to raise those as
+    # well-formed errors
+    for net in unnamed_nets:
+        net_required_names: set[str] = set()
+        net_suggested_names: list[tuple[str, int]] = []
+        implicit_name_candidates: Mapping[str, float] = defaultdict(float)
+        case_insensitive_map: Mapping[str, str] = {}
+
         for mif in net.get_connected_interfaces():
+            # If there's net info, use it
+            depth = len(mif.get_hierarchy())
+
+            if t := mif.try_get_trait(F.has_net_name):
+                if t.level == F.has_net_name.Level.EXPECTED:
+                    net_required_names.add(t.name)
+                elif t.level == F.has_net_name.Level.SUGGESTED:
+                    net_suggested_names.append((t.name, len(mif.get_hierarchy())))
+                continue
+
+            # Rate implicit names
             # lower case so we are not case sensitive
             try:
-                name = mif.get_name().lower()
+                name = mif.get_name()
             except NodeNoParent:
                 # Skip no names
                 continue
 
-            if _shit_name(name):
+            lower_name = name.lower()
+            case_insensitive_map[lower_name] = name
+
+            if _shit_name(lower_name):
                 # Skip ranking shitty names
                 continue
 
-            depth = len(mif.get_hierarchy())
             if mif.get_parent_of_type(L.ModuleInterface):
                 # Give interfaces on the same level a fighting chance
                 depth -= 1
 
-            name_candidates[name] += _decay(depth)
+            implicit_name_candidates[case_insensitive_map[lower_name]] += _decay(depth)
+
+        # Check required names
+        if net_required_names:
+            if len(set(net_required_names)) > 1:
+                raise UserException(
+                    f"Multiple conflicting required net names: {net_required_names}"
+                )
+            net.add(F.has_overriden_name_defined(net_required_names.pop()))
+            continue
+
+        if net_suggested_names:
+            net.add(
+                F.has_overriden_name_defined(
+                    min(net_suggested_names, key=lambda x: x[1])[0]
+                )
+            )
+            continue
 
         names[net] = _NetName()
-        if name_candidates:
-            names[net].base_name = max(name_candidates, key=name_candidates.get)
+        if implicit_name_candidates:
+            names[net].base_name = max(
+                implicit_name_candidates, key=implicit_name_candidates.get
+            )
 
     # Resolve as many conflict as possible by prefixing on the lowest common node's full name # noqa: E501  # pre-existing
     for conflict_nets in _conflicts(names):
         for net in conflict_nets:
-            if lcn := _lowest_common_ancestor(net.get_connected_interfaces()):
+            if lcn := L.Node.deepest_common_parent(*net.get_connected_interfaces()):
                 names[net].prefix = lcn[0].get_full_name()
 
     # Resolve remaining conflicts by suffixing on a number
@@ -280,3 +300,5 @@ def generate_net_names(nets: list[F.Net]) -> None:
         else:
             name_str = name.name
         net.add(F.has_overriden_name_defined(name_str))
+
+    assert all(n.has_trait(F.has_overriden_name) for n in nets)

--- a/src/faebryk/exporters/pcb/kicad/pcb.py
+++ b/src/faebryk/exporters/pcb/kicad/pcb.py
@@ -296,6 +296,9 @@ class PCB:
             pcb.kicad_pcb.nets.append(pcb_net)
             pcb_nets[net_name] = (pcb_net, [])
         pcb.kicad_pcb.nets.sort(key=lambda x: x.number)
+        # Check that net numbers are unique
+        # FIXME: this is broken by conflicting net numbers on the loaded PCB
+        assert len(pcb.kicad_pcb.nets) == len(set(n.number for n in pcb.kicad_pcb.nets))
 
         # Components ===================================================================
         pcb_comps = {

--- a/src/faebryk/library/ElectricPower.py
+++ b/src/faebryk/library/ElectricPower.py
@@ -119,3 +119,6 @@ class ElectricPower(F.Power):
         self.bus_max_current_consumption_sum.add(
             F.is_bus_parameter(reduce=(self.max_current, Add))
         )
+
+        self.hv.add(F.has_net_name("vcc"))
+        self.lv.add(F.has_net_name("gnd"))

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -25,6 +25,7 @@ from faebryk.library.has_single_electric_reference import has_single_electric_re
 from faebryk.library.can_specialize_defined import can_specialize_defined
 from faebryk.library.Power import Power
 from faebryk.library.can_be_surge_protected import can_be_surge_protected
+from faebryk.library.has_net_name import has_net_name
 from faebryk.library.is_bus_parameter import is_bus_parameter
 from faebryk.library.is_optional_defined import is_optional_defined
 from faebryk.library.Signal import Signal

--- a/src/faebryk/library/has_net_name.py
+++ b/src/faebryk/library/has_net_name.py
@@ -1,168 +1,35 @@
-import math
-from collections import defaultdict
-from dataclasses import dataclass
-from enum import Enum, auto
-from typing import Generator, Iterable, Mapping
+from enum import IntEnum, auto
 
-import faebryk.library._F as F
-from faebryk.core.node import NodeNoParent
 from faebryk.core.trait import TraitImpl
 from faebryk.libs.library import L
-from faebryk.libs.util import FuncDict, groupby
 
 
 class has_net_name(L.Trait.decless()):
     """Provide a net name suggestion or expectation"""
 
-    class Level(Enum):
-        IMPLICIT = auto()
+    # TODO:
+    # Currently this is just a data-class, which is EXPECRTED to be used by
+    # src/faebryk/exporters/netlist/graph.py to compute the net names
+    # The intelligence of graph.py should be split and moved here
+
+    class Level(IntEnum):
         SUGGESTED = auto()
         EXPECTED = auto()
 
     def __init__(self, name: str, level: Level = Level.SUGGESTED):
-        self.names = [(name, level)]
+        super().__init__()
+        self.name = name
+        self.level = level
 
     @classmethod
-    def suggest_name(
-        cls, mif: L.ModuleInterface
-    ) -> list[tuple[str | None, float]]:
-        suggestions = []
+    def suggested(cls, name: str) -> "has_net_name":
+        return cls(name, cls.Level.SUGGESTED)
 
-        if t := mif.get_trait(cls):
-            for name, level in t.names:
-                if level == cls.Level.EXPECTED:
-                    suggestions.append((name, math.inf))
-                elif level == cls.Level.SUGGESTED:
-                    suggestions.append((name, 1))
-
-                try:
-                    name = mif.get_name()
-                except NodeNoParent:
-                    # Skip no names
-                    return [(None, 0)]
-
-                if _shit_name(name):
-                    return [(None, 0)]
-
-        return suggestions
+    @classmethod
+    def expected(cls, name: str) -> "has_net_name":
+        return cls(name, cls.Level.EXPECTED)
 
     def handle_duplicate(self, old: TraitImpl, node: L.Node) -> bool:
-        assert isinstance(old, has_net_name)  # Trait, not trait impl check
-        old.names.extend(self.names)
-        return False
-
-
-@dataclass
-class _NetName:
-    base_name: str | None = None
-    prefix: str | None = None
-    suffix: int | None = None
-
-    @property
-    def name(self) -> str:
-        """
-        Get the name of the net.
-        Net names should take the form of: <prefix>-<base_name>-<suffix>
-        There must always be some base, and if it's not provided, it's just 'net'
-        Prefixes and suffixes are joined with a "-" if they exist.
-        """
-        return "-".join(
-            str(n) for n in [self.prefix, self.base_name or "net", self.suffix] if n
-        )
-
-
-def _conflicts(
-    names: Mapping[F.Net, _NetName],
-) -> Generator[Iterable[F.Net], None, None]:
-    for items in groupby(names.items(), lambda it: it[1].name).values():
-        if len(items) > 1:
-            yield [net for net, _ in items]
-
-
-def _shit_name(name: str | None) -> bool:
-    """Caesar says 👎"""
-    if name is None:
-        return True
-
-    # By the time we're here, we have a bunch of pads with the name net attached
-    if name == "net":
-        return True
-
-    if name in {"p1", "p2"}:
-        return True
-
-    if name.startswith("unnamed"):
-        return True
-
-    return False
-
-
-def _decay(depth: int) -> float:
-    return 1 / (depth + 1)
-
-
-def generate_net_names(nets: list[F.Net]) -> None:
-    """
-    Generate good net names, assuming that we're passed all the nets in a design
-    """
-
-    # Ignore nets with names already
-    nets = [n for n in nets if not n.has_trait(F.has_overriden_name)]
-
-    names = FuncDict[F.Net, _NetName]()
-
-    # First generate candidate base names
-    for net in nets:
-        required_names: set[str] = set()
-
-        implicit_name_candidates: Mapping[str, float] = defaultdict(float)
-        case_insensitive_map: Mapping[str, str] = {}
-        net_mifs = net.get_connected_interfaces()
-        for mif in net_mifs:
-            # Rate implicit names
-            # lower case so we are not case sensitive
-            try:
-                name = mif.get_name()
-            except NodeNoParent:
-                # Skip no names
-                continue
-
-            lower_name = name.lower()
-            case_insensitive_map[lower_name] = name
-
-            if _shit_name(lower_name):
-                # Skip ranking shitty names
-                continue
-
-            depth = len(mif.get_hierarchy())
-            if mif.get_parent_of_type(L.ModuleInterface):
-                # Give interfaces on the same level a fighting chance
-                depth -= 1
-
-            implicit_name_candidates[case_insensitive_map[lower_name]] += _decay(depth)
-
-        names[net] = _NetName()
-        if implicit_name_candidates:
-            names[net].base_name = max(
-                implicit_name_candidates, key=implicit_name_candidates.get
-            )
-
-    # Resolve as many conflict as possible by prefixing on the lowest common node's full name # noqa: E501  # pre-existing
-    for conflict_nets in _conflicts(names):
-        for net in conflict_nets:
-            if lcn := L.Node.deepest_common_parent(net.get_connected_interfaces()):
-                names[net].prefix = lcn[0].get_full_name()
-
-    # Resolve remaining conflicts by suffixing on a number
-    for conflict_nets in _conflicts(names):
-        for i, net in enumerate(conflict_nets):
-            names[net].suffix = i
-
-    # Override the net names we've derived
-    for net, name in names.items():
-        # Limit name length to 255 chars
-        if len(name.name) > 255:
-            name_str = name.name[:200] + "..." + name.name[-50:]
-        else:
-            name_str = name.name
-        net.add(F.has_overriden_name_defined(name_str))
+        assert isinstance(old, has_net_name)  # Asserting trait, not impl
+        # FIXME: gracefully handle hitting this multiple times
+        return super().handle_duplicate(old, node)

--- a/src/faebryk/library/has_net_name.py
+++ b/src/faebryk/library/has_net_name.py
@@ -1,0 +1,168 @@
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Generator, Iterable, Mapping
+
+import faebryk.library._F as F
+from faebryk.core.node import NodeNoParent
+from faebryk.core.trait import TraitImpl
+from faebryk.libs.library import L
+from faebryk.libs.util import FuncDict, groupby
+
+
+class has_net_name(L.Trait.decless()):
+    """Provide a net name suggestion or expectation"""
+
+    class Level(Enum):
+        IMPLICIT = auto()
+        SUGGESTED = auto()
+        EXPECTED = auto()
+
+    def __init__(self, name: str, level: Level = Level.SUGGESTED):
+        self.names = [(name, level)]
+
+    @classmethod
+    def suggest_name(
+        cls, mif: L.ModuleInterface
+    ) -> list[tuple[str | None, float]]:
+        suggestions = []
+
+        if t := mif.get_trait(cls):
+            for name, level in t.names:
+                if level == cls.Level.EXPECTED:
+                    suggestions.append((name, math.inf))
+                elif level == cls.Level.SUGGESTED:
+                    suggestions.append((name, 1))
+
+                try:
+                    name = mif.get_name()
+                except NodeNoParent:
+                    # Skip no names
+                    return [(None, 0)]
+
+                if _shit_name(name):
+                    return [(None, 0)]
+
+        return suggestions
+
+    def handle_duplicate(self, old: TraitImpl, node: L.Node) -> bool:
+        assert isinstance(old, has_net_name)  # Trait, not trait impl check
+        old.names.extend(self.names)
+        return False
+
+
+@dataclass
+class _NetName:
+    base_name: str | None = None
+    prefix: str | None = None
+    suffix: int | None = None
+
+    @property
+    def name(self) -> str:
+        """
+        Get the name of the net.
+        Net names should take the form of: <prefix>-<base_name>-<suffix>
+        There must always be some base, and if it's not provided, it's just 'net'
+        Prefixes and suffixes are joined with a "-" if they exist.
+        """
+        return "-".join(
+            str(n) for n in [self.prefix, self.base_name or "net", self.suffix] if n
+        )
+
+
+def _conflicts(
+    names: Mapping[F.Net, _NetName],
+) -> Generator[Iterable[F.Net], None, None]:
+    for items in groupby(names.items(), lambda it: it[1].name).values():
+        if len(items) > 1:
+            yield [net for net, _ in items]
+
+
+def _shit_name(name: str | None) -> bool:
+    """Caesar says 👎"""
+    if name is None:
+        return True
+
+    # By the time we're here, we have a bunch of pads with the name net attached
+    if name == "net":
+        return True
+
+    if name in {"p1", "p2"}:
+        return True
+
+    if name.startswith("unnamed"):
+        return True
+
+    return False
+
+
+def _decay(depth: int) -> float:
+    return 1 / (depth + 1)
+
+
+def generate_net_names(nets: list[F.Net]) -> None:
+    """
+    Generate good net names, assuming that we're passed all the nets in a design
+    """
+
+    # Ignore nets with names already
+    nets = [n for n in nets if not n.has_trait(F.has_overriden_name)]
+
+    names = FuncDict[F.Net, _NetName]()
+
+    # First generate candidate base names
+    for net in nets:
+        required_names: set[str] = set()
+
+        implicit_name_candidates: Mapping[str, float] = defaultdict(float)
+        case_insensitive_map: Mapping[str, str] = {}
+        net_mifs = net.get_connected_interfaces()
+        for mif in net_mifs:
+            # Rate implicit names
+            # lower case so we are not case sensitive
+            try:
+                name = mif.get_name()
+            except NodeNoParent:
+                # Skip no names
+                continue
+
+            lower_name = name.lower()
+            case_insensitive_map[lower_name] = name
+
+            if _shit_name(lower_name):
+                # Skip ranking shitty names
+                continue
+
+            depth = len(mif.get_hierarchy())
+            if mif.get_parent_of_type(L.ModuleInterface):
+                # Give interfaces on the same level a fighting chance
+                depth -= 1
+
+            implicit_name_candidates[case_insensitive_map[lower_name]] += _decay(depth)
+
+        names[net] = _NetName()
+        if implicit_name_candidates:
+            names[net].base_name = max(
+                implicit_name_candidates, key=implicit_name_candidates.get
+            )
+
+    # Resolve as many conflict as possible by prefixing on the lowest common node's full name # noqa: E501  # pre-existing
+    for conflict_nets in _conflicts(names):
+        for net in conflict_nets:
+            if lcn := L.Node.deepest_common_parent(net.get_connected_interfaces()):
+                names[net].prefix = lcn[0].get_full_name()
+
+    # Resolve remaining conflicts by suffixing on a number
+    for conflict_nets in _conflicts(names):
+        for i, net in enumerate(conflict_nets):
+            names[net].suffix = i
+
+    # Override the net names we've derived
+    for net, name in names.items():
+        # Limit name length to 255 chars
+        if len(name.name) > 255:
+            name_str = name.name[:200] + "..." + name.name[-50:]
+        else:
+            name_str = name.name
+        net.add(F.has_overriden_name_defined(name_str))

--- a/test/core/test_node.py
+++ b/test/core/test_node.py
@@ -1,0 +1,66 @@
+from unittest.mock import Mock
+
+import pytest
+
+from faebryk.core.node import Node
+
+
+@pytest.fixture
+def node_hierarchy():
+    """Creates a mock node hierarchy for testing."""
+    root = Mock(spec=Node)
+    child1 = Mock(spec=Node)
+    child2 = Mock(spec=Node)
+    grandchild1 = Mock(spec=Node)
+    grandchild2 = Mock(spec=Node)
+
+    # Setup hierarchies
+    root.get_hierarchy = lambda: [(root, "root")]
+    child1.get_hierarchy = lambda: [(root, "root"), (child1, "child1")]
+    child2.get_hierarchy = lambda: [(root, "root"), (child2, "child2")]
+    grandchild1.get_hierarchy = lambda: [
+        (root, "root"),
+        (child1, "child1"),
+        (grandchild1, "grandchild1"),
+    ]
+    grandchild2.get_hierarchy = lambda: [
+        (root, "root"),
+        (child2, "child2"),
+        (grandchild2, "grandchild2"),
+    ]
+
+    return type(
+        "NodeHierarchy",
+        (),
+        {
+            "root": root,
+            "child1": child1,
+            "child2": child2,
+            "grandchild1": grandchild1,
+            "grandchild2": grandchild2,
+        },
+    )
+
+
+def test_deepest_common_parent_single_node(node_hierarchy):
+    result = Node.deepest_common_parent(node_hierarchy.child1)
+    assert result == (node_hierarchy.child1, "child1")
+
+
+def test_deepest_common_parent_common_parent(node_hierarchy):
+    result = Node.deepest_common_parent(node_hierarchy.child1, node_hierarchy.child2)
+    assert result == (node_hierarchy.root, "root")
+
+
+def test_deepest_common_parent_different_depths(node_hierarchy):
+    result = Node.deepest_common_parent(
+        node_hierarchy.grandchild1, node_hierarchy.child2
+    )
+    assert result == (node_hierarchy.root, "root")
+
+
+def test_deepest_common_parent_same_branch(node_hierarchy):
+    result = Node.deepest_common_parent(
+        node_hierarchy.grandchild1, node_hierarchy.child1
+    )
+    assert result == (node_hierarchy.child1, "child1")

--- a/test/core/test_node.py
+++ b/test/core/test_node.py
@@ -43,24 +43,24 @@ def node_hierarchy():
 
 
 def test_deepest_common_parent_single_node(node_hierarchy):
-    result = Node.deepest_common_parent(node_hierarchy.child1)
+    result = Node.nearest_common_ancestor(node_hierarchy.child1)
     assert result == (node_hierarchy.child1, "child1")
 
 
 def test_deepest_common_parent_common_parent(node_hierarchy):
-    result = Node.deepest_common_parent(node_hierarchy.child1, node_hierarchy.child2)
+    result = Node.nearest_common_ancestor(node_hierarchy.child1, node_hierarchy.child2)
     assert result == (node_hierarchy.root, "root")
 
 
 def test_deepest_common_parent_different_depths(node_hierarchy):
-    result = Node.deepest_common_parent(
+    result = Node.nearest_common_ancestor(
         node_hierarchy.grandchild1, node_hierarchy.child2
     )
     assert result == (node_hierarchy.root, "root")
 
 
 def test_deepest_common_parent_same_branch(node_hierarchy):
-    result = Node.deepest_common_parent(
+    result = Node.nearest_common_ancestor(
         node_hierarchy.grandchild1, node_hierarchy.child1
     )
     assert result == (node_hierarchy.child1, "child1")

--- a/test/exporters/netlist/test_graph.py
+++ b/test/exporters/netlist/test_graph.py
@@ -5,7 +5,6 @@ import pytest
 from faebryk.core.node import Node
 from faebryk.exporters.netlist.graph import (
     _conflicts,
-    _lowest_common_ancestor,
     _NetName,
 )
 from faebryk.library import Net as F
@@ -62,34 +61,6 @@ def node_hierarchy():
             "grandchild2": grandchild2,
         },
     )
-
-
-def test_lowest_common_ancestor_empty():
-    assert _lowest_common_ancestor([]) is None
-
-
-def test_lowest_common_ancestor_single_node(node_hierarchy):
-    result = _lowest_common_ancestor([node_hierarchy.child1])
-    assert result == (node_hierarchy.child1, "child1")
-
-
-def test_lowest_common_ancestor_common_parent(node_hierarchy):
-    result = _lowest_common_ancestor([node_hierarchy.child1, node_hierarchy.child2])
-    assert result == (node_hierarchy.root, "root")
-
-
-def test_lowest_common_ancestor_different_depths(node_hierarchy):
-    result = _lowest_common_ancestor(
-        [node_hierarchy.grandchild1, node_hierarchy.child2]
-    )
-    assert result == (node_hierarchy.root, "root")
-
-
-def test_lowest_common_ancestor_same_branch(node_hierarchy):
-    result = _lowest_common_ancestor(
-        [node_hierarchy.grandchild1, node_hierarchy.child1]
-    )
-    assert result == (node_hierarchy.child1, "child1")
 
 
 @pytest.fixture


### PR DESCRIPTION
These tools are implemented in `v0.2` via the `.override_net_name` attr

Additionally, it adds the "suggested" net name as requested @napowderly 