### PR TITLE
Faebryk: exporters: PCB: KiCad: Add `hide_all_designators()` method

### DIFF
--- a/src/faebryk/exporters/pcb/kicad/transformer.py
+++ b/src/faebryk/exporters/pcb/kicad/transformer.py
@@ -1303,6 +1303,15 @@ class PCB_Transformer:
         LEFT = auto()
         RIGHT = auto()
 
+    def hide_all_designators(
+        self,
+    ) -> None:
+        for _, fp in self.get_all_footprints():
+            fp.propertys["Reference"].hide = True
+
+            for txt in [txt for txt in fp.fp_texts if txt.text == "${REFERENCE}"]:
+                txt.effects.hide = True
+
     def set_designator_position(
         self,
         offset: float,


### PR DESCRIPTION
# Faebryk: exporters: PCB: KiCad: Add `hide_all_designators()` method

# Description

Add functionality in the KiCad PCB transformer to hide all designators.
Fixes https://github.com/atopile/atopile/issues/1008

# Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] Any dependent changes have been merged and published in downstream modules
