### PR TITLE
updated .value to .resistance

### DIFF
--- a/src/faebryk/library/resistors.ato
+++ b/src/faebryk/library/resistors.ato
@@ -7,8 +7,8 @@ module I2CPullup:
     power = new ElectricPower
     i2c = new I2C
 
-    r_sda.value = 10kohm +/- 20%
-    r_scl.value = 10kohm +/- 20%
+    r_sda.resistance = 10kohm +/- 20%
+    r_scl.resistance = 10kohm +/- 20%
 
     r_sda.package = "R0402"
     r_scl.package = "R0402"


### PR DESCRIPTION
.value no longer supported in std library parts, need to use .resistance instead