### PR TITLE
Fix PyPI publish failure due to missing `pyproject.toml`

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -101,10 +101,6 @@ jobs:
       attestations: write
 
     steps:
-    - uses: actions/setup-python@v5
-      with:
-        python-version-file: 'pyproject.toml'
-
     - uses: actions/download-artifact@v4
       with:
         pattern: cibw-*


### PR DESCRIPTION
Failure seen in: https://github.com/atopile/atopile/actions/runs/12564201707/job/35027048579

Fixes spurious dependency on repository contents introduced in #616. Python doesn't seem to be required by any subsequent steps.