### PR TITLE
Add credentials env variables for pytest history db reporting

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -43,6 +43,9 @@ jobs:
         -m "not not_in_ci and not slow and not regression"
         --timeout=300
       env:
+        GH_TOKEN: ${{ github.token }}
+        PYTEST_HISTORY_EMAIL: ${{ vars.PYTEST_HISTORY_EMAIL }}
+        PYTEST_HISTORY_PASSWORD: ${{ secrets.PYTEST_HISTORY_PASSWORD }}
         COLUMNS: 150  # rich console width will be pulled from this
 
     - name: Upload all test logs


### PR DESCRIPTION
Pytest is not reporting as the email and password is missing from the enviroment variables, copying from regressions.yml where this is working.
