### PR TITLE
Fix #935 - `ato build <entry addr>`

### DIFF
--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -150,7 +150,7 @@ def _find_project_config_file(start: Path) -> Path | None:
     path = start
     while not (path / PROJECT_CONFIG_FILENAME).exists():
         path = path.parent
-        if path == path.root:
+        if path == path.parent:
             return None
 
     return path.resolve().absolute() / PROJECT_CONFIG_FILENAME


### PR DESCRIPTION
This worked before when you pointed at the root dir, but not when code was in a subdirectory.

We're now searching parents for the `ato.yaml` config file as well