### PR TITLE
Drop `pytest-asyncio` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ dev = [
     "nanobind>=2.2,<3.0",
     "pre-commit>=2.20,<4.0",
     "pyinstrument~=4.7.1",
-    "pytest-asyncio!=0.23.3",
     "pytest-datafiles",
     "pytest-html",
     "pytest-xdist~=3.6.1",
@@ -153,8 +152,6 @@ addopts = [
 ]
 filterwarnings = ["ignore:.*:DeprecationWarning"]
 testpaths = ["test"]
-asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
 log_file_format = "%(asctime)s %(levelname)s %(name)s %(message)s"
 # log_file_level = "DEBUG"  # <-- you can set this in a PR if you want to debug tests in CI
 markers = [

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pyinstrument" },
     { name = "pytest" },
-    { name = "pytest-asyncio" },
     { name = "pytest-benchmark" },
     { name = "pytest-datafiles" },
     { name = "pytest-history" },
@@ -255,7 +254,6 @@ dev = [
     { name = "pre-commit", specifier = ">=2.20,<4.0" },
     { name = "pyinstrument", specifier = "~=4.7.1" },
     { name = "pytest", specifier = ">=7.1.3,<9.0.0" },
-    { name = "pytest-asyncio", specifier = "!=0.23.3" },
     { name = "pytest-benchmark", specifier = ">=5.1.0,<6.0.0" },
     { name = "pytest-datafiles" },
     { name = "pytest-history", git = "https://github.com/atopile/pytest-history.git" },
@@ -415,7 +413,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -1362,7 +1360,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -1999,18 +1997,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/05/35/30e0d83068951d90a01852cb1cef56e5d8a09d20c7f511634cc2f7e0372a/pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761", size = 1445919 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/92/76a1c94d3afee238333bc0a42b82935dd8f9cf8ce9e336ff87ee14d9e1cf/pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6", size = 343083 },
-]
-
-[[package]]
-name = "pytest-asyncio"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/94/18/82fcb4ee47d66d99f6cd1efc0b11b2a25029f303c599a5afda7c1bca4254/pytest_asyncio-0.25.0.tar.gz", hash = "sha256:8c0610303c9e0442a5db8604505fc0f545456ba1528824842b37b4a626cbf609", size = 53298 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/56/2ee0cab25c11d4e38738a2a98c645a8f002e2ecf7b5ed774c70d53b92bb1/pytest_asyncio-0.25.0-py3-none-any.whl", hash = "sha256:db5432d18eac6b7e28b46dcd9b69921b55c3b1086e85febfe04e70b18d9e81b3", size = 19245 },
 ]
 
 [[package]]


### PR DESCRIPTION
No longer being used and Interferes with IDE type inference.