### PR TITLE
fix: standardize quantity operator precedence

### DIFF
--- a/src/faebryk/libs/sets/quantity_sets.py
+++ b/src/faebryk/libs/sets/quantity_sets.py
@@ -591,8 +591,6 @@ class Quantity_Interval_Disjoint(Quantity_Set):
             return Quantity_Interval_Disjoint(other)
         if isinstance(other, (int, float)):
             return Quantity_Set_Discrete(quantity(other))
-        if isinstance(other, ParameterOperatable):
-            raise NotImplementedError(f"unsupported type: {type(other)}")
         raise ValueError(f"unsupported type: {type(other)}")
 
     @staticmethod
@@ -603,11 +601,12 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         for o in obj[1:]:
             intersected = intersected & Quantity_Interval_Disjoint.from_value(o)
         return intersected
-    
+
     @staticmethod
     def _check_parameter_operable(other: Any) -> bool:
         # Local import to avoid circular dependency
         from faebryk.core.parameter import ParameterOperatable
+
         return isinstance(other, ParameterOperatable)
 
     def __eq__(self, value: Any) -> bool:

--- a/src/faebryk/libs/sets/quantity_sets.py
+++ b/src/faebryk/libs/sets/quantity_sets.py
@@ -591,6 +591,8 @@ class Quantity_Interval_Disjoint(Quantity_Set):
             return Quantity_Interval_Disjoint(other)
         if isinstance(other, (int, float)):
             return Quantity_Set_Discrete(quantity(other))
+        if isinstance(other, ParameterOperatable):
+            raise NotImplementedError(f"unsupported type: {type(other)}")
         raise ValueError(f"unsupported type: {type(other)}")
 
     @staticmethod
@@ -601,6 +603,12 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         for o in obj[1:]:
             intersected = intersected & Quantity_Interval_Disjoint.from_value(o)
         return intersected
+    
+    @staticmethod
+    def _check_parameter_operable(other: Any) -> bool:
+        # Local import to avoid circular dependency
+        from faebryk.core.parameter import ParameterOperatable
+        return isinstance(other, ParameterOperatable)
 
     def __eq__(self, value: Any) -> bool:
         if value is None:
@@ -611,12 +619,16 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self._intervals == value_q._intervals
 
     def __add__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
+        if self._check_parameter_operable(other):
+            return NotImplemented
         return self.op_add_intervals(Quantity_Interval_Disjoint.from_value(other))
 
     def __radd__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         return self + other
 
     def __sub__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
+        if self._check_parameter_operable(other):
+            return NotImplemented
         return self.op_subtract_intervals(Quantity_Interval_Disjoint.from_value(other))
 
     def __rsub__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
@@ -626,12 +638,16 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self.op_negate()
 
     def __mul__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
+        if self._check_parameter_operable(other):
+            return NotImplemented
         return self.op_mul_intervals(Quantity_Interval_Disjoint.from_value(other))
 
     def __rmul__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         return self * other
 
     def __truediv__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
+        if self._check_parameter_operable(other):
+            return NotImplemented
         return self.op_div_intervals(Quantity_Interval_Disjoint.from_value(other))
 
     def __rtruediv__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
@@ -644,12 +660,16 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self.op_intersect_intervals(Quantity_Interval_Disjoint.from_value(other))
 
     def __rand__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
+        if self._check_parameter_operable(other):
+            return NotImplemented
         return Quantity_Interval_Disjoint.from_value(other) & self
 
     def __or__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         return self.op_union_intervals(Quantity_Interval_Disjoint.from_value(other))
 
     def __ror__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
+        if self._check_parameter_operable(other):
+            return NotImplemented
         return Quantity_Interval_Disjoint.from_value(other) | self
 
     def __ge__(self, other: QuantitySetLike) -> BoolSet:

--- a/src/faebryk/libs/sets/quantity_sets.py
+++ b/src/faebryk/libs/sets/quantity_sets.py
@@ -602,13 +602,6 @@ class Quantity_Interval_Disjoint(Quantity_Set):
             intersected = intersected & Quantity_Interval_Disjoint.from_value(o)
         return intersected
 
-    @staticmethod
-    def _check_parameter_operable(other: Any) -> bool:
-        # Local import to avoid circular dependency
-        from faebryk.core.parameter import ParameterOperatable
-
-        return isinstance(other, ParameterOperatable)
-
     def __eq__(self, value: Any) -> bool:
         if value is None:
             return False
