### PR TITLE
fix net numbering and pad rotations

### DIFF
--- a/src/faebryk/exporters/pcb/kicad/pcb.py
+++ b/src/faebryk/exporters/pcb/kicad/pcb.py
@@ -286,11 +286,11 @@ class PCB:
         # Add new nets -----------------------------------------------------------------
         logger.debug(f"New nets: {nets_added}")
         existing_net_numbers = {net.number for net in pcb.kicad_pcb.nets}
+        net_numbers = iter(yield_missing(existing_net_numbers))
 
         for net_name in nets_added:
             # Find the first unused net number
-            net_number = next(yield_missing(existing_net_numbers))
-            existing_net_numbers.add(net_number)
+            net_number = next(net_numbers)
 
             pcb_net = C_kicad_pcb_file.C_kicad_pcb.C_net(
                 name=net_name,

--- a/src/faebryk/exporters/pcb/kicad/pcb.py
+++ b/src/faebryk/exporters/pcb/kicad/pcb.py
@@ -30,6 +30,7 @@ from faebryk.libs.util import (
     find,
     find_or,
     not_none,
+    yield_missing,
 )
 
 logger = logging.getLogger(__name__)
@@ -288,11 +289,7 @@ class PCB:
 
         for net_name in nets_added:
             # Find the first unused net number
-            net_number = next(
-                i
-                for i in range(len(existing_net_numbers) + len(nets_added))
-                if i not in existing_net_numbers
-            )
+            net_number = next(yield_missing(existing_net_numbers))
             existing_net_numbers.add(net_number)
 
             pcb_net = C_kicad_pcb_file.C_kicad_pcb.C_net(
@@ -437,18 +434,13 @@ class PCB:
                             )
                             if p.name in pads
                             else None,
-                            # rest of fields
-                            # **dataclass_as_kwargs(p),
                             **{
-                                k: v
-                                for k, v in dataclass_as_kwargs(p).items()
-                                if k != "at"
+                                **dataclass_as_kwargs(p),
+                                "at": C_xyr(x=p.at.x, y=p.at.y, r=p.at.r + at.r),
                             },
-                            at=C_xyr(x=p.at.x, y=p.at.y, r=p.at.r + at.r),
                         )
                         for p in footprint.pads
                     ],
-                    #
                     name=footprint_identifier,
                     layer=footprint.layer,
                     propertys=footprint.propertys,

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -33,6 +33,7 @@ from typing import (
     Any,
     Callable,
     Concatenate,
+    Container,
     Generator,
     Hashable,
     Iterable,
@@ -1811,6 +1812,14 @@ def robustly_rm_dir(path: os.PathLike) -> None:
         func(path)
 
     shutil.rmtree(path, onexc=remove_readonly)
+
+
+def yield_missing(existing: Container, candidates: Iterable | None = None):
+    if candidates is None:
+        candidates = range(10000)  # Prevent counting to infinity by default
+    for c in candidates:
+        if c not in existing:
+            yield c
 
 
 def try_relative_to(

--- a/test/libs/util/test_yield_missing.py
+++ b/test/libs/util/test_yield_missing.py
@@ -1,0 +1,29 @@
+import pytest
+
+from faebryk.libs.util import yield_missing
+
+
+def test_basic():
+    existing = {1, 2, 3}
+    candidates = [1, 2, 3, 4, 5]
+    assert list(yield_missing(existing, candidates)) == [4, 5]
+
+
+def test_no_candidates():
+    existing = {0, 1, 3}
+    missing = iter(yield_missing(existing))
+    assert next(missing) == 2
+    assert next(missing) == 4
+    assert next(missing) == 5
+    assert next(missing) == 6
+
+
+def test_max_range():
+    existing = {1, 2, 3}
+    missing = iter(yield_missing(existing, range(7)))
+    assert next(missing) == 0
+    assert next(missing) == 4
+    assert next(missing) == 5
+    assert next(missing) == 6
+    with pytest.raises(StopIteration):
+        next(missing)


### PR DESCRIPTION
# Fix: Net numbering and pad rotations

# Description
Pads were not having rotation re-applied when reloaded by ato
Net re-numbering will now find next available number, avoiding duplicates.

Fixes # (issue)

# Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
