### PR TITLE
Remove cleanup from PCB transformer and buildutil

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -88,7 +88,7 @@ def build(app: Module) -> None:
 
     # Load PCB / cached --------------------------------------------------------
     pcb = C_kicad_pcb_file.loads(config.build.paths.layout)
-    transformer = PCB_Transformer(pcb.kicad_pcb, G, app, cleanup=False)
+    transformer = PCB_Transformer(pcb.kicad_pcb, G, app)
     load_designators(G, attach=True)
 
     # Pre-run solver -----------------------------------------------------------
@@ -127,9 +127,6 @@ def build(app: Module) -> None:
     # Update PCB --------------------------------------------------------------
     logger.info("Updating PCB")
     original_pcb = deepcopy(pcb)
-    # We have to cleanup before applying the design, because otherwise we'll
-    # delete the things we're adding
-    transformer.cleanup()
     transformer.apply_design(config.build.paths.fp_lib_table)
     transformer.check_unattached_fps()
 


### PR DESCRIPTION
It was causing cycles where it'd remove something from the pcb's "footprints" list, but it'd still be linked via a trait. This means it wouldn't be output on rebuild, then it'd be re-added on the next run. This caused cycling where components wouldn't appear every second run under some circumstances

Fixes: #846