@@ -618,17 +611,21 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self._intervals == value_q._intervals
 
     def __add__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        if self._check_parameter_operable(other):
+        try:
+            other_qty = Quantity_Interval_Disjoint.from_value(other)
+        except ValueError:
             return NotImplemented
-        return self.op_add_intervals(Quantity_Interval_Disjoint.from_value(other))
+        return self.op_add_intervals(other_qty)
 
     def __radd__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         return self + other
 
     def __sub__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        if self._check_parameter_operable(other):
+        try:
+            other_qty = Quantity_Interval_Disjoint.from_value(other)
+        except ValueError:
             return NotImplemented
-        return self.op_subtract_intervals(Quantity_Interval_Disjoint.from_value(other))
+        return self.op_subtract_intervals(other_qty)
 
     def __rsub__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         return -self + other
@@ -637,17 +634,21 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self.op_negate()
 
     def __mul__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        if self._check_parameter_operable(other):
+        try:
+            other_qty = Quantity_Interval_Disjoint.from_value(other)
+        except ValueError:
             return NotImplemented
-        return self.op_mul_intervals(Quantity_Interval_Disjoint.from_value(other))
+        return self.op_mul_intervals(other_qty)
 
     def __rmul__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         return self * other
 
     def __truediv__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        if self._check_parameter_operable(other):
+        try:
+            other_qty = Quantity_Interval_Disjoint.from_value(other)
+        except ValueError:
             return NotImplemented
-        return self.op_div_intervals(Quantity_Interval_Disjoint.from_value(other))
+        return self.op_div_intervals(other_qty)
 
     def __rtruediv__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         return self.op_invert() * Quantity_Interval_Disjoint.from_value(other)
@@ -656,20 +657,24 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self.op_pow_intervals(Quantity_Interval_Disjoint.from_value(other))
 
     def __and__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        return self.op_intersect_intervals(Quantity_Interval_Disjoint.from_value(other))
+        try:
+            other_qty = Quantity_Interval_Disjoint.from_value(other)
+        except ValueError:
+            return NotImplemented
+        return self.op_intersect_intervals(other_qty)
 
     def __rand__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        if self._check_parameter_operable(other):
-            return NotImplemented
-        return Quantity_Interval_Disjoint.from_value(other) & self
+        return self & other
 
     def __or__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        return self.op_union_intervals(Quantity_Interval_Disjoint.from_value(other))
+        try:
+            other_qty = Quantity_Interval_Disjoint.from_value(other)
+        except ValueError:
+            return NotImplemented
+        return self.op_union_intervals(other_qty)
 
     def __ror__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        if self._check_parameter_operable(other):
-            return NotImplemented
-        return Quantity_Interval_Disjoint.from_value(other) | self
+        return self | other
 
     def __ge__(self, other: QuantitySetLike) -> BoolSet:
         other_q = Quantity_Interval_Disjoint.from_value(other)

--- a/src/faebryk/libs/sets/quantity_sets.py
+++ b/src/faebryk/libs/sets/quantity_sets.py
@@ -664,7 +664,7 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self.op_intersect_intervals(other_qty)
 
     def __rand__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        return self & other
+        return Quantity_Interval_Disjoint.from_value(other) & self
 
     def __or__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
         try:
@@ -674,7 +674,7 @@ class Quantity_Interval_Disjoint(Quantity_Set):
         return self.op_union_intervals(other_qty)
 
     def __ror__(self, other: QuantitySetLike) -> "Quantity_Interval_Disjoint":
-        return self | other
+        return Quantity_Interval_Disjoint.from_value(other) | self
 
     def __ge__(self, other: QuantitySetLike) -> BoolSet:
         other_q = Quantity_Interval_Disjoint.from_value(other)

--- a/uv.lock
+++ b/uv.lock
@@ -108,7 +108,7 @@ wheels = [
 
 [[package]]
 name = "atopile"
-version = "0.3.1.dev93+g105d402a.d20241224"
+version = "0.3.6.dev1+gf5b6e475.d20250104"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },

--- a/uv.lock
+++ b/uv.lock
@@ -108,7 +108,7 @@ wheels = [
 
 [[package]]
 name = "atopile"
-version = "0.3.6.dev1+gf5b6e475.d20250104"
+version = "0.3.1.dev93+g105d402a.d20241224"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
- Ensure consistent behavior between __mul__ and __rmul__
- Add ParameterOperatable checks to all operator methods
- Create helper method for parameter operability checks
- Maintain type safety while allowing operator fallback

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
