### PR TITLE
Remove slow marking from examples

### DIFF
--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -18,7 +18,6 @@ ATO_EXAMPLES = [p for p in EXAMPLES_DIR.glob("*.ato") if p.is_file()]
 
 
 # FIXME: Test ato examples too
-@pytest.mark.slow
 @pytest.mark.parametrize(
     "example",
     FABLL_EXAMPLES,


### PR DESCRIPTION
Marking examples as slow prevented them from running in CI

