### PR TITLE
Fix website deployment workflow missing `mkdocstrings` plugin

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -10,19 +10,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.x
+          python-version-file: 'pyproject.toml'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: '0.5.5'
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+
       - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+
+      - run: uv run --dev mkdocs gh-deploy --force


### PR DESCRIPTION
Fixes:
```
> Run mkdocs gh-deploy --force
ERROR   -  Config value 'plugins': The "mkdocstrings" plugin is not installed

Aborted with a configuration error!
```