### PR TITLE
Stabilise version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,13 @@ artifacts = ["**/viewer/dist"]
 [tool.hatch.version]
 source = "vcs"
 
+[tool.hatch.version.raw-options]
+# Passed through to setuptools-scm
+# See: https://setuptools-scm.readthedocs.io/en/latest/config/
+# https://setuptools-scm.readthedocs.io/en/latest/extending/
+version_scheme = "only-version"
+local_scheme = "no-local-version"
+
 [tool.isort]
 profile = "black"
 known_third_party = []


### PR DESCRIPTION
Now the version string is just `major.minor.patch`/`.dev0`

This helps us with `uv` lock stability, but without auto-incrementing the `.dev` distance, auto-deployments to test pypi won't go as often as I'd like