### PR TITLE
Fix footprint 3D file path

### DIFF
--- a/src/atopile/cli/build.py
+++ b/src/atopile/cli/build.py
@@ -92,7 +92,7 @@ def build(
                 lcsc.BUILD_FOLDER = build_ctx.paths.build
                 lcsc.LIB_FOLDER = build_ctx.paths.component_lib
                 lcsc.LIB_FOLDER.mkdir(exist_ok=True, parents=True)
-                # lcsc.MODEL_PATH = None  # TODO: assign to something to download the 3d models # noqa: E501  # pre-existing
+                lcsc.KICAD_PROJECT_PATH = build_ctx.paths.kicad_project.parent
 
                 # TODO: add a mechanism to override the following with custom build machinery # noqa: E501  # pre-existing
                 buildutil.build(build_ctx, app)

--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -34,6 +34,7 @@ CRAWL_DATASHEET = ConfigFlag(
 # TODO dont hardcode relative paths
 BUILD_FOLDER = Path("./build")
 LIB_FOLDER = Path("./src/kicad/libs")
+KICAD_PROJECT_PATH: Path | None = None
 MODEL_PATH: str | None = None
 
 EXPORT_NON_EXISTING_MODELS = False
@@ -172,6 +173,11 @@ def download_easyeda_info(lcsc_id: str, get_model: bool = True):
         kicad_model_path = (
             f"{MODEL_PATH}/3dmodels/lcsc.3dshapes"
             if MODEL_PATH
+            else str(
+                "${KIPRJMOD}"
+                / model_base_path_full.relative_to(KICAD_PROJECT_PATH, walk_up=True)
+            )
+            if KICAD_PROJECT_PATH
             else str(model_base_path_full.resolve())
         )
         ki_footprint.export(

--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -34,7 +34,7 @@ CRAWL_DATASHEET = ConfigFlag(
 # TODO dont hardcode relative paths
 BUILD_FOLDER = Path("./build")
 LIB_FOLDER = Path("./src/kicad/libs")
-MODEL_PATH: str | None = "${KIPRJMOD}/../libs/"
+MODEL_PATH: str | None = None
 
 EXPORT_NON_EXISTING_MODELS = False
 


### PR DESCRIPTION
# Fix footprint 3D file path

## Description

This works for now, but as stated in the [TODO](https://github.com/atopile/atopile/blob/a0a8acc6358c0ff7629fa581248b0fdbd4bd8f0e/src/atopile/cli/build.py#L91), should use buildcontext instead.

Fixes #712 

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
