### PR TITLE
Update `ato install`

### DIFF
--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -232,7 +232,7 @@ def project(
 
     # Install dependencies listed in the ato.yaml, typically just generics
     do_install(
-        to_install=None,
+        to_install="generics",
         link=True,
         upgrade=True,
         path=Path(repo_obj.working_tree_dir),

--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -32,13 +32,13 @@ def install(
     jlcpcb: Annotated[
         bool, typer.Option("--jlcpcb", "-j", help="JLCPCB component ID", hidden=True)
     ] = False,
-    link: Annotated[
+    vendor: Annotated[
         bool,
         typer.Option(
-            "--link/--vendor",
-            help="Keep this dependency linked to the source or vendor it",
+            "--vendor",
+            help="Copy the contents of this dependency into the repo",
         ),
-    ] = True,
+    ] = False,
     upgrade: Annotated[
         bool, typer.Option("--upgrade", "-u", help="Upgrade dependencies")
     ] = False,
@@ -54,7 +54,7 @@ def install(
 
     config.apply_options(None)
 
-    do_install(to_install, link, upgrade, path)
+    do_install(to_install, not vendor, upgrade, path)
 
 
 def do_install(

--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -18,7 +18,7 @@ from git import GitCommandError, InvalidGitRepositoryError, NoSuchPathError, Rep
 
 import faebryk.libs.exceptions
 from atopile import errors, version
-from atopile.config import Dependency, config
+from atopile.config import Dependency, ProjectConfig, config
 from faebryk.libs.util import robustly_rm_dir
 
 yaml = ruamel.yaml.YAML()
@@ -154,8 +154,14 @@ def install_single_dependency(to_install: str, link: bool, upgrade: bool):
         dependency.version_spec = f"@{installed_version}"
 
     def add_dependency(config_data, new_data):
-        if config_data.get("dependencies") is None:
-            config_data["dependencies"] = []
+        config_data["dependencies"] = [
+            dep.model_dump()
+            # add_dependencies is the field validator that loads the dependencies
+            # from the config file. It ensures the format of the ato.yaml
+            for dep in ProjectConfig.add_dependencies(
+                config_data.get("dependencies"),
+            )  # type: ignore  add_dependencies is a classmethod
+        ]
 
         for i, dep in enumerate(config_data["dependencies"]):
             if not isinstance(dep, dict):

--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -54,12 +54,12 @@ def install(
 
     config.apply_options(None)
 
-    do_install(to_install, not vendor, upgrade, path)
+    do_install(to_install, vendor, upgrade, path)
 
 
 def do_install(
     to_install: str | None,
-    link: bool,
+    vendor: bool,
     upgrade: bool,
     path: Path | None,
 ):
@@ -78,7 +78,7 @@ def do_install(
 
     if to_install:
         # eg. "ato install some-atopile-module"
-        install_single_dependency(to_install, link, upgrade)
+        install_single_dependency(to_install, vendor, upgrade)
     else:
         # eg. "ato install"
         install_project_dependencies(upgrade)
@@ -116,17 +116,17 @@ def get_package_repo_from_registry(module_name: str) -> str:
     return return_url
 
 
-def install_single_dependency(to_install: str, link: bool, upgrade: bool):
+def install_single_dependency(to_install: str, vendor: bool, upgrade: bool):
     dependency = Dependency.from_str(to_install)
     name = _name_and_clone_url_helper(dependency.name)[0]
-    if link:
+    if vendor:
+        dependency.link_broken = True
+        abs_path = config.project.paths.src / name
+        dependency.path = abs_path.relative_to(config.project.paths.root)
+    else:
         dependency.link_broken = False
         abs_path = config.project.paths.modules / name
         dependency.path = abs_path.relative_to(config.project.paths.root)
-    else:
-        abs_path = config.project.paths.src / name
-        dependency.path = abs_path.relative_to(config.project.paths.root)
-        dependency.link_broken = True
 
     try:
         installed_version = install_dependency(dependency, upgrade, abs_path)

--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -34,8 +34,11 @@ def install(
     ] = False,
     link: Annotated[
         bool,
-        typer.Option("--link", "-l", help="Keep this dependency linked to the source"),
-    ] = False,
+        typer.Option(
+            "--link/--vendor",
+            help="Keep this dependency linked to the source or vendor it",
+        ),
+    ] = True,
     upgrade: Annotated[
         bool, typer.Option("--upgrade", "-u", help="Upgrade dependencies")
     ] = False,
@@ -155,7 +158,11 @@ def install_single_dependency(to_install: str, link: bool, upgrade: bool):
             config_data["dependencies"] = []
 
         for i, dep in enumerate(config_data["dependencies"]):
-            if dep["name"] == new_data["name"]:
+            if not isinstance(dep, dict):
+                continue
+
+            # Use .get here to avoid KeyErrors
+            if dep.get("name") == new_data["name"]:
                 config_data["dependencies"][i] = new_data
                 break
         else:

--- a/src/atopile/cli/install.py
+++ b/src/atopile/cli/install.py
@@ -164,15 +164,12 @@ def install_single_dependency(to_install: str, link: bool, upgrade: bool):
         ]
 
         for i, dep in enumerate(config_data["dependencies"]):
-            if not isinstance(dep, dict):
-                continue
-
-            # Use .get here to avoid KeyErrors
-            if dep.get("name") == new_data["name"]:
+            if dep["name"] == new_data["name"]:
                 config_data["dependencies"][i] = new_data
                 break
         else:
             config_data["dependencies"] = config_data["dependencies"] + [new_data]
+
         return config_data
 
     config.update_project_config(add_dependency, dependency.model_dump())


### PR DESCRIPTION
Link generics by default on install.
Change option for vendoring to `--vendor`
Install generics by default on `ato create`