### PR TITLE
Update test_regressions.py

### DIFF
--- a/test/test_regressions.py
+++ b/test/test_regressions.py
@@ -23,9 +23,6 @@ class BuildError(Exception):
     """Failed to build the project."""
 
 
-@pytest.mark.xfail(
-    reason="Projects require update to use the latest version of atopile"
-)
 @pytest.mark.slow
 @pytest.mark.regression
 @pytest.mark.parametrize(


### PR DESCRIPTION
Regressions are marked XFail, which might be causing pytest to report failures as skips.

XFail is nolonger required as regressions and examples have been split into separate workflows and project regressions are triggered manually.