### PR TITLE
Use packaged `atopile-easyeda2kicad`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,12 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    # Faebryk minimal dependencies
     "numpy>=2.2.0,<3.0.0",
     "matplotlib>=3.7.1,<4.0.0",
     "sexpdata>=1.0.2,<2.0.0",
     "black>=24.4.2,<24.11.0",
     "typing-extensions>=4.6.3,<5.0.0",
-    "easyeda2kicad @ git+https://github.com/atopile/easyeda2kicad.py.git",
+    "atopile-easyeda2kicad>=0.9.0",
     "shapely>=2.0.1,<3.0.0",
     "freetype-py>=2.4,<2.6",
     "kicadcliwrapper>=1.0.0,<2.0.0",


### PR DESCRIPTION
Use packaged `atopile-easyeda2kicad` instead of repo install, so we can deploy atopile to pypi