### PR TITLE
Solver: Remove try_extract where not needed

### DIFF
--- a/src/faebryk/core/parameter.py
+++ b/src/faebryk/core/parameter.py
@@ -1706,3 +1706,5 @@ Commutative = (
 FullyAssociative = Add | Multiply | And | Or | Xor | Union | Intersection
 LeftAssociative = Subtract | Divide | Difference
 Associative = FullyAssociative | LeftAssociative
+
+Reflexive = Is | IsSubset | GreaterOrEqual

--- a/src/faebryk/core/parameter.py
+++ b/src/faebryk/core/parameter.py
@@ -610,16 +610,10 @@ class Expression(ParameterOperatable):
         )
 
     def get_literal_operands(self) -> dict[int, ParameterOperatable.Literal]:
-        if isinstance(self, (Is, IsSubset)):
-            return {
-                i: o
-                for i, o in enumerate(self.operands)
-                if ParameterOperatable.is_literal(o)
-            }
-        # TODO not sure its a good idea to do this that recursive
         return {
-            i: ParameterOperatable.try_extract_literal(o)
+            i: o
             for i, o in enumerate(self.operands)
+            if ParameterOperatable.is_literal(o)
         }
 
     def get_involved_parameters(self) -> Counter["Parameter"]:

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -244,9 +244,13 @@ def resolve_alias_classes(mutator: Mutator):
                     for e in operand.get_operations()
                     # skip POps Is, because they create the alias classes
                     # or literal aliases (done by distribute algo)
-                    if not isinstance(e, Is)
+                    if not (isinstance(e, Is) and e.constrained)
                     # skip literal subsets (done by distribute algo)
-                    and not (isinstance(e, IsSubset) and e.get_literal_operands())
+                    and not (
+                        isinstance(e, IsSubset)
+                        and e.get_literal_operands()
+                        and e.constrained
+                    )
                 }
                 if not class_expressions:
                     continue

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -19,6 +19,7 @@ from faebryk.core.parameter import (
     Parameter,
     ParameterOperatable,
     Power,
+    Reflexive,
 )
 from faebryk.core.solver.mutator import Mutator
 from faebryk.core.solver.utils import (
@@ -883,3 +884,28 @@ def remove_tautologies(mutator: Mutator):
             continue
 
         alias_is_literal_and_check_predicate_eval(pred, True, mutator)
+
+
+@algorithm("Reflexive predicates")
+def reflexive_predicates(mutator: Mutator):
+    """
+    A not lit (done by literal_folding)
+    A is A -> True
+    A ss A -> True
+    A >= A -> True
+    """
+
+    def if_operands_same_make_true(pred: ConstrainableExpression) -> bool:
+        if pred.operands[0] is not pred.operands[1]:
+            return False
+        if not isinstance(pred.operands[0], ParameterOperatable):
+            return False
+        alias_is_literal_and_check_predicate_eval(pred, True, mutator)
+        return True
+
+    predicates = mutator.nodes_of_types(Reflexive, sort_by_depth=True)
+    for pred in predicates:
+        assert isinstance(pred, ConstrainableExpression)
+        if not pred.operatable_operands:
+            continue
+        if_operands_same_make_true(pred)

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -299,10 +299,13 @@ def resolve_alias_classes(mutator: Mutator):
         # This will implicitly swap out the expr in other exprs with the repr
         for e in alias_class_exprs:
             copy_expr = mutator.mutate_expression(e)
-            expr = mutator.create_expression(
-                Is, copy_expr, representative, from_ops=alias_class_p_ops
-            )
-            expr.constrain()  # p_eq_classes is derived from constrained exprs only
+            mutator.create_expression(
+                Is,
+                copy_expr,
+                representative,
+                from_ops=alias_class_p_ops,
+                constrain=True,
+            )  # p_eq_classes is derived from constrained exprs only
             # DANGER!
             mutator._override_repr(e, representative)
 

--- a/src/faebryk/core/solver/canonical.py
+++ b/src/faebryk/core/solver/canonical.py
@@ -325,7 +325,9 @@ def convert_to_canonical_operations(mutator: Mutator):
             p = Parameter(units=e.units)
             mutator.register_created_parameter(p, from_ops=from_ops)
             union = Union(*[mutator.get_copy(o) for o in e.operands])
-            mutator.create_expression(IsSubset, p, union, from_ops=from_ops).constrain()
+            mutator.create_expression(
+                IsSubset, p, union, from_ops=from_ops, constrain=True
+            )
             if isinstance(e, Min):
                 mutator.create_expression(GreaterOrEqual, union, p, from_ops=from_ops)
             else:

--- a/src/faebryk/core/solver/defaultsolver.py
+++ b/src/faebryk/core/solver/defaultsolver.py
@@ -20,7 +20,7 @@ from faebryk.core.solver import analytical, canonical, literal_folding
 from faebryk.core.solver.mutator import REPR_MAP, Mutator
 from faebryk.core.solver.solver import LOG_PICK_SOLVE, Solver
 from faebryk.core.solver.utils import (
-    DEBUG_ALLOW_PARTIAL_STATE,
+    ALLOW_PARTIAL_STATE,
     MAX_ITERATIONS_HEURISTIC,
     PRINT_START,
     S_LOG,
@@ -73,6 +73,7 @@ class DefaultSolver(Solver):
             analytical.remove_congruent_expressions,
             analytical.convert_inequality_with_literal_to_subset,
             analytical.compress_associative,
+            analytical.reflexive_predicates,
             literal_folding.fold_pure_literal_expressions,
             *literal_folding.fold_algorithms,
             analytical.merge_intersect_subsets,
@@ -229,11 +230,6 @@ class DefaultSolver(Solver):
             first_iter = iterno == 0
 
             if iterno > MAX_ITERATIONS_HEURISTIC:
-                if DEBUG_ALLOW_PARTIAL_STATE:
-                    return (
-                        self.partial_state.data.total_repr_map,
-                        self.partial_state.print_context,
-                    )
                 raise TimeoutError(
                     "Solver Bug: Too many iterations, likely stuck in a loop"
                 )
@@ -361,6 +357,8 @@ class DefaultSolver(Solver):
         try:
             repr_map, print_context = self.simplify_symbolically(param.get_graph())
         except TimeoutError:
+            if not ALLOW_PARTIAL_STATE:
+                raise
             if self.partial_state is None:
                 raise
             repr_map = self.partial_state.data.total_repr_map
@@ -425,6 +423,8 @@ class DefaultSolver(Solver):
             except TimeoutError:
                 if LOG_PICK_SOLVE:
                     logger.warning(f"TIMEOUT: {pred.compact_repr(print_context)}")
+                if not ALLOW_PARTIAL_STATE:
+                    raise
                 if self.partial_state is None:
                     result.unknown_predicates.append(p)
                     continue

--- a/src/faebryk/core/solver/literal_folding.py
+++ b/src/faebryk/core/solver/literal_folding.py
@@ -460,20 +460,22 @@ def fold_not(
                                 isinstance(not_op, ConstrainableExpression)
                                 and not not_op.constrained
                             ):
-                                cast_assert(
-                                    ConstrainableExpression,
-                                    mutator.get_copy(not_op),
-                                ).constrain()
+                                mutator.constrain(
+                                    cast_assert(
+                                        ConstrainableExpression,
+                                        mutator.get_copy(not_op),
+                                    )
+                                )
                     # ¬(A v ...)
                     elif isinstance(inner_op, ConstrainableExpression):
                         parent_nots = inner_op.get_operations(Not)
                         if parent_nots:
                             for n in parent_nots:
-                                n.constrain()
+                                mutator.constrain(n)
                         else:
                             mutator.create_expression(
-                                Not, inner_op, from_ops=[expr]
-                            ).constrain()
+                                Not, inner_op, from_ops=[expr], constrain=True
+                            )
 
     if expr.constrained:
         alias_is_literal_and_check_predicate_eval(op, False, mutator)
@@ -497,7 +499,7 @@ def fold_is(
         # P1 is! True -> P1!
         # P1 is! P2!  -> P1! (implicit)
         for p in expr.get_operatable_operands(ConstrainableExpression):
-            p.constrain()
+            mutator.constrain(p)
 
 
 def fold_subset(
@@ -543,11 +545,11 @@ def fold_subset(
             and B.constrained
         ):
             assert isinstance(A, ConstrainableExpression)
-            A.constrain()
+            mutator.constrain(A)
         # P ss! False -> ¬!P
         if B == BoolSet(False):
             assert isinstance(A, ConstrainableExpression)
-            mutator.create_expression(Not, A, from_ops=[expr]).constrain()
+            mutator.create_expression(Not, A, from_ops=[expr], constrain=True)
 
 
 def fold_ge(

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -775,7 +775,7 @@ class Mutator:
                         and n._solver_terminated
                         and (
                             # A is/ss Lit
-                            any(ParameterOperatable.is_literal(o) for o in n.operands)
+                            n.get_literal_operands()
                             # A is/ss A
                             or n.operands[0] is n.operands[1]
                         )

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -280,7 +280,7 @@ class Mutator:
         out = self._mutate(expr, self.get_copy(unpacked))
         if isinstance(expr, ConstrainableExpression) and expr.constrained:
             assert isinstance(out, ConstrainableExpression)
-            out.constrain()
+            self.constrain(out)
         return out
 
     def mutator_neutralize_expressions(self, expr: Expression) -> ParameterOperatable:
@@ -298,7 +298,7 @@ class Mutator:
             raise ValueError("Unpacked operand can't be a literal")
         out = self._mutate(expr, self.get_copy(inner_operand))
         if isinstance(out, ConstrainableExpression) and out.constrained:
-            out.constrain()
+            self.constrain(out)
         return out
 
     def mutate_expression_with_op_map(

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -604,10 +604,9 @@ class Mutator:
             )
             if bool(
                 expr.constrained
-                and expr.get_literal_operands()
-                and expr.operatable_operands
                 # match A ⊆!!✓ ([5, 20]) but not ([5, 20]) ⊆!!✓ A
                 and isinstance(expr.operands[0], ParameterOperatable)
+                and ParameterOperatable.is_literal(expr.operands[1])
             )
         )
 

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -166,35 +166,6 @@ def try_extract_literal_info(
     return lit, False
 
 
-def try_extract_numeric_literal(
-    po, allow_subset: bool = False
-) -> CanonicalNumber | None:
-    lit = try_extract_literal(po, allow_subset)
-    assert isinstance(lit, (CanonicalNumber, NoneType))
-    return lit
-
-
-def try_extract_boolset(po, allow_subset: bool = False) -> CanonicalBoolean | None:
-    lit = try_extract_literal(po, allow_subset)
-    assert isinstance(lit, (CanonicalBoolean, NoneType))
-    return lit
-
-
-def try_extract_all_literals[T: P_Set](
-    expr: Expression,
-    allow_subset: bool = False,
-    lit_type: type[T] = P_Set,
-    accept_partial: bool = False,
-) -> list[T] | None:
-    as_lits = [try_extract_literal(o, allow_subset) for o in expr.operands]
-
-    if None in as_lits and not accept_partial:
-        return None
-    as_lits = [lit for lit in as_lits if lit is not None]
-    assert all(isinstance(lit, lit_type) for lit in as_lits)
-    return cast(list[T], as_lits)
-
-
 def map_extract_literals(
     expr: Expression,
 ) -> list[SolverOperatable]:

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -77,9 +77,7 @@ MAX_ITERATIONS_HEURISTIC = int(
     ConfigFlagInt("SMAX_ITERATIONS", default=40, descr="Max iterations")
 )
 TIMEOUT = ConfigFlagInt("STIMEOUT", default=120, descr="Solver timeout").get()
-DEBUG_ALLOW_PARTIAL_STATE = ConfigFlag(
-    "SPARTIAL", default=False, descr="Allow partial state"
-)
+ALLOW_PARTIAL_STATE = ConfigFlag("SPARTIAL", default=True, descr="Allow partial state")
 # --------------------------------------------------------------------------------------
 
 if S_LOG:

--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -1061,7 +1061,10 @@ def test_fold_correlated():
     assert is_lit != op_inv(lit2, lit1)
 
     # Test for correct is estimation
-    # assert is_lit == lit_operand  # TODO
+    try:
+        assert is_lit == lit_operand
+    except AssertionError:
+        pytest.xfail("TODO")
 
 
 def test_fold_pow():

--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -893,7 +893,6 @@ def test_jlcpcb_pick_led():
     print(led.get_trait(F.has_part_picked).get_part())
 
 
-@pytest.mark.xfail(reason="Need picker backtracking")
 def test_jlcpcb_pick_powered_led():
     led = F.PoweredLED()
     led.led.color.constrain_subset(L.EnumSet(F.LED.Color.EMERALD))
@@ -1159,7 +1158,6 @@ def test_find_contradiction_by_predicate(op, invert):
         solver.simplify_symbolically(A.get_graph())
 
 
-@pytest.mark.xfail(reason="No support for GT")
 def test_find_contradiction_by_gt():
     A = Parameter()
     B = Parameter()


### PR DESCRIPTION
# Solver: Remove try_extract where not needed

# Description

- **Fix: Solver: No inf loop on disproven preds**
- **comment -> xfail**
- **get_literal_operands no extract**
- **remove unused extract helpers**
- **remove xfail for passing tests**
- **use get_literal_ops**
- **use mutator constrain**

