### PR TITLE
Core: Solver: More literal folding 2

### DIFF
--- a/src/faebryk/core/parameter.py
+++ b/src/faebryk/core/parameter.py
@@ -496,6 +496,7 @@ class ParameterOperatable(Node):
             return po.depth()
         return 0
 
+    @once
     def _get_lit_suffix(self) -> str:
         out = ""
         try:
@@ -769,7 +770,8 @@ class Expression(ParameterOperatable):
             if self._solver_terminated:
                 symbol_suffix += "!"
         symbol += symbol_suffix
-        symbol += self._get_lit_suffix()
+        lit_suffix = self._get_lit_suffix()
+        symbol += lit_suffix
 
         def format_operand(op):
             if not isinstance(op, ParameterOperatable):
@@ -797,6 +799,11 @@ class Expression(ParameterOperatable):
                 out = f"({', '.join(formatted_operands)}){symbol}"
         elif len(formatted_operands) == 1:
             out = f"{type(self).__name__}{symbol_suffix}({formatted_operands[0]})"
+        elif lit_suffix and len(formatted_operands) > 2:
+            out = (
+                f"{type(self).__name__}{symbol_suffix}{lit_suffix}"
+                f"({', '.join(formatted_operands)})"
+            )
         elif style.placement == Expression.ReprStyle.Placement.INFIX:
             symbol = f" {symbol} "
             out = f"{symbol.join(formatted_operands)}"

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -606,35 +606,35 @@ def predicate_unconstrained_operands_deduce(mutator: Mutator):
 
 
 # TODO: some kind of aliased singleton stuff for constrained/is/ss exprs
-def _todo(mutator: Mutator):
-    exprs = mutator.nodes_of_types(
-        (Is, IsSubset), sort_by_depth=True, include_terminated=False
-    )
-    exprs = cast(list[Is | IsSubset], exprs)
-    for e in exprs:
-        if not e.constrained:
-            continue
-        if not any(is_constrained(op) for op in e.operatable_operands):
-            continue
-
-    #    # Avoid creating True is/ss! True
-    #    if (
-    #        isinstance(e, (IsSubset, Is))
-    #        and e.constrained
-    #        and isinstance(e.operands[0], ConstrainableExpression)
-    #    ):
-    #        # if set(ops) == {BoolSet(True)}
-    #        # TODO reconsider terminating operand[0]
-    #        # only valid in specific cases, eg if operand[1] created by subset or is
-    #        # estimation
-    #        ## mutator.predicate_terminate(e.operands[0])
-    #        # mutator.predicate_terminate(e)
-    #        continue
-
-    # Don't make from A is! X -> X is! X
-    # TODO do we have to create A is! X, A is! Y -> X is! Y?
-    # if yes do it somewhere else
-    pass
+# def _todo(mutator: Mutator):
+#     exprs = mutator.nodes_of_types(
+#         (Is, IsSubset), sort_by_depth=True, include_terminated=False
+#     )
+#     exprs = cast(list[Is | IsSubset], exprs)
+#     for e in exprs:
+#         if not e.constrained:
+#             continue
+#         if not any(is_constrained(op) for op in e.operatable_operands):
+#             continue
+#
+#     #    # Avoid creating True is/ss! True
+#     #    if (
+#     #        isinstance(e, (IsSubset, Is))
+#     #        and e.constrained
+#     #        and isinstance(e.operands[0], ConstrainableExpression)
+#     #    ):
+#     #        # if set(ops) == {BoolSet(True)}
+#     #        # TODO reconsider terminating operand[0]
+#     #        # only valid in specific cases, eg if operand[1] created by subset or is
+#     #        # estimation
+#     #        ## mutator.predicate_terminate(e.operands[0])
+#     #        # mutator.predicate_terminate(e)
+#     #        continue
+#
+#     # Don't make from A is! X -> X is! X
+#     # TODO do we have to create A is! X, A is! Y -> X is! Y?
+#     # if yes do it somewhere else
+#     pass
 
 
 @algorithm("Convert aliased singletons into literals")

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -83,6 +83,17 @@ if S_LOG:
 # TODO: mark destructive=False where applicable
 
 
+@algorithm("Check literal contradiction")
+def check_literal_contradiction(mutator: Mutator):
+    """
+    Check if a literal is contradictory
+    """
+
+    lit_mappings = mutator.get_literal_mappings(new_only=False, allow_subset=True)
+    for op in lit_mappings:
+        try_extract_literal(op, allow_subset=True)
+
+
 @algorithm("Convert inequality with literal to subset")
 def convert_inequality_with_literal_to_subset(mutator: Mutator):
     # TODO if not! A <= x it can be replaced by A intersect [-inf, a] is {}

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -150,10 +150,12 @@ def remove_congruent_expressions(mutator: Mutator):
     # No (Automatic): X1 = A + C, X2 = A + B, C ~ B -> X1 ~ X2
 
     all_exprs = mutator.nodes_of_type(Expression, sort_by_depth=True)
-    exprs_by_type = groupby(all_exprs, type)
+    exprs_by_type = groupby(all_exprs, lambda e: (type(e), len(e.operands)))
     full_eq = EquivalenceClasses[Expression](all_exprs)
 
     for exprs in exprs_by_type.values():
