### PR TITLE
Fix Voltage dividers

### DIFF
--- a/src/faebryk/library/ResistorVoltageDivider.py
+++ b/src/faebryk/library/ResistorVoltageDivider.py
@@ -21,18 +21,20 @@ class ResistorVoltageDivider(Module):
     output.reference.lv ~ node[2]
     """
 
-    r_bottom: F.Resistor
-    r_top: F.Resistor
+    # External interfaces
     power: F.ElectricPower
-    # input: F.ElectricSignal
     output: F.ElectricSignal
 
-    total_resistance = L.p_field(units=P.Ω)
-    ratio = L.p_field(units=P.dimensionless)
-    max_current = L.p_field(units=P.A)
+    # Components
+    r_bottom: F.Resistor
+    r_top: F.Resistor
 
+    # Variables
     v_in = L.p_field(units=P.V)
     v_out = L.p_field(units=P.V)
+    max_current = L.p_field(units=P.A)
+    total_resistance = L.p_field(units=P.Ω)
+    ratio = L.p_field(units=P.dimensionless)
 
     @L.rt_field
     def can_bridge(self):
@@ -44,10 +46,7 @@ class ResistorVoltageDivider(Module):
             [self.r_top, self.output.line, self.r_bottom], self.power.lv
         )
 
-        # self.power.connect(self.input.reference)
-        # self.power.hv.connect(self.input.line)
-
-        # Variables
+        # Short variables
         ratio = self.ratio
         r_total = self.total_resistance
         r_top = self.r_top.resistance
@@ -56,7 +55,7 @@ class ResistorVoltageDivider(Module):
         v_in = self.v_in
         max_current = self.max_current
 
-        # Link variables
+        # Link interface voltages
         v_out.alias_is(self.output.reference.voltage)
         v_in.alias_is(self.power.voltage)
 

--- a/src/faebryk/library/ResistorVoltageDivider.py
+++ b/src/faebryk/library/ResistorVoltageDivider.py
@@ -56,23 +56,18 @@ class ResistorVoltageDivider(Module):
         v_in = self.v_in
         max_current = self.max_current
 
-        # Equations
+        # Link variables
         v_out.alias_is(self.output.reference.voltage)
         v_in.alias_is(self.power.voltage)
-        r_total.alias_is(r_top + r_bottom)
-        ratio.alias_is(r_bottom / r_total)
-        v_out.alias_is(v_in * ratio)
-        ratio.alias_is(v_out / v_in)
-        max_current.alias_is(v_in / r_total)
 
-        # help solver
-        r_top.alias_is(r_total - r_bottom)
-        r_bottom.alias_is(r_total - r_top)
-        r_bottom.alias_is(ratio * r_total)
-        r_total.alias_is(r_bottom / ratio)
-        r_total.alias_is(v_in / max_current)
-        v_in.alias_is(max_current * r_total)
+        # Equations
         r_top.alias_is((v_in / max_current) - r_bottom)
         r_bottom.alias_is((v_in / max_current) - r_top)
         r_top.alias_is((v_in - v_out) / max_current)
         r_bottom.alias_is(v_out / max_current)
+
+        # Calculate outputs
+        r_total.alias_is(r_top + r_bottom)
+        v_out.alias_is(v_in * r_bottom / r_total)
+        max_current.alias_is(v_in / r_total)
+        ratio.alias_is(r_bottom / r_total)

--- a/src/faebryk/library/USB2514B_ReferenceDesign.py
+++ b/src/faebryk/library/USB2514B_ReferenceDesign.py
@@ -260,7 +260,7 @@ class USB2514B_ReferenceDesign(Module):
         ).capacitance.constrain_subset(L.Range.from_center_rel(100 * P.nF, 0.5))
 
         # VBUS detect
-        for r in self.vbus_voltage_divider.resistor:
+        for r in [self.vbus_voltage_divider.r_top, self.vbus_voltage_divider.r_bottom]:
             r.resistance.constrain_subset(L.Range.from_center_rel(100 * P.kohm, 0.01))
 
         # reset
@@ -305,10 +305,8 @@ class USB2514B_ReferenceDesign(Module):
         )  # TODO: replace with pull?
 
         # voltage divider
-        vbus.hv.connect_via(
-            self.vbus_voltage_divider, self.hub_controller.vbus_detect.line
-        )
-        self.vbus_voltage_divider.node[2].connect(vbus.lv)
+        vbus.connect(self.vbus_voltage_divider.power)
+        self.vbus_voltage_divider.output.connect(self.hub_controller.vbus_detect)
 
         # USB upstream
         self.usb_ufp.usb_if.d.connect(self.hub_controller.usb_upstream)

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -137,11 +137,9 @@ from faebryk.library.has_package import has_package
 from faebryk.library.is_surge_protected import is_surge_protected
 from faebryk.library.Common_Mode_Filter import Common_Mode_Filter
 from faebryk.library.Potentiometer import Potentiometer
-from faebryk.library.ResistorVoltageDivider import ResistorVoltageDivider
 from faebryk.library.Capacitor import Capacitor
 from faebryk.library.has_package_requirement import has_package_requirement
 from faebryk.library.is_surge_protected_defined import is_surge_protected_defined
-from faebryk.library.Resistor_Voltage_Divider import Resistor_Voltage_Divider
 from faebryk.library.CapacitorElectrolytic import CapacitorElectrolytic
 from faebryk.library.Crystal_Oscillator import Crystal_Oscillator
 from faebryk.library.MultiCapacitor import MultiCapacitor
@@ -166,6 +164,7 @@ from faebryk.library.ElectricLogic import ElectricLogic
 from faebryk.library.FilterElectricalLC import FilterElectricalLC
 from faebryk.library.FilterElectricalRC import FilterElectricalRC
 from faebryk.library.PowerMux import PowerMux
+from faebryk.library.ResistorVoltageDivider import ResistorVoltageDivider
 from faebryk.library.Shenzhen_Kinghelm_Elec_KH_BNC75_3511 import Shenzhen_Kinghelm_Elec_KH_BNC75_3511
 from faebryk.library.PANASONIC_AQY212EHAX import PANASONIC_AQY212EHAX
 from faebryk.library.PoweredLED import PoweredLED
@@ -195,6 +194,7 @@ from faebryk.library.Wuxi_I_core_Elec_AiP74LVC1T45GB236_TR import Wuxi_I_core_El
 from faebryk.library.XL_3528RGBW_WS2812B import XL_3528RGBW_WS2812B
 from faebryk.library.can_switch_power import can_switch_power
 from faebryk.library.pf_74AHCT2G125 import pf_74AHCT2G125
+from faebryk.library.Resistor_Voltage_Divider import Resistor_Voltage_Divider
 from faebryk.library.TPS2116 import TPS2116
 from faebryk.library.ElecSuper_PSM712_ES import ElecSuper_PSM712_ES
 from faebryk.library.Diodes_Incorporated_AP2552W6_7 import Diodes_Incorporated_AP2552W6_7

--- a/src/faebryk/library/regulators.ato
+++ b/src/faebryk/library/regulators.ato
@@ -1,9 +1,9 @@
 import ElectricPower, Regulator
-from "vdivs.ato" import _VDiv
+from "vdivs.ato" import VDiv
 
 module AdjustableRegulator from Regulator:
     # using vanilla voltage divider without equations
-    feedback_div = new _VDiv
+    feedback_div = new VDiv
     v_ref: voltage
     i_q: current
     r_total: resistance

--- a/src/faebryk/library/vdivs.ato
+++ b/src/faebryk/library/vdivs.ato
@@ -1,47 +1,17 @@
-import Capacitor, Resistor, ElectricSignal, ElectricPower
+import Capacitor, ResistorVoltageDivider, ElectricPower, ElectricSignal
 
+module VDiv:
+    power = new ElectricPower
+    out = new ElectricSignal
+    vdiv = new ResistorVoltageDivider
+    power ~ vdiv.power
+    out ~ vdiv.output
 
-#FIXME: de-duplicate with ResistorVoltageDivider
-module VDiv from _VDiv:
     v_in: voltage
     v_out: voltage
     i_q: current
 
-    i_q = 100uA to 10mA
+    v_in = vdiv.v_in
+    v_out = vdiv.v_out
+    i_q = vdiv.max_current
 
-    assert v_in * r_bottom.resistance / (r_top.resistance + r_bottom.resistance) within v_out
-    assert v_in / (r_bottom.resistance + r_top.resistance) within i_q
-
-
-module _VDiv:
-    signal top
-    signal bottom
-
-    out = new ElectricSignal
-    out.line ~ out
-
-    power = new ElectricPower
-    power.vcc ~ top
-    bottom ~ power.gnd
-    out.reference ~ power
-
-    r_top = new Resistor
-    r_bottom = new Resistor
-    r_top.package = "R0402"
-    r_bottom.package = "R0402"
-
-    top ~ r_top.p1; r_top.p2 ~ r_bottom.p1; r_bottom.p2 ~ bottom
-    r_top.p2 ~ out.line
-
-
-module VDivLowPassFilter from VDiv:
-    cap = new Capacitor
-    cap.package = "C0402"
-    cutoff_frequency: frequency
-
-    out ~ cap.p1; cap.p2 ~ bottom
-    cap.capacitance = 100nF +/- 10%
-
-    cutoff_frequency: frequency
-
-    assert 1 / (2 * 3.14 * r_top.resistance * cap.capacitance) is cutoff_frequency

--- a/src/faebryk/library/vdivs.ato
+++ b/src/faebryk/library/vdivs.ato
@@ -6,6 +6,5 @@ module VDiv from ResistorVoltageDivider:
     out = new ElectricSignal
     out ~ output
 
-    # renaming
     i_q: current
     assert i_q is max_current

--- a/src/faebryk/library/vdivs.ato
+++ b/src/faebryk/library/vdivs.ato
@@ -1,17 +1,10 @@
-import Capacitor, ResistorVoltageDivider, ElectricPower, ElectricSignal
+import ResistorVoltageDivider, ElectricPower, ElectricSignal
 
-module VDiv:
-    power = new ElectricPower
+
+module VDiv from ResistorVoltageDivider:
     out = new ElectricSignal
-    vdiv = new ResistorVoltageDivider
-    power ~ vdiv.power
-    out ~ vdiv.output
 
-    v_in: voltage
-    v_out: voltage
+    out ~ output
+
     i_q: current
-
-    v_in = vdiv.v_in
-    v_out = vdiv.v_out
-    i_q = vdiv.max_current
-
+    i_q = max_current

--- a/src/faebryk/library/vdivs.ato
+++ b/src/faebryk/library/vdivs.ato
@@ -2,9 +2,10 @@ import ResistorVoltageDivider, ElectricPower, ElectricSignal
 
 
 module VDiv from ResistorVoltageDivider:
+    # renaming
     out = new ElectricSignal
-
     out ~ output
 
+    # renaming
     i_q: current
-    i_q = max_current
+    assert i_q is max_current

--- a/src/faebryk/libs/sets/quantity_sets.py
+++ b/src/faebryk/libs/sets/quantity_sets.py
@@ -78,7 +78,7 @@ class Quantity_Set(P_UnitSet[QuantityLike]):
             Quantity, quantity(value, self.interval_units).to(self.units)
         )
 
-    def _format_number(self, number: Number, num_decimals: int = 9) -> str:
+    def _format_number(self, number: Number, num_decimals: int = 3) -> str:
         if self.units.is_compatible_with(dimensionless):
             if math.isinf(number):
                 return "∞" if number > 0 else "-∞"


### PR DESCRIPTION
- Unified voltaged dividers in Fabll and ato with the base definition in ResistorVoltageDivider.py
- Reordered equations a to work within current solver capabilities
- Adds MIFs as a type that can be used in connect_via, helpful to add a connection in-between two components.
- Adds several tests for Vdiv solving