### PR TITLE
Feature: Add formatting of user visible json files

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -307,7 +307,7 @@ def generate_manifest(app: Module) -> None:
             manifest_path = config.project.paths.manifest
             manifest_path.parent.mkdir(exist_ok=True, parents=True)
             with open(manifest_path, "w", encoding="utf-8") as f:
-                json.dump(manifest, f)
+                json.dump(manifest, f, indent=4)
 
 
 @muster.register("layout-module-map")

--- a/src/atopile/cli/cli.py
+++ b/src/atopile/cli/cli.py
@@ -114,7 +114,7 @@ def export_config_schema(pretty: bool = False):
     config_schema = ProjectConfig.model_json_schema()
 
     if pretty:
-        print(json.dumps(config_schema, indent=2))
+        print(json.dumps(config_schema, indent=4))
     else:
         print(json.dumps(config_schema))
 
@@ -124,7 +124,7 @@ def dump_config(pretty: bool = False):
     from rich import print
 
     if pretty:
-        print(json.dumps(config.project, indent=2))
+        print(json.dumps(config.project, indent=4))
     else:
         print(json.dumps(config.project))
 

--- a/src/atopile/layout.py
+++ b/src/atopile/layout.py
@@ -137,4 +137,4 @@ def generate_module_map(app: Module) -> None:
         "w",
         encoding="utf-8",
     ) as f:
-        json.dump(module_map, f)
+        json.dump(module_map, f, indent=4)


### PR DESCRIPTION
# Feature: Add formatting of user visible json files

Add 4 space indentation as used in python (PEP8) for consistency. 
This make the json files human readable

**_Note: idk if you want to format all json files, and if they all should be 4 space indentation_**

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