+        # optimization: can't be congruent if they have uncorrelated literals
+        exprs = [e for e in exprs if not e.get_uncorrelatable_literals()]
         if len(exprs) <= 1:
             continue
         # TODO use hash to speed up comparisons

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -498,7 +498,11 @@ def upper_estimation_of_expressions_with_subsets(mutator: Mutator):
         # no point in op! ss op! (always true)
         if isinstance(expr, ConstrainableExpression) and expr.constrained:
             mutator.create_expression(
-                type(expr), *operands, constrain=True, allow_uncorrelated=True
+                type(expr),
+                *operands,
+                constrain=True,
+                allow_uncorrelated=True,
+                from_ops=[expr],
             )
             continue
 
@@ -890,7 +894,11 @@ def uncorrelated_alias_fold(mutator: Mutator):
         # no point in op! is op! (always true)
         if isinstance(expr, ConstrainableExpression) and expr.constrained:
             mutator.create_expression(
-                type(expr), *operands, constrain=True, allow_uncorrelated=True
+                type(expr),
+                *operands,
+                constrain=True,
+                allow_uncorrelated=True,
+                from_ops=[expr],
             )
             continue
 

--- a/src/faebryk/core/solver/analytical.py
+++ b/src/faebryk/core/solver/analytical.py
@@ -937,6 +937,7 @@ def upper_estimation_of_expressions_with_subsets(mutator: Mutator):
 
     exprs = {e for alias in new_exprs.keys() for e in alias.get_operations()}
     exprs.update(mutator.mutated_since_last_run)
+    exprs = ParameterOperatable.sort_by_depth(exprs, ascending=True)
 
     for expr in exprs:
         assert isinstance(expr, CanonicalExpression)
@@ -990,6 +991,7 @@ def uncorrelated_alias_fold(mutator: Mutator):
     }
     # Include mutated since last run
     exprs.update(mutator.mutated_since_last_run)
+    exprs = ParameterOperatable.sort_by_depth(exprs, ascending=True)
 
     for expr in exprs:
         assert isinstance(expr, CanonicalExpression)

--- a/src/faebryk/core/solver/canonical.py
+++ b/src/faebryk/core/solver/canonical.py
@@ -66,7 +66,6 @@ NumericLiteralR = (*QuantityLikeR, Quantity_Interval_Disjoint, Quantity_Interval
 def constrain_within_domain(mutator: Mutator):
     """
     Translate domain and within constraints to parameter constraints.
-    Alias predicates to True since we need to assume they are true.
     """
 
     for param in mutator.nodes_of_type(Parameter):
@@ -80,6 +79,13 @@ def constrain_within_domain(mutator: Mutator):
                 mutator,
                 from_ops=[param],
             )
+
+
+@algorithm("Alias predicates to true", single=True, destructive=False)
+def alias_predicates_to_true(mutator: Mutator):
+    """
+    Alias predicates to True since we need to assume they are true.
+    """
 
     for predicate in mutator.nodes_of_type(ConstrainableExpression):
         if predicate.constrained:

--- a/src/faebryk/core/solver/defaultsolver.py
+++ b/src/faebryk/core/solver/defaultsolver.py
@@ -87,8 +87,8 @@ class DefaultSolver(Solver):
             analytical.transitive_subset,
             analytical.isolate_lone_params,
             analytical.remove_empty_graphs,
-            analytical.upper_estimation_of_expressions_with_subsets,
             analytical.uncorrelated_alias_fold,
+            analytical.upper_estimation_of_expressions_with_subsets,
         ],
     )
 

--- a/src/faebryk/core/solver/defaultsolver.py
+++ b/src/faebryk/core/solver/defaultsolver.py
@@ -183,7 +183,9 @@ class DefaultSolver(Solver):
                 iteration_repr_maps.append(algo_result.repr_map)
                 # append to per-algo iteration repr_map
                 assert algo_result.repr_map
-                for reprs in data.repr_since_last_iteration.values():
+                for _algo, reprs in data.repr_since_last_iteration.items():
+                    if _algo is algo:
+                        continue
                     for old_s, old_d in list(reprs.items()):
                         new_d = algo_result.repr_map.get(old_d)
                         if new_d is None:

--- a/src/faebryk/core/solver/defaultsolver.py
+++ b/src/faebryk/core/solver/defaultsolver.py
@@ -66,6 +66,7 @@ class DefaultSolver(Solver):
             canonical.alias_predicates_to_true,
         ],
         iterative=[
+            analytical.check_literal_contradiction,
             analytical.remove_unconstrained,
             analytical.convert_operable_aliased_to_single_into_literal,
             analytical.resolve_alias_classes,

--- a/src/faebryk/core/solver/defaultsolver.py
+++ b/src/faebryk/core/solver/defaultsolver.py
@@ -63,6 +63,7 @@ class DefaultSolver(Solver):
             canonical.convert_to_canonical_literals,
             canonical.convert_to_canonical_operations,
             canonical.constrain_within_domain,
+            canonical.alias_predicates_to_true,
         ],
         iterative=[
             analytical.remove_unconstrained,

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -321,8 +321,9 @@ class Mutator:
     ) -> T:
         if self.has_been_mutated(current):
             copy = self.get_mutated(current)
