### PR TITLE
Library: KicadFootprint: Add ValueError for kicad identifier

### DIFF
--- a/src/faebryk/library/KicadFootprint.py
+++ b/src/faebryk/library/KicadFootprint.py
@@ -16,8 +16,7 @@ if TYPE_CHECKING:
 class KicadFootprint(F.Footprint):
     class has_file(F.Footprint.TraitT.decless()):
         """
-        Direct reference to a KiCAD footprint file, which will
-        later
+        Direct reference to a KiCAD footprint file
         """
 
         def __init__(self, file: PathLike):
@@ -27,6 +26,11 @@ class KicadFootprint(F.Footprint):
     class has_kicad_identifier(F.Footprint.TraitT.decless()):
         def __init__(self, kicad_identifier: str):
             super().__init__()
+            if ":" not in kicad_identifier:
+                raise ValueError(
+                    'kicad_identifier must be in the format "library:footprint".'
+                    " If not, it'll cause downstream problems"
+                )
             self.kicad_identifier = kicad_identifier
 
         def on_obj_set(self):


### PR DESCRIPTION
# Library: KicadFootprint: Add ValueError for kicad identifier

## Description

From: https://github.com/atopile/faebryk/pull/39

Co-authored-by: @mawildoer

Fixes # (issue)

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
