### PR TITLE
skip bus parameter resolution if skip solving is enabled

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -81,16 +81,19 @@ def build(app: Module) -> None:
     G = app.get_graph()
     solver = _get_solver()
 
-    logger.info("Resolving bus parameters")
-    try:
-        F.is_bus_parameter.resolve_bus_parameters(G)
-    # FIXME: this is a hack around a compiler bug
-    except KeyErrorAmbiguous as ex:
-        raise UserException(
-            "Unfortunately, there's a compiler bug at the moment that means that "
-            "this sometimes fails. Try again, and it'll probably work. "
-            "See https://github.com/atopile/atopile/issues/807"
-        ) from ex
+    if not SKIP_SOLVING:
+        logger.info("Resolving bus parameters")
+        try:
+            F.is_bus_parameter.resolve_bus_parameters(G)
+        # FIXME: this is a hack around a compiler bug
+        except KeyErrorAmbiguous as ex:
+            raise UserException(
+                "Unfortunately, there's a compiler bug at the moment that means that "
+                "this sometimes fails. Try again, and it'll probably work. "
+                "See https://github.com/atopile/atopile/issues/807"
+            ) from ex
+    else:
+        logger.warning("Skipping bus parameter resolution")
 
     logger.info("Running checks")
     run_checks(app, G)


### PR DESCRIPTION
to get large boards to build, both parameter solving and bus params resolution must be disabled, this is a hack to be able to get HIL to build in CI.