### PR TITLE
Add `gnd` shim to `I2C`

### DIFF
--- a/src/atopile/attributes.py
+++ b/src/atopile/attributes.py
@@ -505,4 +505,10 @@ class Power(F.ElectricPower):
         return self.max_current
 
 
-_register_shim("generics/interfaces.ato:I2C", "import I2C")(F.I2C)
+@_register_shim("generics/interfaces.ato:I2C", "import I2C")
+class I2C(F.I2C):
+    """Temporary shim to translate I2C interfaces."""
+
+    @property
+    def gnd(self):
+        return self.single_electric_reference.get_reference().gnd

--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -679,6 +679,8 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
                             + ", ".join(f"`{p}`" for p in gospel_params)
                         )
 
+        self._param_assignments.clear()
+
     @property
     def _current_node(self) -> L.Node:
         return self._node_stack[-1]

--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -635,9 +635,11 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
                         # TODO: consider a warning for definitions that aren't purely
                         # narrowing
                         if is_part_module and non_root_definitions:
-                            raise errors.UserNotImplementedError(
+                            raise errors.UserNotImplementedError.from_ctx(
+                                last(non_root_definitions).ctx,
                                 "You can't assign to a `component` with a specific"
-                                " part number outside of its definition"
+                                " part number outside of its definition",
+                                traceback=last(non_root_definitions).traceback,
                             )
 
                         elif is_part_module and root_definitions:

--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -76,7 +76,6 @@ from faebryk.libs.util import (
     import_from_path,
     is_type_pair,
     not_none,
-    partition,
     partition_as_list,
 )
 
@@ -582,7 +581,7 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
             errors._BaseBaseUserException, SkipPriorFailedException
         ) as ex_acc:
             # Handle missing definitions
-            params_without_defitions, params_with_definitions = partition(
+            params_without_defitions, params_with_definitions = partition_as_list(
                 lambda p: any(a.is_definition for a in self._param_assignments[p]),
                 self._param_assignments,
             )

--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -525,6 +525,8 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
         }
 
     def _build(self, context: Context, ref: Ref) -> L.Node:
+        self._assert_is_reset()
+
         if ref not in context.refs:
             raise errors.UserKeyError.from_ctx(
                 context.scope_ctx, f"No declaration of `{ref}` in {context.file_path}"
@@ -543,6 +545,14 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
             raise errors.UserException("Build failed")
         finally:
             self._finish()
+
+    def _assert_is_reset(self):
+        """
+        Make sure caches that aren't intended to be shared between builds are empty.
+        """
+        assert not self._node_stack
+        assert not self._traceback_stack
+        assert not self._param_assignments
 
     # TODO: @v0.4 remove this deprecated import form
     _suppressor_finish = suppress_after_count(


### PR DESCRIPTION
This remains incomplete, because `has_single_electric_reference` provides no mechanism for `ato` to readily get the reference. I believe this needs to be addressed considering https://github.com/atopile/atopile/discussions/921