### PR TITLE
Core: Solver add param mapping constraint

### DIFF
--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -278,7 +278,8 @@ class Mutator:
         if not isinstance(unpacked, ParameterOperatable):
             raise ValueError("Unpacked operand can't be a literal")
         out = self._mutate(expr, self.get_copy(unpacked))
-        if isinstance(out, ConstrainableExpression) and out.constrained:
+        if isinstance(expr, ConstrainableExpression) and expr.constrained:
+            assert isinstance(out, ConstrainableExpression)
             out.constrain()
         return out
 


### PR DESCRIPTION
# Core: Solver add param mapping constraint

Allows to do this:

```
A, B = times(2, Parameter)

A.constrain_mapping(B, {5: Range(10, 100), 10: Range(500, 1000))
```

This creates under the hood a constrained implication per mapping case.
Very useful for configuration resistors etc.
