### PR TITLE
Fix `(island)` zones sexp decoding, `CatchAll` and `CatchAll` reproduction sequence

### DIFF
--- a/src/faebryk/libs/kicad/fileformats.py
+++ b/src/faebryk/libs/kicad/fileformats.py
@@ -933,9 +933,8 @@ class C_kicad_pcb_file(SEXP_File):
             @dataclass(kw_only=True)
             class C_filled_polygon:
                 layer: str
-                island: Optional[bool] = field(
-                    **sexp_field(positional=True), default=None
-                )
+                # FIXME: decode (island), a bracketed positional
+                # We're currently relying on the CatchAll to re-serialise it
                 pts: C_pts
                 unknown: CatchAll = None
 

--- a/src/faebryk/libs/sexp/dataclass_sexp.py
+++ b/src/faebryk/libs/sexp/dataclass_sexp.py
@@ -370,7 +370,7 @@ def _decode[T](
                 f" {sp.assert_value} but is {value_dict[f.name]}"
             )
 
-    # Unprocessed values should be None is there aren't any,
+    # Unprocessed values should be None if there aren't any,
     # so they don't get reproduced etc...
     if catch_all_fields and not unprocessed:
         value_dict[catch_all_fields[0].name] = None

--- a/src/faebryk/libs/sexp/dataclass_sexp.py
+++ b/src/faebryk/libs/sexp/dataclass_sexp.py
@@ -493,8 +493,8 @@ def _encode(t) -> netlist_type:
 
     if catch_all_field is not None:
         catch_all: dict[int, Any] = getattr(t, catch_all_field.name, {}) or {}
-        for i, v in catch_all.items():
-            sexp.insert(i + 1, v)
+        for i, v in sorted(catch_all.items(), key=lambda x: x[0]):
+            sexp.insert(i, v)
 
     if logger.isEnabledFor(logging.DEBUG):
         logger.debug(f"Dumping {type(t).__name__} {'-'*40}")

