### PR TITLE
Improve build target paths configuration handling

### DIFF
--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -250,11 +250,8 @@ class BuildTargetPaths(BaseConfigModel):
     """Build-target KiCAD project file"""
 
     def __init__(self, name: str, project_paths: ProjectPaths, **data: Any):
-        data.setdefault(
-            "layout",
-            BuildTargetPaths.ensure_layout(
-                project_paths.root / project_paths.layout / name
-            ),
+        data["layout"] = BuildTargetPaths.ensure_layout(
+            Path(data.get("layout", project_paths.root / project_paths.layout / name))
         )
         data.setdefault("output_base", project_paths.build / name)
         data.setdefault("netlist", data["output_base"] / f"{name}.net")
@@ -378,11 +375,13 @@ class BuildTargetConfig(BaseConfigModel):
 
     @property
     def entry_file_path(self) -> Path:
+        """An absolute path to the entry file."""
         address = AddrStr(self.address)
         return self._project_paths.root / address.file_path
 
     @property
     def entry_section(self) -> str:
+        """The path to the entry module."""
         address = AddrStr(self.address)
         return address.entry_section
 

--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -250,10 +250,18 @@ class BuildTargetPaths(BaseConfigModel):
     """Build-target KiCAD project file"""
 
     def __init__(self, name: str, project_paths: ProjectPaths, **data: Any):
-        data["layout"] = BuildTargetPaths.ensure_layout(
-            Path(data.get("layout", project_paths.root / project_paths.layout / name))
-        )
-        data.setdefault("output_base", project_paths.build / name)
+        if layout_data := data.get("layout"):
+            data["layout"] = BuildTargetPaths.ensure_layout(Path(layout_data))
+        else:
+            data["layout"] = BuildTargetPaths.ensure_layout(
+                project_paths.root / project_paths.layout / name
+            )
+
+        if output_base_data := data.get("output_base"):
+            data["output_base"] = Path(output_base_data)
+        else:
+            data["output_base"] = project_paths.build / name
+
         data.setdefault("netlist", data["output_base"] / f"{name}.net")
         data.setdefault("fp_lib_table", data["layout"].parent / "fp-lib-table")
         data.setdefault("kicad_project", data["layout"].with_suffix(".kicad_pro"))


### PR DESCRIPTION
- Enhance layout path resolution in BuildTargetPaths
- Add docstrings for entry file path and section properties
- Simplify layout path initialization with more flexible path handling

This means something like this works:

```yaml
ato-version: ^0.2.0
builds:
  default:
    entry: elec/src/hil-blocks.ato:HilBlocks
  # ...
  lv2842kit:
    entry: elec/src/components/lv2842xlvddcr/elec/src/lv2842kit.ato:LV2842Kit
    paths:
      layout: elec/src/components/lv2842xlvddcr/elec/layout/default/LV2842Kit.kicad_pcb
dependencies:
- generics

```