### PR TITLE
Simplify regression test project builds

### DIFF
--- a/test/test_regressions.py
+++ b/test/test_regressions.py
@@ -24,7 +24,7 @@ class BuildError(Exception):
     """Failed to build the project."""
 
 
-def build_project(prj_path: Path, env: dict[str, str], request: pytest.FixtureRequest):
+def build_project(prj_path: Path, request: pytest.FixtureRequest):
     """Generically "build" the project."""
     friendly_node_name = pathvalidate.sanitize_filename(str(request.node.name))
     artifact_dir = _repo_root() / "artifacts"
@@ -39,6 +39,8 @@ def build_project(prj_path: Path, env: dict[str, str], request: pytest.FixtureRe
                 "--html",
                 "-o",
                 profile_path,
+                "-i",
+                "0.01",
                 "-m",
                 "atopile",
                 "-v",
@@ -46,7 +48,7 @@ def build_project(prj_path: Path, env: dict[str, str], request: pytest.FixtureRe
                 "--keep-picked-parts",
                 "--keep-net-names",
             ],
-            env={**os.environ, "NONINTERACTIVE": "1", **env},
+            env={**os.environ, "NONINTERACTIVE": "1"},
             cwd=prj_path,
             stdout=print,
             stderr=print,
@@ -65,39 +67,21 @@ def build_project(prj_path: Path, env: dict[str, str], request: pytest.FixtureRe
 @pytest.mark.slow
 @pytest.mark.regression
 @pytest.mark.parametrize(
-    "repo_uri, env",
+    "repo_uri",
     [
-        ("https://github.com/atopile/spin-servo-drive", {}),
-        ("https://github.com/atopile/esp32-s3", {}),
-        # ("https://github.com/atopile/nonos", {}), # Removing from critical path
-        (
-            "https://github.com/atopile/cell-sim",
-            {
-                # TODO: @lazy-mifs remove this
-                "FBRK_MAX_PATHS": "1e7",
-                "FBRK_MAX_PATHS_NO_WEAK": "1e6",
-                "FBRK_MAX_PATHS_NO_NEW_WEAK": "1e5",
-            },
-        ),
-        (
-            "https://github.com/atopile/hil",
-            {
-                # TODO: @lazy-mifs remove this
-                "FBRK_MAX_PATHS": "1e7",
-                "FBRK_MAX_PATHS_NO_WEAK": "1e6",
-                "FBRK_MAX_PATHS_NO_NEW_WEAK": "1e5",
-            },
-        ),
-        ("https://github.com/atopile/rp2040", {}),
-        ("https://github.com/atopile/tca9548apwr", {}),
-        ("https://github.com/atopile/nau7802", {}),
-        ("https://github.com/atopile/lv2842xlvddcr", {}),
-        ("https://github.com/atopile/bq24045dsqr", {}),
+        ("https://github.com/atopile/spin-servo-drive"),
+        ("https://github.com/atopile/esp32-s3"),
+        ("https://github.com/atopile/cell-sim",),
+        ("https://github.com/atopile/hil",),
+        ("https://github.com/atopile/rp2040"),
+        ("https://github.com/atopile/tca9548apwr"),
+        ("https://github.com/atopile/nau7802"),
+        ("https://github.com/atopile/lv2842xlvddcr"),
+        ("https://github.com/atopile/bq24045dsqr"),
     ],
 )
 def test_projects(
     repo_uri: str,
-    env: dict[str, str],
     tmp_path: Path,
     request: pytest.FixtureRequest,
 ):
@@ -119,7 +103,7 @@ def test_projects(
     try:
         run_live(
             [sys.executable, "-m", "atopile", "-v", "install"],
-            env={**os.environ, "NONINTERACTIVE": "1", **env},
+            env={**os.environ, "NONINTERACTIVE": "1"},
             cwd=prj_path,
             stdout=print,
             stderr=print,
@@ -128,7 +112,7 @@ def test_projects(
         # Translate the error message to clearly distinguish from clone errors
         raise InstallError from ex
 
-    build_project(prj_path, env, request=request)
+    build_project(prj_path, request=request)
 
     repo = git.Repo(prj_path)
     if any(item.a_path.endswith(".kicad_pcb") for item in repo.index.diff(None)):


### PR DESCRIPTION
- Increase instrumentation interval for profiling to 10ms (from 1ms)
- Remove environment-specific parameters from test_projects