### PR TITLE
More literal folding testing

### DIFF
--- a/src/faebryk/libs/sets/numeric_sets.py
+++ b/src/faebryk/libs/sets/numeric_sets.py
@@ -45,7 +45,7 @@ class Numeric_Interval(Numeric_Set[NumericT]):
     def __init__(self, min: NumericT, max: NumericT):
         if not min <= max:
             raise ValueError("min must be less than or equal to max")
-        if (min == float("inf") or max == float("-inf")) and min != max:
+        if min == float("inf") or max == float("-inf"):
             raise ValueError("min or max has bad infinite value")
         self._min = min
         self._max = max

--- a/src/faebryk/libs/sets/numeric_sets.py
+++ b/src/faebryk/libs/sets/numeric_sets.py
@@ -45,7 +45,7 @@ class Numeric_Interval(Numeric_Set[NumericT]):
     def __init__(self, min: NumericT, max: NumericT):
         if not min <= max:
             raise ValueError("min must be less than or equal to max")
-        if min == float("inf") or max == float("-inf"):
+        if (min == float("inf") or max == float("-inf")) and min != max:
             raise ValueError("min or max has bad infinite value")
         self._min = min
         self._max = max

--- a/src/faebryk/libs/sets/quantity_sets.py
+++ b/src/faebryk/libs/sets/quantity_sets.py
@@ -335,6 +335,10 @@ class Quantity_Singleton(Quantity_Interval):
     """
 
     def __init__(self, value: QuantityLike):
+        # FIXME: handle inf Quantity too
+        if value == float("inf") or value == float("-inf"):
+            raise ValueError("value cannot be infinity for quantity singleton")
+
         super().__init__(min=value, max=value)
 
     def get_value(self) -> Quantity:

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -165,11 +165,13 @@ class st_values(Namespace):
         st.integers(min_value=int(-1e12), max_value=int(1e12)),
         st.floats(
             allow_nan=False,
-            allow_infinity=False,  # FIXME
+            allow_infinity=False,
             min_value=-1e12,
             max_value=1e12,
             allow_subnormal=False,
         ),
+        st.just(float("inf")),
+        st.just(float("-inf")),
     )
 
     small_numeric = st.one_of(

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -170,8 +170,6 @@ class st_values(Namespace):
             max_value=1e12,
             allow_subnormal=False,
         ),
-        st.just(float("inf")),
-        st.just(float("-inf")),
     )
 
     small_numeric = st.one_of(
@@ -182,7 +180,11 @@ class st_values(Namespace):
     )
 
     ranges = st.builds(
-        lambda values: Range(*sorted(values)), st.tuples(numeric, numeric)
+        lambda values: Range(*sorted(values)),
+        st.tuples(
+            st.one_of(st.just(float("-inf")), numeric),
+            st.one_of(st.just(float("inf")), numeric),
+        ),
     )
 
     small_ranges = st.builds(


### PR DESCRIPTION
@iopapamanoglou wanted to see how far the fuzzer made it with `inf` and `-inf` in it. The answer wasn't very far at all!

6c5953db68b3a8ea0e912a3171bb7f8270c60e55 adds the testing
978c3c80fd12e0d46f347e7658a1364603a2f52f adds a plausible, but perhaps ill-considered upgrade to numerics to support it. Can obviously be ignored / overriden