### PR TITLE
fix error message for ERC short

### DIFF
--- a/src/faebryk/libs/app/erc.py
+++ b/src/faebryk/libs/app/erc.py
@@ -68,7 +68,7 @@ def simple_erc(G: Graph, voltage_limit=1e5 * P.V):
     logger.info(f"Checking {len(electricpower)} Power")
     for ep in electricpower:
         if ep.lv.is_connected_to(ep.hv):
-            raise ERCFaultShort([ep], "shorted power")
+            raise ERCFaultShort([ep.lv, ep.hv], "shorted power")
         if ep.has_trait(F.Power.is_power_source):
             other_sources = [
                 other


### PR DESCRIPTION
Power ERC short check currently passes a power interface to the ercfault short exception handler, should pass hv and lv.