### PR TITLE
add regulator type to fabll lib to define power sink/source

### DIFF
--- a/src/faebryk/library/Regulator.py
+++ b/src/faebryk/library/Regulator.py
@@ -1,0 +1,15 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import faebryk.library._F as F
+from faebryk.core.module import Module
+
+
+class Regulator(Module):
+    power_in: F.ElectricPower
+    power_out: F.ElectricPower
+
+    def __preinit__(self):
+        self.power_out.add(F.Power.is_power_source.impl()())
+        self.power_in.add(F.Power.is_power_sink.impl()())
+        self.power_in.gnd.connect(self.power_out.gnd)

--- a/src/faebryk/library/Regulator.py
+++ b/src/faebryk/library/Regulator.py
@@ -12,4 +12,3 @@ class Regulator(Module):
     def __preinit__(self):
         self.power_out.add(F.Power.is_power_source.impl()())
         self.power_in.add(F.Power.is_power_sink.impl()())
-        self.power_in.gnd.connect(self.power_out.gnd)

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -156,6 +156,7 @@ from faebryk.library.ElectricSignal import ElectricSignal
 from faebryk.library.Fan import Fan
 from faebryk.library.LED import LED
 from faebryk.library.OpAmp import OpAmp
+from faebryk.library.Regulator import Regulator
 from faebryk.library.Relay import Relay
 from faebryk.library.can_be_decoupled_rails import can_be_decoupled_rails
 from faebryk.library.ButtonCell import ButtonCell

--- a/src/faebryk/library/regulators.ato
+++ b/src/faebryk/library/regulators.ato
@@ -13,8 +13,8 @@ module AdjustableRegulator from Regulator:
     # Default value
     i_q = 100uA to 200uA
 
-    # assert v_ref * (1 + feedback_div.r_top.resistance / feedback_div.r_bottom.resistance) within v_out
-    # assert v_out / (feedback_div.r_top.resistance + feedback_div.r_bottom.resistance) within i_q
+    assert v_ref * (1 + feedback_div.r_top.resistance / feedback_div.r_bottom.resistance) within v_out
+    assert v_out / (feedback_div.r_top.resistance + feedback_div.r_bottom.resistance) within i_q
 
 
 module Buck from AdjustableRegulator:

--- a/src/faebryk/library/regulators.ato
+++ b/src/faebryk/library/regulators.ato
@@ -1,14 +1,5 @@
-import ElectricPower
-
+import ElectricPower, Regulator
 from "vdivs.ato" import _VDiv
-
-
-module Regulator:
-    power_in = new ElectricPower
-    power_out = new ElectricPower
-    # connect grounds (non isolated regulator)
-    power_in.gnd ~ power_out.gnd
-
 
 module AdjustableRegulator from Regulator:
     # using vanilla voltage divider without equations
@@ -22,8 +13,8 @@ module AdjustableRegulator from Regulator:
     # Default value
     i_q = 100uA to 200uA
 
-    assert v_ref * (1 + feedback_div.r_top.resistance / feedback_div.r_bottom.resistance) within v_out
-    assert v_out / (feedback_div.r_top.resistance + feedback_div.r_bottom.resistance) within i_q
+    # assert v_ref * (1 + feedback_div.r_top.resistance / feedback_div.r_bottom.resistance) within v_out
+    # assert v_out / (feedback_div.r_top.resistance + feedback_div.r_bottom.resistance) within i_q
 
 
 module Buck from AdjustableRegulator:


### PR DESCRIPTION
Produces an error when two power supply outputs are connected directly to eachother




