### PR TITLE
Meta: Enable dependabot for `uv`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,6 @@
 version: 2
+enable-beta-ecosystems: true  # required for uv
+
 updates:
   - package-ecosystem: 'github-actions'
     directory: "/"
@@ -7,22 +9,12 @@ updates:
     labels:
       - 'no-changelog'
 
-  - package-ecosystem: 'pip'
+  - package-ecosystem: 'uv'
     directory: /
     schedule:
       interval: daily
     labels:
       - 'no-changelog'
-
-  - package-ecosystem: 'pip'
-    directory: /src/vscode-atopile/
-    schedule:
-      interval: daily
-    labels:
-      - 'debt'
-    commit-message:
-      include: 'scope'
-      prefix: 'pip'
 
   - package-ecosystem: 'npm'
     directory: /src/vscode-atopile/


### PR DESCRIPTION
Updates dependabot config to enable the `uv` updater.

Caveats:
- requires beta flag
- doesn't yet look at `uv.lock`
- or dependency groups in `pyproject.toml`