### PR TITLE
Initial support for KiCad 9 file format

### DIFF
--- a/src/faebryk/libs/kicad/fileformats_common.py
+++ b/src/faebryk/libs/kicad/fileformats_common.py
@@ -98,6 +98,7 @@ class C_effects:
     class C_font:
         size: C_wh
         thickness: Optional[float] = None
+        unresolved_font_name: Optional[str] = None
 
     @dataclass
     class C_justify:


### PR DESCRIPTION
# Initial support for KiCad 9 file format

## Description

- Plus adding missing fields from KiCad 8

### TODO

extra:
- [ ] add `pcb` to filenames
- [ ] put changes into `fileformats_pcb_v9.py` and `fileformats_pcb_v8.py`
- [ ] add post init funtions to set values (e.g. `hide` should be set on 2 places)

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
