### PR TITLE
Fix: Solver: No inf loop on disproven preds

### DIFF
--- a/src/faebryk/core/parameter.py
+++ b/src/faebryk/core/parameter.py
@@ -1706,3 +1706,5 @@ Commutative = (
 FullyAssociative = Add | Multiply | And | Or | Xor | Union | Intersection
 LeftAssociative = Subtract | Divide | Difference
 Associative = FullyAssociative | LeftAssociative
+
+Reflexive = Is | IsSubset | GreaterOrEqual

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -19,6 +19,7 @@ from faebryk.core.parameter import (
     Parameter,
     ParameterOperatable,
     Power,
+    Reflexive,
 )
 from faebryk.core.solver.mutator import Mutator
 from faebryk.core.solver.utils import (
@@ -883,3 +884,28 @@ def remove_tautologies(mutator: Mutator):
             continue
 
         alias_is_literal_and_check_predicate_eval(pred, True, mutator)
+
+
+@algorithm("Reflexive predicates")
+def reflexive_predicates(mutator: Mutator):
+    """
+    A not lit (done by literal_folding)
+    A is A -> True
+    A ss A -> True
+    A >= A -> True
+    """
+
+    def if_operands_same_make_true(pred: ConstrainableExpression) -> bool:
+        if pred.operands[0] is not pred.operands[1]:
+            return False
+        if not isinstance(pred.operands[0], ParameterOperatable):
+            return False
+        alias_is_literal_and_check_predicate_eval(pred, True, mutator)
+        return True
+
+    predicates = mutator.nodes_of_types(Reflexive, sort_by_depth=True)
+    for pred in predicates:
+        assert isinstance(pred, ConstrainableExpression)
+        if not pred.operatable_operands:
+            continue
+        if_operands_same_make_true(pred)

--- a/src/faebryk/core/solver/defaultsolver.py
+++ b/src/faebryk/core/solver/defaultsolver.py
@@ -20,7 +20,7 @@ from faebryk.core.solver import analytical, canonical, literal_folding
 from faebryk.core.solver.mutator import REPR_MAP, Mutator
 from faebryk.core.solver.solver import LOG_PICK_SOLVE, Solver
 from faebryk.core.solver.utils import (
-    DEBUG_ALLOW_PARTIAL_STATE,
+    ALLOW_PARTIAL_STATE,
     MAX_ITERATIONS_HEURISTIC,
     PRINT_START,
     S_LOG,
@@ -73,6 +73,7 @@ class DefaultSolver(Solver):
             analytical.remove_congruent_expressions,
             analytical.convert_inequality_with_literal_to_subset,
             analytical.compress_associative,
+            analytical.reflexive_predicates,
             literal_folding.fold_pure_literal_expressions,
             *literal_folding.fold_algorithms,
             analytical.merge_intersect_subsets,
@@ -229,11 +230,6 @@ class DefaultSolver(Solver):
             first_iter = iterno == 0
 
             if iterno > MAX_ITERATIONS_HEURISTIC:
-                if DEBUG_ALLOW_PARTIAL_STATE:
-                    return (
-                        self.partial_state.data.total_repr_map,
-                        self.partial_state.print_context,
-                    )
                 raise TimeoutError(
                     "Solver Bug: Too many iterations, likely stuck in a loop"
                 )
@@ -361,6 +357,8 @@ class DefaultSolver(Solver):
         try:
             repr_map, print_context = self.simplify_symbolically(param.get_graph())
         except TimeoutError:
+            if not ALLOW_PARTIAL_STATE:
+                raise
             if self.partial_state is None:
                 raise
             repr_map = self.partial_state.data.total_repr_map
@@ -425,6 +423,8 @@ class DefaultSolver(Solver):
             except TimeoutError:
                 if LOG_PICK_SOLVE:
                     logger.warning(f"TIMEOUT: {pred.compact_repr(print_context)}")
+                if not ALLOW_PARTIAL_STATE:
+                    raise
                 if self.partial_state is None:
                     result.unknown_predicates.append(p)
                     continue

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -77,9 +77,7 @@ MAX_ITERATIONS_HEURISTIC = int(
     ConfigFlagInt("SMAX_ITERATIONS", default=40, descr="Max iterations")
 )
 TIMEOUT = ConfigFlagInt("STIMEOUT", default=120, descr="Solver timeout").get()
-DEBUG_ALLOW_PARTIAL_STATE = ConfigFlag(
-    "SPARTIAL", default=False, descr="Allow partial state"
-)
+ALLOW_PARTIAL_STATE = ConfigFlag("SPARTIAL", default=True, descr="Allow partial state")
 # --------------------------------------------------------------------------------------
 
 if S_LOG:


### PR DESCRIPTION
# Fix: Solver: No inf loop on disproven preds

!Not(P), P is! False led to inf loop
Group Reflexive pred folding
Remove old comments `fold_is`