--- a/test/libs/kicad/test_fileformats.py
+++ b/test/libs/kicad/test_fileformats.py
@@ -2,11 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 import logging
-from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
-from dataclasses_json import CatchAll
 
 import faebryk.library._F as F  # noqa: F401  # This is required to prevent a circular import
 from faebryk.libs.kicad.fileformats import (
@@ -20,13 +18,7 @@ from faebryk.libs.kicad.fileformats import (
 )
 from faebryk.libs.kicad.fileformats_sch import C_kicad_sch_file, C_kicad_sym_file
 from faebryk.libs.kicad.fileformats_version import kicad_footprint_file
-from faebryk.libs.sexp.dataclass_sexp import (
-    JSON_File,
-    SEXP_File,
-    dataclass_dfs,
-    dumps,
-    loads,
-)
+from faebryk.libs.sexp.dataclass_sexp import JSON_File, SEXP_File
 from faebryk.libs.test.fileformats import (
     _FP_DIR,
     _FPLIB_DIR,  # noqa: F401
@@ -207,88 +199,6 @@ def test_dump_load_equality(parser: type[SEXP_File | JSON_File], path: Path):
     loaded_dump = parser.loads(dump)
     dump2 = loaded_dump.dumps()
     assert dump == dump2
-
-
-def test_sexp():
-    pcb = C_kicad_pcb_file.loads(PCBFILE)
-    dfs = list(dataclass_dfs(pcb))
-    for obj, path, name_path in dfs:
-        name = "".join(name_path)
-        logger.debug(f"{name:70} {[type(p).__name__ for p in path + [obj]]}")
-
-    logger.debug("-" * 80)
-
-    level2 = [p for p in dfs if len(p[1]) == 2]
-    for obj, path, name_path in level2:
-        name = "".join(name_path)
-        logger.debug(f"{name:70}  {[type(p).__name__ for p in path + [obj]]}")
-
-
-def _unformat(s: str) -> str:
-    return s.replace("\n", "").replace(" ", "")
-
-
-def test_no_unknowns():
-    @dataclass
-    class Container:
-        @dataclass
-        class SomeDataclass:
-            a: int
-            b: str
-
-        some_dataclass: SomeDataclass
-
-    container = Container(some_dataclass=Container.SomeDataclass(a=1, b="hello"))
-    cereal = dumps(container)
-
-    assert _unformat(cereal) == _unformat('(some_dataclass (a 1) (b "hello"))')
-
-    assert loads(cereal, Container) == container
-
-
-def test_empty_unknowns():
-    @dataclass
-    class Container:
-        @dataclass
-        class SomeDataclass:
-            a: int
-            b: str
-            unknown: CatchAll = None
-
-        some_dataclass: SomeDataclass
-
-    container = Container(some_dataclass=Container.SomeDataclass(a=1, b="hello"))
-
-    cereal = dumps(container)
-
-    assert _unformat(cereal) == _unformat('(some_dataclass (a 1) (b "hello"))')
-
-    assert loads(cereal, Container) == container
-
-
-def test_unknowns():
-    @dataclass
-    class Container:
-        @dataclass
-        class SomeDataclass:
-            a: int
-            b: str
-            unknown: CatchAll = None
-
-        some_dataclass: SomeDataclass
-
-    cereal = (
-        '(some_dataclass (a 1) (b "hello") gibberish (thingo) (random_key'
-        ' "random_value") (whats_this (who_even_knows True)))'
-    )
-
-    container = loads(cereal, Container)
-
-    assert container.some_dataclass.a == 1
-    assert container.some_dataclass.b == "hello"
-    assert container.some_dataclass.unknown  # there is content
-
-    assert _unformat(dumps(container)) == _unformat(cereal)
 
 
 @pytest.mark.parametrize(

--- a/test/libs/kicad/test_sexp.py
+++ b/test/libs/kicad/test_sexp.py
@@ -4,6 +4,7 @@
 import logging
 from dataclasses import dataclass
 
+import pytest
 from dataclasses_json import CatchAll
 
 import faebryk.library._F as F  # noqa: F401  # This is required to prevent a circular import
@@ -44,6 +45,10 @@ def test_no_unknowns():
     assert _unformat(cereal) == _unformat('(some_dataclass (a 1) (b "hello"))')
 
     assert loads(cereal, Container) == container
+
+    bad_cereal = '(some_dataclass gibberish (a 1) (b "hello"))'
+    with pytest.raises(ValueError):
+        loads(bad_cereal, Container)
 
 
 def test_empty_unknowns():

--- a/test/libs/kicad/test_sexp.py
+++ b/test/libs/kicad/test_sexp.py
@@ -41,18 +41,18 @@ def _unformat(s: str) -> str:
 class Container:
     @dataclass(kw_only=True)
     class SomeDataclass:
-        class SomeEnum(SymEnum):
+        class E_Numbers(SymEnum):
             ONE = "one"
             TWO = "two"
 
         a: int = field(**sexp_field(positional=True))
         b: bool = field(**sexp_field(positional=True))
         c: Optional[bool] = field(**sexp_field(positional=True), default=None)
-        d: Optional[SomeEnum] = field(**sexp_field(positional=True), default=None)
-        e: int
-        f: bool
-        g: Optional[bool] = None
-        h: Optional[SomeEnum] = None
+        d: Optional[E_Numbers] = field(**sexp_field(positional=True), default=None)
+        f: int
+        g: bool
+        h: Optional[bool] = None
+        i: Optional[E_Numbers] = None
 
     some_dataclass: SomeDataclass
 
@@ -63,10 +63,10 @@ class Container:
         (
             Container(
                 some_dataclass=Container.SomeDataclass(
-                    a=1, b=True, c=None, d=None, e=2, f=False, g=None, h=None
+                    a=1, b=True, c=None, d=None, f=2, g=False, h=None, i=None
                 )
             ),
-            "(some_dataclass 1 yes (e 2) (f no))",
+            "(some_dataclass 1 yes (f 2) (g no))",
         ),
         (
             Container(
@@ -74,14 +74,14 @@ class Container:
                     a=1,
                     b=True,
                     c=False,
-                    d=Container.SomeDataclass.SomeEnum.ONE,
-                    e=2,
-                    f=False,
-                    g=True,
-                    h=Container.SomeDataclass.SomeEnum.TWO,
+                    d=Container.SomeDataclass.E_Numbers.ONE,
+                    f=2,
+                    g=False,
+                    h=True,
+                    i=Container.SomeDataclass.E_Numbers.TWO,
                 )
             ),
-            "(some_dataclass 1 yes no one (e 2) (f no) (g yes) (h two))",
+            "(some_dataclass 1 yes no one (f 2) (g no) (h yes) (i two))",
         ),
     ],
 )
@@ -130,8 +130,8 @@ def test_unknowns():
         some_dataclass: SomeDataclass
 
     cereal = (
-        '(some_dataclass (a 1) (b "hello") gibberish (thingo) (random_key'
-        ' "random_value") (whats_this (who_even_knows True)))'
+        '(some_dataclass gibberish (thingo) (a 1) (b "hello") gibberish (thingo) '
+        '(random_key "random_value") (whats_this (who_even_knows True)))'
     )
 
     container = loads(cereal, Container)

--- a/test/libs/kicad/test_sexp.py
+++ b/test/libs/kicad/test_sexp.py
@@ -3,7 +3,6 @@
 
 import logging
 from dataclasses import dataclass, field
-from enum import StrEnum
 
 import pytest
 from dataclasses_json import CatchAll