-            exps = copy.get_operations()
-            assert all(isinstance(o, (Is, IsSubset)) and o.constrained for o in exps)
+            exps = copy.get_operations()  # noqa: F841
+            # FIXME: reenable, but alias classes need to take this into account
+            # assert all(isinstance(o, (Is, IsSubset)) and o.constrained for o in exps)
 
         self.transformations.soft_replaced[current] = new
         return self.get_copy(current, accept_soft=False)  # type: ignore

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -38,6 +38,7 @@ from faebryk.core.solver.utils import (
     get_graphs,
     get_supersets,
     is_alias_is_literal,
+    is_subset_literal,
     make_if_doesnt_exist,
     make_lit,
     try_extract_literal,
@@ -898,17 +899,7 @@ class Mutator:
                 nodes = [
                     n
                     for n in pre_nodes
-                    if not (
-                        isinstance(n, (Is, IsSubset))
-                        and n.constrained
-                        and n._solver_terminated
-                        and (
-                            # A is/ss Lit
-                            n.get_literal_operands()
-                            # A is/ss A
-                            or n.operands[0] is n.operands[1]
-                        )
-                    )
+                    if not (is_alias_is_literal(n) or is_subset_literal(n))
                 ]
             out = ""
             node_by_depth = groupby(nodes, key=ParameterOperatable.get_depth)

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -43,6 +43,7 @@ from faebryk.core.solver.utils import (
     try_extract_literal,
 )
 from faebryk.libs.exceptions import downgrade
+from faebryk.libs.logging import TERMINAL_WIDTH
 from faebryk.libs.sets.quantity_sets import (
     Quantity_Interval,
     Quantity_Interval_Disjoint,
@@ -863,7 +864,12 @@ class Mutator:
             rows.sort(key=lambda r: tuple(r))
             for row in rows:
                 table.add_row(*row)
-            console = Console(record=True, width=80, file=io.StringIO())
+
+            console = Console(
+                record=True,
+                width=int(TERMINAL_WIDTH) - 40,
+                file=io.StringIO(),
+            )
             console.print(table)
             log(console.export_text(styles=True))
 

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -312,6 +312,15 @@ def is_alias_is_literal(po: ParameterOperatable) -> TypeGuard[Is]:
     )
 
 
+def is_subset_literal(po: ParameterOperatable) -> TypeGuard[IsSubset]:
+    return bool(
+        isinstance(po, IsSubset)
+        and po.constrained
+        and is_literal(po.operands[1])
+        and isinstance(po.operands[0], ParameterOperatable)
+    )
+
+
 def alias_is_literal_and_check_predicate_eval(
     expr: ParameterOperatable, value: BoolSet | bool, mutator: "Mutator"
 ):

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -173,7 +173,13 @@ def alias_is_literal(
         if literal in po.get_literal_operands().values():
             return
     out = mutator.create_expression(
-        Is, po, literal, from_ops=from_ops, constrain=True, allow_uncorrelated=True
+        Is,
+        po,
+        literal,
+        from_ops=from_ops,
+        constrain=True,
+        # already checked for uncorrelated lit, op needs to be correlated
+        allow_uncorrelated=False,
     )
     if terminate:
         mutator.predicate_terminate(out)
@@ -213,7 +219,13 @@ def subset_literal(
             return
 
     return mutator.create_expression(
-        IsSubset, po, literal, from_ops=from_ops, constrain=True
+        IsSubset,
+        po,
+        literal,
+        from_ops=from_ops,
+        constrain=True,
+        # already checked for uncorrelated lit, op needs to be correlated
+        allow_uncorrelated=False,
     )
 
 

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -164,6 +164,9 @@ def map_extract_literals(
     out = []
     any_lit = False
     for op in expr.operands:
+        if is_literal(op):
+            out.append(op)
+            continue
         lit = try_extract_literal(op, allow_subset=allow_subset)
         if lit is None:
             out.append(op)

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -240,10 +240,10 @@ def subset_literal(
 
     existing = try_extract_literal(po, allow_subset=True, check_pre_transform=mutator)
     if existing is not None:
-        # if already narrower, no point
-        # if equal, use create_expression for duplicate detection
+        # no point in adding more general subset
         if existing.is_subset_of(literal):  # type: ignore #TODO
             return
+        # other cases handled by intersect subsets algo
 
     return mutator.create_expression(
         IsSubset,

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -7,7 +7,7 @@ import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from functools import wraps
-from itertools import pairwise
+from itertools import combinations
 from statistics import median
 from types import NoneType
 from typing import TYPE_CHECKING, Callable, Iterable, Sequence, TypeGuard, cast
@@ -460,7 +460,7 @@ def get_correlations(
 
     exprs = {o: get_constrained_expressions_involved_in(o, Is) for o in op_set}
     # check disjoint sets
-    for e1, e2 in pairwise(operables):
+    for e1, e2 in combinations(operables, 2):
         if e1 is e2:
             yield e1, e2, exprs[e1].difference(excluded)
         overlap = (exprs[e1] & exprs[e2]).difference(excluded)

--- a/src/faebryk/library/Crystal_Oscillator.py
+++ b/src/faebryk/library/Crystal_Oscillator.py
@@ -31,7 +31,7 @@ class Crystal_Oscillator(Module):
 
     def __preinit__(self):
         for cap in self.capacitors:
-            cap.capacitance.alias_is(self.capacitance)
+            cap.capacitance.constrain_subset(self.capacitance)
 
         self.current_limiting_resistor.allow_removal_if_zero()
 

--- a/src/faebryk/libs/logging.py
+++ b/src/faebryk/libs/logging.py
@@ -2,16 +2,38 @@
 # SPDX-License-Identifier: MIT
 
 import logging
+import os
+import sys
 
 from rich.console import Console
 from rich.highlighter import RegexHighlighter
 from rich.logging import RichHandler
 from rich.theme import Theme
 
-from faebryk.libs.util import ConfigFlag
+from faebryk.libs.util import ConfigFlag, ConfigFlagInt
+
+
+def is_piped_to_file() -> bool:
+    return not sys.stdout.isatty()
+
+
+def get_terminal_width() -> int:
+    if is_piped_to_file():
+        if "COLUMNS" in os.environ:
+            return int(os.environ["COLUMNS"])
+        else:
+            return 240
+    else:
+        return Console().size.width
+
 
 PLOG = ConfigFlag("PLOG", descr="Enable picker debug log")
 FLOG_FMT = ConfigFlag("LOG_FMT", descr="Enable (old) log formatting")
+TERMINAL_WIDTH = ConfigFlagInt(
+    "TERMINAL_WIDTH",
+    default=get_terminal_width(),
+    descr="Width of the terminal",
+)
 
 
 def setup_basic_logging(
@@ -30,6 +52,7 @@ def setup_basic_logging(
                         safe_box=False,
                         theme=theme,
                         force_terminal=True,
+                        width=int(TERMINAL_WIDTH),
                     ),
                     highlighter=NodeHighlighter(),
                 )

--- a/src/faebryk/libs/sets/numeric_sets.py
+++ b/src/faebryk/libs/sets/numeric_sets.py
@@ -74,8 +74,11 @@ class Numeric_Interval(Numeric_Set[NumericT]):
             raise ValueError("min must be less than or equal to max")
         if min == float("inf") or max == float("-inf"):
             raise ValueError("min or max has bad infinite value")
-        self._min = rel_round(float_round(min, ABS_DIGITS), REL_DIGITS)
-        self._max = rel_round(float_round(max, ABS_DIGITS), REL_DIGITS)
+        # FIXME
+        # self._min = rel_round(float_round(min, ABS_DIGITS), REL_DIGITS)
+        # self._max = rel_round(float_round(max, ABS_DIGITS), REL_DIGITS)
+        self._min = float_round(min, ABS_DIGITS)
+        self._max = float_round(max, ABS_DIGITS)
 
     def is_empty(self) -> bool:
         return False

--- a/src/faebryk/libs/sets/numeric_sets.py
+++ b/src/faebryk/libs/sets/numeric_sets.py
@@ -14,11 +14,12 @@ logger = logging.getLogger(__name__)
 
 NumericT = TypeVar("NumericT", int, float, contravariant=False, covariant=False)
 
+REL_DIGITS = 7  # 99.99999% precision
+ABS_DIGITS = 15  # femto
 # math.isclose default is 1e-9
 # numpy default is 1e-5
 # empirically we need <= 1e-8
-EPSILON_REL = 1e-6
-ABS_DIGITS = 15  # femto
+EPSILON_REL = 10 ** -(REL_DIGITS - 1)
 EPSILON_ABS = 10**-ABS_DIGITS
 
 
@@ -31,7 +32,31 @@ def float_round[T](value: T, digits: int = 0) -> T:
     if isinstance(value, float):
         return float(out)  # type: ignore
     assert isinstance(value, int)
-    return out  # type: ignore
+    return int(out)  # type: ignore
+
+
+def rel_round[T](value: T, digits: int = 0) -> T:
+    """ """
+    if not isinstance(value, (float, int)):
+        raise ValueError("value must be a float or int")
+    if digits < 0:
+        raise ValueError("digits must be non-negative")
+
+    if value in [math.inf, -math.inf]:
+        return value  # type: ignore
+    if value == 0:
+        return value  # type: ignore
+
+    a_val = abs(value)
+    if a_val >= 1:
+        magnitude = math.floor(math.log10(a_val)) + 1
+        digits -= magnitude
+
+    out = round(value, digits)
+    if isinstance(value, float):
+        return float(out)  # type: ignore
+    assert isinstance(value, int)
+    return int(out)  # type: ignore
 
 
 # Numeric ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -49,8 +74,8 @@ class Numeric_Interval(Numeric_Set[NumericT]):
             raise ValueError("min must be less than or equal to max")
         if min == float("inf") or max == float("-inf"):
             raise ValueError("min or max has bad infinite value")
-        self._min = float_round(min, ABS_DIGITS)
-        self._max = float_round(max, ABS_DIGITS)
+        self._min = rel_round(float_round(min, ABS_DIGITS), REL_DIGITS)
+        self._max = rel_round(float_round(max, ABS_DIGITS), REL_DIGITS)
 
     def is_empty(self) -> bool:
         return False

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -1851,7 +1851,7 @@ def indented_container(
     recursive: bool = False,
     use_repr: bool = True,
 ) -> str:
-    kvs = obj.items() if isinstance(obj, dict) else enumerate(obj)
+    kvs = obj.items() if isinstance(obj, dict) else list(enumerate(obj))
 
     def format_v(v: Any) -> str:
         if not recursive or not isinstance(v, Iterable) or isinstance(v, str):
@@ -1860,7 +1860,7 @@ def indented_container(
 
     ind = "\n" + "  " * indent_level
     inside = ind.join(f"{k}: {format_v(v)}" for k, v in kvs)
-    if kvs:
+    if len(kvs):
         inside = f"{ind}{inside}\n"
 
     return f"{{{inside}}}"

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -451,6 +451,7 @@ def _track():
     return _track.count
 
 
+@pytest.mark.not_in_ci
 @pytest.mark.xfail(reason="Still finds problems")
 @given(st_exprs.trees)
 @settings(

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -503,15 +503,6 @@ def test_discover_literal_folding(expr: Arithmetic):
 
 @example(
     Divide(
-        Add(
-            Subtract(lit(0), lit(1)),
-            Abs(lit(Range(-inf, inf))),
-        ),
-        lit(1),
-    ),
-)
-@example(
-    Divide(
         Divide(
             Add(Sqrt(lit(2.0)), Subtract(lit(0), lit(0))),
             lit(891895568.0),
@@ -589,8 +580,6 @@ def debug_fix_literal_folding(expr: Arithmetic):
 #        ),
 #        lit(710038921),
 #    )
-
-
 # @example(
 #    Add(
 #        Subtract(lit(-999_999_935_634), lit(-999_999_999_992)),
@@ -598,6 +587,15 @@ def debug_fix_literal_folding(expr: Arithmetic):
 #    )
 # )
 # )
+@example(
+    Divide(
+        Add(
+            Subtract(lit(0), lit(1)),
+            Abs(lit(Range(-inf, inf))),
+        ),
+        lit(1),
+    ),
+)
 @example(
     Add(
         lit(1),

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -373,12 +373,12 @@ def _track():
     if not hasattr(_track, "count"):
         _track.count = 0
     _track.count += 1
-    if _track.count % 10 == 0:
+    if _track.count % 100 == 0:
         print(f"track: {_track.count}")
     return _track.count
 
 
-@pytest.mark.xfail(reason="Still finds problems")
+# @pytest.mark.xfail(reason="Still finds problems")
 @given(st_exprs.trees)
 @settings(
     deadline=None,  # timedelta(milliseconds=1000),
@@ -426,6 +426,8 @@ def test_discover_literal_folding(expr: Arithmetic):
 
 
 # Examples -----------------------------------------------------------------------------
+
+
 # --------------------------------------------------------------------------------------
 @given(st_exprs.trees)
 @settings(
@@ -481,13 +483,27 @@ def debug_fix_literal_folding(expr: Arithmetic):
     input()
 
 
-# FIXME: this example is failing in CI consistently
-# @example(
-#     Add(
-#         Subtract(lit(-999_999_935_634), lit(-999_999_999_992)),
-#         Subtract(lit(-82408), lit(-999_998_999_993)),
-#     )
-# )
+@example(
+    expr=Multiply(
+        Sqrt(Sqrt(lit(2))),
+        Sqrt(Sqrt(lit(2))),
+    )
+)
+@example(
+    Divide(
+        Divide(
+            Sqrt(Add(lit(2))),
+            lit(2),
+        ),
+        lit(710038921),
+    )
+)
+@example(
+    Add(
+        Subtract(lit(-999_999_935_634), lit(-999_999_999_992)),
+        Subtract(lit(-82408), lit(-999_998_999_993)),
+    )
+)
 @example(
     expr=Subtract(
         Round(lit(Range(2, 10))),

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -428,31 +428,6 @@ def test_discover_literal_folding(expr: Arithmetic):
 # Examples -----------------------------------------------------------------------------
 
 
-@example(Subtract(Abs(p(Range(5, 6))), Abs(p(Range(5, 6)))))
-@example(
-    Subtract(
-        Abs(p(Range(-inf, inf))),
-        Abs(p(Range(-inf, inf))),
-    )
-)
-@example(
-    expr=Add(
-        Add(lit(-999_999_950_000)),
-        Subtract(lit(50000), lit(-999_997_650_001)),
-    ),
-)
-@example(
-    expr=Subtract(
-        Add(
-            Add(lit(0)),
-            Subtract(
-                Add(lit(0)),
-                Add(lit(1)),
-            ),
-        ),
-        Add(lit(1)),
-    )
-)
 # --------------------------------------------------------------------------------------
 @given(st_exprs.trees)
 @settings(
@@ -508,25 +483,68 @@ def debug_fix_literal_folding(expr: Arithmetic):
     input()
 
 
+# TODO: rounding
+# @example(
+#    Divide(
+#        Divide(
+#            Sqrt(Add(lit(2))),
+#            lit(2),
+#        ),
+#        lit(710038921),
+#    )
+
+
+# @example(
+#    Add(
+#        Subtract(lit(-999_999_935_634), lit(-999_999_999_992)),
+#        Subtract(lit(-82408), lit(-999_998_999_993)),
+#    )
+# )
+# )
+@example(
+    Add(
+        Sqrt(lit(1)),
+        Abs(lit(Range(-inf, inf))),
+    ),
+)
+@example(
+    expr=Add(
+        Add(lit(-999_999_950_000)),
+        Subtract(lit(50000), lit(-999_997_650_001)),
+    ),
+)
+@example(
+    expr=Subtract(
+        Add(
+            Add(lit(0)),
+            Subtract(
+                Add(lit(0)),
+                Add(lit(1)),
+            ),
+        ),
+        Add(lit(1)),
+    )
+)
+@example(
+    expr=Subtract(
+        Subtract(
+            lit(1),
+            lit(Range(-inf, inf)),
+        ),
+        Add(lit(0)),
+    ),
+)
+@example(
+    Subtract(
+        Abs(p(Range(-inf, inf))),
+        Abs(p(Range(-inf, inf))),
+    )
+)
+@example(Subtract(Abs(p(Range(5, 6))), Abs(p(Range(5, 6)))))
 @example(
     expr=Multiply(
         Sqrt(Sqrt(lit(2))),
         Sqrt(Sqrt(lit(2))),
-    )
-)
-@example(
-    Divide(
-        Divide(
-            Sqrt(Add(lit(2))),
-            lit(2),
-        ),
-        lit(710038921),
-    )
-)
-@example(
-    Add(
-        Subtract(lit(-999_999_935_634), lit(-999_999_999_992)),
-        Subtract(lit(-82408), lit(-999_998_999_993)),
     )
 )
 @example(
@@ -562,12 +580,6 @@ def debug_fix_literal_folding(expr: Arithmetic):
 @example(Multiply(Add(lit(0)), Abs(lit(Range(-inf, inf)))))
 @example(Add(Add(lit(0)), Abs(p(-1))))
 @example(Abs(p(-1)))
-@example(
-    Add(
-        Sqrt(lit(1)),
-        Abs(lit(Range(-inf, inf))),
-    ),
-)
 @example(expr=Round(Add(Abs(lit(0)), Round(lit(-1)))))
 @example(
     expr=Add(

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -428,6 +428,31 @@ def test_discover_literal_folding(expr: Arithmetic):
 # Examples -----------------------------------------------------------------------------
 
 
+@example(Subtract(Abs(p(Range(5, 6))), Abs(p(Range(5, 6)))))
+@example(
+    Subtract(
+        Abs(p(Range(-inf, inf))),
+        Abs(p(Range(-inf, inf))),
+    )
+)
+@example(
+    expr=Add(
+        Add(lit(-999_999_950_000)),
+        Subtract(lit(50000), lit(-999_997_650_001)),
+    ),
+)
+@example(
+    expr=Subtract(
+        Add(
+            Add(lit(0)),
+            Subtract(
+                Add(lit(0)),
+                Add(lit(1)),
+            ),
+        ),
+        Add(lit(1)),
+    )
+)
 # --------------------------------------------------------------------------------------
 @given(st_exprs.trees)
 @settings(
@@ -476,7 +501,7 @@ def debug_fix_literal_folding(expr: Arithmetic):
 
     if not correct:
         logger.error(f"Failing expression: {expr.compact_repr()}")
-        logger.error(f"{solver_result} != {evaluated_expr}")
+        logger.error(f"Solver {solver_result} != {evaluated_expr} Literal")
         input()
         return
     logger.warning("PASSES")

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -123,13 +123,19 @@ class Builders(Namespace):
     Differentiate = operator(Differentiate)
 
 
-ValueT = Quantity_Interval_Disjoint | Parameter
+ValueT = Quantity_Interval_Disjoint | Parameter | Arithmetic
 
 
 class Filters(Namespace):
     @staticmethod
     def _unwrap_param(value: ValueT) -> Quantity_Interval_Disjoint:
-        return value.get_literal() if isinstance(value, Parameter) else value
+        assert isinstance(value, ValueT)
+        if isinstance(value, Parameter):
+            return value.get_literal()
+        elif isinstance(value, Arithmetic):
+            return evaluate_expr(value)
+        else:
+            return value
 
     @staticmethod
     def is_negative(value: ValueT) -> bool:
@@ -166,6 +172,28 @@ class Filters(Namespace):
         return value.is_empty()
 
     @staticmethod
+    def within_limits(value: ValueT) -> bool:
+        value = Filters._unwrap_param(value)
+        return bool(
+            (value.min_elem >= -LIMIT or value.min_elem == -inf)
+            and (value.max_elem <= LIMIT or value.max_elem == inf)
+        )
+
+    @staticmethod
+    def no_op_overflow(
+        op: Callable[[Any, Any], Any],
+    ):
+        def f(values: tuple[ValueT, ValueT]) -> bool:
+            return Filters.within_limits(
+                op(
+                    Filters._unwrap_param(values[0]),
+                    Filters._unwrap_param(values[1]),
+                )
+            )
+
+        return f
+
+    @staticmethod
     def is_valid_for_power(
         pair: tuple[ValueT, ValueT],
     ) -> bool:
@@ -179,25 +207,29 @@ class Filters(Namespace):
         )
 
 
-class st_values(Namespace):
-    numeric = st.one_of(
-        # [pico, tera]
-        st.integers(min_value=int(-1e12), max_value=int(1e12)),
-        st.floats(
-            allow_nan=False,
-            allow_infinity=False,
-            min_value=-1e12,
-            max_value=1e12,
-            allow_subnormal=False,
-        ),
-    )
+LIMIT = 1e4  # Terra/pico or inf
 
-    small_numeric = st.one_of(
-        st.integers(min_value=-100, max_value=100),
-        st.floats(
-            allow_nan=False, allow_infinity=False, min_value=-10.0, max_value=10.0
-        ),
-    )
+
+class st_values(Namespace):
+    @staticmethod
+    def _numbers_with_limit(limit: float):
+        return st.one_of(
+            st.integers(
+                min_value=int(-limit),
+                max_value=int(limit),
+            ),
+            st.floats(
+                allow_nan=False,
+                allow_infinity=False,
+                min_value=-limit,
+                max_value=limit,
+                allow_subnormal=False,
+            ),
+        )
+
+    numeric = _numbers_with_limit(LIMIT)
+
+    small_numeric = _numbers_with_limit(100)
 
     ranges = st.builds(
         lambda values: Range(*sorted(values)),
@@ -231,9 +263,21 @@ class st_values(Namespace):
 
     pairs = st.tuples(values, values)
 
-    division_pairs = st.tuples(values, values.filter(Filters.does_not_cross_zero))
+    @staticmethod
+    def no_overflow_pairs(op: Callable[[Any, Any], Any]):
+        return st.tuples(st_values.values, st_values.values).filter(
+            Filters.no_op_overflow(op)
+        )
 
-    power_pairs = st.tuples(values, small_values).filter(Filters.is_valid_for_power)
+    division_pairs = st.tuples(
+        values, values.filter(Filters.does_not_cross_zero)
+    ).filter(Filters.no_op_overflow(truediv))
+
+    power_pairs = (
+        st.tuples(values, small_values)
+        .filter(Filters.is_valid_for_power)
+        .filter(Filters.no_op_overflow(pow))
+    )
 
 
 class Extension(Namespace):
@@ -242,19 +286,31 @@ class Extension(Namespace):
         return st.tuples(children, children)
 
     @staticmethod
+    def tuples_no_overflow(op: Callable[[Any, Any], Any]):
+        def f(children: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
+            return st.tuples(children, children).filter(Filters.no_op_overflow(op))
+
+        return f
+
+    @staticmethod
     def single(children: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
         return children
 
     @staticmethod
     def tuples_power(children: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
-        return st.tuples(children, st_values.small_values).filter(
-            Filters.is_valid_for_power
+        return (
+            st.tuples(children, st_values.small_values)
+            .filter(Filters.is_valid_for_power)
+            .filter(Filters.no_op_overflow(pow))
         )
 
     @staticmethod
     def tuples_division(children: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
         # TODO: exprs on the right side
-        return st.tuples(children, st_values.values.filter(Filters.does_not_cross_zero))
+        return st.tuples(
+            children,
+            st_values.values.filter(Filters.does_not_cross_zero),
+        ).filter(Filters.no_op_overflow(truediv))
 
     @staticmethod
     def single_positive(children: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
@@ -270,7 +326,11 @@ class ExprType(NamedTuple):
 EXPR_TYPES = [
     ExprType(Builders.Add, st_values.lists, Extension.tuples),
     ExprType(Builders.Subtract, st_values.pairs, Extension.tuples),
-    ExprType(Builders.Multiply, st_values.lists, Extension.tuples),
+    ExprType(
+        Builders.Multiply,
+        st_values.no_overflow_pairs(mul),
+        Extension.tuples_no_overflow(mul),
+    ),
     ExprType(Builders.Divide, st_values.division_pairs, Extension.tuples_division),
     ExprType(Builders.Sqrt, st_values.positive_values, Extension.single_positive),
     # ExprType(Builders.Power, st_values.power_pairs, Extension.tuples_power),
@@ -295,19 +355,19 @@ class st_exprs(Namespace):
         *[st.builds(expr_type.builder, expr_type.strategy) for expr_type in EXPR_TYPES]
     )
 
-    # flat
-    # op1(flat, flat) | flat
-    # op2(op1 | flat, op1 | flat)
-    trees = st.recursive(
-        flat,
-        lambda children: st.one_of(
+    @staticmethod
+    def _extend_tree(children: st.SearchStrategy[Any]) -> st.SearchStrategy[Any]:
+        return st.one_of(
             *[
                 st.builds(expr_type.builder, expr_type.extension_strategy(children))
                 for expr_type in EXPR_TYPES
             ]
-        ),
-        max_leaves=20,
-    )
+        )
+
+    # flat
+    # op1(flat, flat) | flat
+    # op2(op1 | flat, op1 | flat)
+    trees = st.recursive(base=flat, extend=_extend_tree, max_leaves=20)
 
 
 def evaluate_expr(
@@ -428,6 +488,29 @@ def test_discover_literal_folding(expr: Arithmetic):
 # Examples -----------------------------------------------------------------------------
 
 
+@example(
+    Add(
+        lit(1),
+        Abs(
+            Add(p(Range(-inf, inf)), p(Range(-inf, inf))),
+        ),
+    ),
+)
+@example(
+    Divide(
+        Divide(
+            Add(Sqrt(lit(2.0)), Subtract(lit(0), lit(0))),
+            lit(891895568.0),
+        ),
+        lit(2.0),
+    ),
+)
+@example(
+    Subtract(
+        Multiply(lit(-999_992_989_829), lit(-999_992_989_829)),
+        Multiply(lit(-999_991_993_022), lit(-999_991_989_837)),
+    )
+)
 # --------------------------------------------------------------------------------------
 @given(st_exprs.trees)
 @settings(

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -489,14 +489,6 @@ def test_discover_literal_folding(expr: Arithmetic):
 
 
 @example(
-    Add(
-        lit(1),
-        Abs(
-            Add(p(Range(-inf, inf)), p(Range(-inf, inf))),
-        ),
-    ),
-)
-@example(
     Divide(
         Divide(
             Add(Sqrt(lit(2.0)), Subtract(lit(0), lit(0))),
@@ -584,6 +576,14 @@ def debug_fix_literal_folding(expr: Arithmetic):
 #    )
 # )
 # )
+@example(
+    Add(
+        lit(1),
+        Abs(
+            Add(p(Range(-inf, inf)), p(Range(-inf, inf))),
+        ),
+    ),
+)
 @example(
     Add(
         Sqrt(lit(1)),

--- a/test/core/solver/test_literal_folding.py
+++ b/test/core/solver/test_literal_folding.py
@@ -59,6 +59,11 @@ NUM_STAT_EXAMPLES = ConfigFlagInt(
 )
 ENABLE_PROGRESS_TRACKING = ConfigFlag("ST_PROGRESS", default=False)
 
+# TODO set to something reasonable again
+ABS_UPPER_LIMIT = 1e4  # Terra/pico or inf
+ABS_LOWER_LIMIT = 1e-6  # micro
+
+
 # canonical operations:
 # Add, Multiply, Power, Round, Abs, Sin, Log
 # Or, Not
@@ -205,11 +210,6 @@ class Filters(Namespace):
             # TODO enable base crossing zero
             and not (Filters.crosses_zero(base) and Filters.crosses_zero(exp))
         )
-
-
-# TODO set to something reasonable again
-ABS_UPPER_LIMIT = 1e4  # Terra/pico or inf
-ABS_LOWER_LIMIT = 1e-6  # micro
 
 
 class st_values(Namespace):
@@ -451,7 +451,7 @@ def _track():
     return _track.count
 
 
-# @pytest.mark.xfail(reason="Still finds problems")
+@pytest.mark.xfail(reason="Still finds problems")
 @given(st_exprs.trees)
 @settings(
     deadline=None,  # timedelta(milliseconds=1000),
@@ -501,6 +501,22 @@ def test_discover_literal_folding(expr: Arithmetic):
 # Examples -----------------------------------------------------------------------------
 
 
+# TODO: rounding
+@example(
+    Divide(
+        Divide(
+            Sqrt(Add(lit(2))),
+            lit(2),
+        ),
+        lit(710038921),
+    )
+)
+@example(
+    Add(
+        Subtract(lit(-999_999_935_634), lit(-999_999_999_992)),
+        Subtract(lit(-82408), lit(-999_998_999_993)),
+    )
+)
 @example(
     Divide(
         Divide(
@@ -571,22 +587,6 @@ def debug_fix_literal_folding(expr: Arithmetic):
     input()
 
 
-# TODO: rounding
-# @example(
-#    Divide(
-#        Divide(
-#            Sqrt(Add(lit(2))),
-#            lit(2),
-#        ),
-#        lit(710038921),
-#    )
-# @example(
-#    Add(
-#        Subtract(lit(-999_999_935_634), lit(-999_999_999_992)),
-#        Subtract(lit(-82408), lit(-999_998_999_993)),
-#    )
-# )
-# )
 @example(
     Divide(
         Add(

--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -1126,7 +1126,7 @@ def test_ss_intersect():
         (
             [Range(0, 10)],
             [Range(0, 10)],
-            (True, True),
+            (True, False),
         ),
         (
             [Range(0, 10)],

--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -714,6 +714,19 @@ def test_inspect_enum_simple():
     assert solver.inspect_get_known_supersets(A) == F.LED.Color.EMERALD
 
 
+def test_regression_enum_contradiction():
+    A = Parameter(domain=L.Domains.ENUM(F.LED.Color))
+
+    A.constrain_subset(L.EnumSet(F.LED.Color.BLUE, F.LED.Color.RED))
+
+    solver = DefaultSolver()
+    result = solver.assert_any_predicate(
+        [(Is(A, F.LED.Color.EMERALD), None)], lock=False
+    )
+    assert not result.true_predicates
+    assert result.false_predicates
+
+
 def test_inspect_enum_led():
     led = F.LED()
 

--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -455,8 +455,8 @@ def test_literal_folding_add_multiplicative():
 
 
 def test_literal_folding_add_multiplicative_2():
-    A = Parameter(units=dimensionless)
-    B = Parameter(units=dimensionless)
+    A = Parameter()
+    B = Parameter()
 
     expr = (
         A

--- a/test/libs/test_sets.py
+++ b/test/libs/test_sets.py
@@ -11,6 +11,7 @@ from faebryk.libs.sets.numeric_sets import (
     Numeric_Interval,
     Numeric_Interval_Disjoint,
     float_round,
+    rel_round,
 )
 from faebryk.libs.sets.quantity_sets import (
     Quantity_Interval,
@@ -410,3 +411,20 @@ def test_regression_ss_zero():
 def test_round_digits(digits: int, expected: Quantity_Interval_Disjoint):
     x = Quantity_Interval_Disjoint(Quantity_Interval(1.51, 2.42))
     assert round(x, digits) == expected
+
+
+@pytest.mark.parametrize(
+    "value,digits,expected",
+    [
+        (1234.5678, 2, 1200),
+        (1234.5678, 4, 1235),
+        (1234.5678, 6, 1234.57),
+        (1234.5678, 10, 1234.5678),
+        (0.123456, 2, 0.12),
+        (0.123456, 4, 0.1235),
+        (0.123456, 6, 0.123456),
+        (0.123456, 10, 0.123456),
+    ],
+)
+def test_rel_round(value: float | int, digits: int, expected: float | int):
+    assert rel_round(value, digits) == expected


### PR DESCRIPTION
# Core: Solver: More literal folding 2

- configurable console width
- cache compact_repr calls for better perf
- check for none operands in expression
- split out `is_uncorrelatable_literal`
- add `is_congruent_to_factory` as helper
- `check_constrained` flag for congruency check
- fix: check for correlations in pos_congruent
- better printing of infix exprs with lit suffix
- split canonical pred out algo out
- from_ops fold alias/ss
- unique rows print
- cleanup graph logging from ss/is lits
- lits: rel round base code (not in use yet)
- add soft_replace in mutator
- fix alias_lit and subset_lit duplicate detection
- fix ss estimation for logic
- scope singleton alias
- included created in output
- fix ops created in wrong graphs
- more duplicate expr detection
- revert broken mutated_since_last check
- try_extract checks old graphs
- potential improvement of get_correlations
- revert rel rounding for now
- fix indented container if empty
- library: fix xtal osc