### PR TITLE
Ato: Support modules as parts

### DIFF
--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -6,6 +6,7 @@ import itertools
 import logging
 import operator
 import os
+from collections import defaultdict
 from collections.abc import Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -70,6 +71,8 @@ from faebryk.libs.util import (
     has_instance_settable_attr,
     import_from_path,
     is_type_pair,
+    not_none,
+    partition,
 )
 
 logger = logging.getLogger(__name__)
@@ -414,6 +417,39 @@ _declaration_domain_to_unit = {
 }
 
 
+@dataclass
+class _ParameterDefinition:
+    """
+    Holds information about a parameter declaration or assignment.
+    We collect those per parameter in the `Bob._param_assignments` dict.
+    Multiple assignments are allowed, but they interact with each other in non-trivial
+    ways. Thus we need to track them and process them in the end in
+    `_merge_parameter_assignments`.
+    """
+
+    ctx: ParserRuleContext
+    traceback: Sequence[ParserRuleContext]
+    ref: Ref
+    value: Range | Single | None = None
+
+    @property
+    def is_declaration(self) -> bool:
+        return self.value is None
+
+    @property
+    def is_definition(self) -> bool:
+        return not self.is_declaration
+
+    def __post_init__(self):
+        pass
+
+    @property
+    def is_root_assignment(self) -> bool:
+        if not self.is_definition:
+            return False
+        return len(self.ref) > 1
+
+
 class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Overriding base class makes sense here
     """
     Bob is a general contractor who runs his own construction company in the town
@@ -435,15 +471,12 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
         self._node_stack = StackList[L.Node]()
         self._traceback_stack = StackList[ParserRuleContext]()
         # TODO: add tracebacks if we keep this
+        # TODO: this seems like it's not in use?
         self._promised_params = FuncDict[L.Node, list[ParserRuleContext]]()
-        self._param_assignments = FuncDict[
-            Parameter,
-            tuple[
-                Range | Single | None,
-                ParserRuleContext | None,
-                Sequence[ParserRuleContext] | None,
-            ],
-        ]()
+
+        self._param_assignments = defaultdict[Parameter, list[_ParameterDefinition]](
+            list
+        )
         self.search_paths: list[os.PathLike] = []
 
         # Keeps track of the nodes whose construction failed,
@@ -518,36 +551,71 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
     )
 
     def _finish(self):
+        self._merge_parameter_assignments()
+
+    def _merge_parameter_assignments(self):
         with accumulate(
             errors._BaseBaseUserException, SkipPriorFailedException
         ) as ex_acc:
-            for param, (value, ctx, traceback) in self._param_assignments.items():
-                with ex_acc.collect(), ato_error_converter():
-                    if value is None:
-                        ex = errors.UserKeyError.from_ctx(
-                            ctx,
-                            f"Parameter `{param}` never assigned",
-                            traceback=traceback,
-                        )
-                        if param in self._promised_params:
-                            raise ex
-                        else:
-                            with (
-                                downgrade(
-                                    errors.UserActionWithoutEffectError,
-                                    to_level=logging.DEBUG,
-                                ),
-                                self._suppressor_finish,
-                            ):
-                                raise errors.UserActionWithoutEffectError.from_ctx(
-                                    ctx,
-                                    f"Parameter `{param}` declared but never assigned.",
-                                    traceback=traceback,
-                                )
-                            continue
+            # Handle missing definitions
+            params_without_defitions, params_with_definitions = partition(
+                lambda p: any(a.is_definition for a in self._param_assignments[p]),
+                self._param_assignments,
+            )
+            params_without_defitions = set(params_without_defitions)
+            params_with_definitions = set(params_with_definitions)
+            promised_but_not_defined = (
+                set(self._promised_params.keys()) - params_with_definitions
+            )
+            promised_but_not_declared = (
+                set(self._param_assignments.keys()) - self._param_assignments.keys()
+            )
 
-                    if param in self._promised_params:
-                        del self._promised_params[param]
+            for param in promised_but_not_declared:
+                for ctx in self._promised_params[param]:
+                    with ex_acc.collect():
+                        raise errors.UserKeyError.from_ctx(
+                            ctx, f"Attribute `{param}` referenced, but never declared"
+                        )
+            for param in promised_but_not_defined:
+                for ctx in self._promised_params[param]:
+                    with ex_acc.collect(), ato_error_converter():
+                        raise errors.UserKeyError.from_ctx(
+                            ctx, f"Attribute `{param}` referenced, but never assigned"
+                        )
+
+            for param in params_without_defitions:
+                last_declaration = self._param_assignments[param][-1]
+                with ex_acc.collect(), ato_error_converter():
+                    with (
+                        downgrade(
+                            errors.UserActionWithoutEffectError,
+                            to_level=logging.DEBUG,
+                        ),
+                        self._suppressor_finish,
+                    ):
+                        raise errors.UserActionWithoutEffectError.from_ctx(
+                            last_declaration.ctx,
+                            f"Attribute `{param}` declared but never assigned.",
+                            traceback=last_declaration.traceback,
+                        )
+
+            # Handle parameter assignments
+            for param in params_with_definitions:
+                assignments = self._param_assignments[param]
+                definitions = [a for a in assignments if a.is_definition]
+                assert definitions
+
+                with ex_acc.collect(), ato_error_converter():
+                    # TODO: revisit this language detail
+                    # every assignment overrides the previous one
+                    # this is consistent with v0.2
+                    last_definition = definitions[-1]
+                    value, ctx, traceback = (
+                        not_none(last_definition.value),
+                        last_definition.ctx,
+                        last_definition.traceback,
+                    )
 
                     # Set final value of parameter
                     assert isinstance(
@@ -560,13 +628,6 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
                         raise errors.UserTypeError.from_ctx(
                             ctx, str(ex), traceback=traceback
                         ) from ex
-
-            for param, ctxs in self._promised_params.items():
-                for ctx in ctxs:
-                    with ex_acc.collect():
-                        raise errors.UserKeyError.from_ctx(
-                            ctx, f"Attribute `{param}` referenced, but never assigned"
-                        )
 
     @property
     def _current_node(self) -> L.Node:
@@ -993,6 +1054,8 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
         if assignable_ctx.literal_physical() or assignable_ctx.arithmetic_expression():
             unit = HasUnit.get_units(value)
             if provided_unit := self._try_get_unit_from_type_info(ctx.type_info()):
+                # TODO: handle this in _ensure_param with better error
+                # e.g ... with existing units declared here: ...
                 if not provided_unit.is_compatible_with(unit):
                     raise errors.UserIncompatibleUnitError.from_ctx(
                         ctx,
@@ -1000,9 +1063,17 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
                         f" with explicit units ({provided_unit}).",
                         traceback=self.get_traceback(),
                     )
+                self._handleParameterDeclaration(assigned_ref, provided_unit, ctx)
 
             param = self._ensure_param(target, assigned_name, unit, ctx)
-            self._param_assignments[param] = (value, ctx, self.get_traceback())
+            self._param_assignments[param].append(
+                _ParameterDefinition(
+                    ref=assigned_ref,
+                    value=value,
+                    ctx=ctx,
+                    traceback=self.get_traceback(),
+                )
+            )
 
         elif assignable_ctx.string() or assignable_ctx.boolean_():
             # Check if it's a property or attribute that can be set
@@ -1700,6 +1771,36 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
         suppression_warning="Suppressing further warnings of this type",
     )
 
+    def _handleParameterDeclaration(
+        self, ref: Ref, unit: UnitType, ctx: ParserRuleContext
+    ):
+        assert unit is not None, "Type info should be enforced by the parser"
+        name = ref[-1]
+        param = self._ensure_param(self._current_node, name, unit, ctx)
+        if param in self._param_assignments:
+            declaration_after_definition = any(
+                assignment.is_definition
+                for assignment in self._param_assignments[param]
+            )
+            with downgrade(errors.UserKeyError), self._suppressor_visitDeclaration_stmt:
+                if declaration_after_definition:
+                    raise errors.UserKeyError.from_ctx(
+                        ctx,
+                        f"Ignoring declaration of `{name}` "
+                        "because it's already defined",
+                        traceback=self.get_traceback(),
+                    )
+                else:
+                    raise errors.UserKeyError.from_ctx(
+                        ctx,
+                        f"Ignoring redeclaration of `{name}`",
+                        traceback=self.get_traceback(),
+                    )
+        else:
+            self._param_assignments[param].append(
+                _ParameterDefinition(ref=ref, ctx=ctx, traceback=self.get_traceback())
+            )
+
     def visitDeclaration_stmt(self, ctx: ap.Declaration_stmtContext):
         """Handle declaration statements."""
         assigned_value_ref = self.visitName_or_attr(ctx.name_or_attr())
@@ -1710,23 +1811,13 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
                 traceback=self.get_traceback(),
             )
 
-        assigned_name = assigned_value_ref[0]
+        # check declaration type
         unit = self._try_get_unit_from_type_info(ctx.type_info())
-        assert unit is not None, "Type info should be enforced by the parser"
+        if unit is not None:
+            self._handleParameterDeclaration(assigned_value_ref, unit, ctx)
+            return NOTHING
 
-        param = self._ensure_param(self._current_node, assigned_name, unit, ctx)
-        if param in self._param_assignments:
-            with downgrade(errors.UserKeyError), self._suppressor_visitDeclaration_stmt:
-                raise errors.UserKeyError.from_ctx(
-                    ctx,
-                    f"Ignoring declaration of `{assigned_name}` "
-                    "because it's already defined",
-                    traceback=self.get_traceback(),
-                )
-        else:
-            self._param_assignments[param] = (None, ctx, self.get_traceback())
-
-        return NOTHING
+        assert False, "Only parameter declarations supported"
 
     def visitPass_stmt(self, ctx: ap.Pass_stmtContext):
         return NOTHING

--- a/src/faebryk/libs/picker/api/picker_lib.py
+++ b/src/faebryk/libs/picker/api/picker_lib.py
@@ -36,7 +36,11 @@ from faebryk.libs.picker.lcsc import (
     check_attachable,
     get_raw,
 )
-from faebryk.libs.picker.picker import MultiPickError, PickError
+from faebryk.libs.picker.picker import (
+    MultiPickError,
+    PickError,
+    does_not_require_picker_check,
+)
 from faebryk.libs.sets.sets import P_Set
 from faebryk.libs.util import Tree, groupby, not_none
 
@@ -303,7 +307,11 @@ def get_compatible_parameters(
             c_range = param.domain.unbounded(param)
         return param, c_range
 
-    param_mapping = [_map_param(name, param) for name, param in design_params.items()]
+    param_mapping = [
+        _map_param(name, param)
+        for name, param in design_params.items()
+        if not param.has_trait(does_not_require_picker_check)
+    ]
 
     # check for any param that has few supersets whether the component's range
     # is compatible already instead of waiting for the solver

--- a/src/faebryk/libs/picker/picker.py
+++ b/src/faebryk/libs/picker/picker.py
@@ -144,6 +144,10 @@ class PickErrorParams(PickError):
         super().__init__(message, module)
 
 
+class does_not_require_picker_check(Parameter.TraitT.decless()):
+    pass
+
+
 def pick_module_by_params(
     module: Module, solver: Solver, options: Iterable[PickerOption]
 ):

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -1533,6 +1533,23 @@ def partition(pred, iterable):  # type: ignore
     return p(pred, iterable)
 
 
+@overload
+def partition_as_list[Y, T](
+    pred: Callable[[T], TypeGuard[Y]], iterable: Iterable[T]
+) -> tuple[list[T], list[Y]]: ...
+
+
+@overload
+def partition_as_list[T](
+    pred: Callable[[T], bool], iterable: Iterable[T]
+) -> tuple[list[T], list[T]]: ...
+
+
+def partition_as_list(pred, iterable):  # type: ignore
+    false_list, true_list = partition(pred, iterable)
+    return list(false_list), list(true_list)
+
+
 def times_out(seconds: float):
     # if running in debugger, don't timeout
     if hasattr(sys, "gettrace") and sys.gettrace():


### PR DESCRIPTION
# Ato: Support modules as parts

- Differentiate external and root assignments to a parameter
- Special case root assignments in a part module

Depends on #933