@@ -13,6 +12,7 @@ import faebryk.library._F as F  # noqa: F401  # This is required to prevent a ci
 from faebryk.libs.kicad.fileformats import C_kicad_pcb_file
 from faebryk.libs.sexp.dataclass_sexp import (
     DecodeError,
+    SymEnum,
     dataclass_dfs,
     dumps,
     loads,
@@ -41,7 +41,7 @@ def _unformat(s: str) -> str:
 class Container:
     @dataclass(kw_only=True)
     class SomeDataclass:
-        class SomeEnum(StrEnum):
+        class SomeEnum(SymEnum):
             ONE = "one"
             TWO = "two"
 
@@ -81,7 +81,7 @@ class Container:
                     h=Container.SomeDataclass.SomeEnum.TWO,
                 )
             ),
-            '(some_dataclass 1 yes no "one" (e 2) (f no) (g yes) (h "two"))',
+            "(some_dataclass 1 yes no one (e 2) (f no) (g yes) (h two))",
         ),
     ],
 )
@@ -95,7 +95,7 @@ def test_no_unknowns(container, str_sexp):
 
 def test_extra_positional():
     with pytest.raises(DecodeError):
-        loads('(some_dataclass 1 yes  no "one" gibberish (e 2) (f no))', Container)
+        loads('(some_dataclass 1 yes no "one" gibberish (e 2) (f no))', Container)
 
 
 def test_empty_unknowns():

--- a/test/libs/kicad/test_sexp.py
+++ b/test/libs/kicad/test_sexp.py
@@ -1,0 +1,106 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import logging
+from dataclasses import dataclass
+
+from dataclasses_json import CatchAll
+
+import faebryk.library._F as F  # noqa: F401  # This is required to prevent a circular import
+from faebryk.libs.kicad.fileformats import C_kicad_pcb_file
+from faebryk.libs.sexp.dataclass_sexp import dataclass_dfs, dumps, loads
+from faebryk.libs.test.fileformats import (
+    _FPLIB_DIR,  # noqa: F401
+    _NETLIST_DIR,  # noqa: F401
+    _PCB_DIR,  # noqa: F401
+    _PRJ_DIR,  # noqa: F401
+    _SCH_DIR,  # noqa: F401
+    _SYM_DIR,  # noqa: F401
+    _VERSION_DIR,  # noqa: F401
+    DEFAULT_VERSION,  # noqa: F401
+    PCBFILE,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _unformat(s: str) -> str:
+    return s.replace("\n", "").replace(" ", "")
+
+
+def test_no_unknowns():
+    @dataclass
+    class Container:
+        @dataclass
+        class SomeDataclass:
+            a: int
+            b: str
+
+        some_dataclass: SomeDataclass
+
+    container = Container(some_dataclass=Container.SomeDataclass(a=1, b="hello"))
+    cereal = dumps(container)
+
+    assert _unformat(cereal) == _unformat('(some_dataclass (a 1) (b "hello"))')
+
+    assert loads(cereal, Container) == container
+
+
+def test_empty_unknowns():
+    @dataclass
+    class Container:
+        @dataclass
+        class SomeDataclass:
+            a: int
+            b: str
+            unknown: CatchAll = None
+
+        some_dataclass: SomeDataclass
+
+    container = Container(some_dataclass=Container.SomeDataclass(a=1, b="hello"))
+
+    cereal = dumps(container)
+
+    assert _unformat(cereal) == _unformat('(some_dataclass (a 1) (b "hello"))')
+
+    assert loads(cereal, Container) == container
+
+
+def test_unknowns():
+    @dataclass
+    class Container:
+        @dataclass
+        class SomeDataclass:
+            a: int
+            b: str
+            unknown: CatchAll = None
+
+        some_dataclass: SomeDataclass
+
+    cereal = (
+        '(some_dataclass (a 1) (b "hello") gibberish (thingo) (random_key'
+        ' "random_value") (whats_this (who_even_knows True)))'
+    )
+
+    container = loads(cereal, Container)
+
+    assert container.some_dataclass.a == 1
+    assert container.some_dataclass.b == "hello"
+    assert container.some_dataclass.unknown  # there is content
+
+    assert _unformat(dumps(container)) == _unformat(cereal)
+
+
+def test_print_sexp():
+    pcb = C_kicad_pcb_file.loads(PCBFILE)
+    dfs = list(dataclass_dfs(pcb))
+    for obj, path, name_path in dfs:
+        name = "".join(name_path)
+        logger.debug(f"{name:70} {[type(p).__name__ for p in path + [obj]]}")
+
+    logger.debug("-" * 80)
+
+    level2 = [p for p in dfs if len(p[1]) == 2]
+    for obj, path, name_path in level2:
+        name = "".join(name_path)
+        logger.debug(f"{name:70}  {[type(p).__name__ for p in path + [obj]]}")


### PR DESCRIPTION
# Description

I've managed to replicate this one and think it's actually a subtly different cause; it's a fault in the `CatchAll` and sexp de/encoder that's moving a positional `(island)` from slot 1 to the end.

I think there are three issues:

1. The positional `(island)` isn't being parsed properly
2. The decoder isn't properly rejecting additional statements without 
3. The `CatchAll` isn't re-placing values back in their correct indices

Fixes #776 

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules
