### PR TITLE
BoM: Easier way to specify fp overrride for explicit part

### DIFF
--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -125,7 +125,6 @@ from faebryk.library.Switch import Switch
 from faebryk.library.B4B_ZR_SM4_TF import B4B_ZR_SM4_TF
 from faebryk.library.DE9Connector import DE9Connector
 from faebryk.library.Header import Header
-from faebryk.library.has_explicit_part import has_explicit_part
 from faebryk.library.pf_533984002 import pf_533984002
 from faebryk.library.DIP import DIP
 from faebryk.library.QFN import QFN
@@ -133,6 +132,7 @@ from faebryk.library.SMDTwoPin import SMDTwoPin
 from faebryk.library.SOIC import SOIC
 from faebryk.library.has_kicad_footprint_equal_ifs_defined import has_kicad_footprint_equal_ifs_defined
 from faebryk.library.Mounting_Hole import Mounting_Hole
+from faebryk.library.has_explicit_part import has_explicit_part
 from faebryk.library.has_package import has_package
 from faebryk.library.is_surge_protected import is_surge_protected
 from faebryk.library.Common_Mode_Filter import Common_Mode_Filter

--- a/src/faebryk/library/has_explicit_part.py
+++ b/src/faebryk/library/has_explicit_part.py
@@ -13,6 +13,7 @@ class has_explicit_part(Module.TraitT.decless()):
     supplier_id: str
     supplier_partno: str
     pinmap: dict[str, F.Electrical | None] | None
+    override_footprint: tuple[F.Footprint, str] | None = None
 
     @classmethod
     def by_mfr(
@@ -20,11 +21,13 @@ class has_explicit_part(Module.TraitT.decless()):
         mfr: str,
         partno: str,
         pinmap: dict[str, F.Electrical | None] | None = None,
+        override_footprint: tuple[F.Footprint, str] | None = None,
     ):
         out = cls()
         out.mfr = mfr
         out.partno = partno
         out.pinmap = pinmap
+        out.override_footprint = override_footprint
         return out
 
     @classmethod
@@ -33,6 +36,7 @@ class has_explicit_part(Module.TraitT.decless()):
         supplier_partno: str,
         supplier_id: str = "lcsc",
         pinmap: dict[str, F.Electrical | None] | None = None,
+        override_footprint: tuple[F.Footprint, str] | None = None,
     ):
         if supplier_id != "lcsc":
             raise NotImplementedError(f"Supplier {supplier_id} not supported")
@@ -40,6 +44,7 @@ class has_explicit_part(Module.TraitT.decless()):
         out.supplier_id = supplier_id
         out.supplier_partno = supplier_partno
         out.pinmap = pinmap
+        out.override_footprint = override_footprint
         return out
 
     @override
@@ -61,3 +66,8 @@ class has_explicit_part(Module.TraitT.decless()):
 
         if self.pinmap:
             obj.add(F.can_attach_to_footprint_via_pinmap(self.pinmap))
+
+        if self.override_footprint:
+            fp, fp_kicad_id = self.override_footprint
+            fp.add(F.KicadFootprint.has_kicad_identifier(fp_kicad_id))
+            obj.get_trait(F.can_attach_to_footprint).attach(fp)

--- a/src/faebryk/libs/app/pcb.py
+++ b/src/faebryk/libs/app/pcb.py
@@ -215,7 +215,7 @@ def check_net_names(graph: Graph):
         raise UserResourceException(f"Net name collision: {net_name_collisions}")
 
 
-def create_footprint_library(app: Module) -> None:
+def create_footprint_library(app: Module, no_fp_lib: bool = False) -> None:
     """
     Ensure all KicadFootprints have a kicad identifier (via the F.has_kicad_footprint
     trait).
@@ -225,6 +225,9 @@ def create_footprint_library(app: Module) -> None:
 
     Check all of the KicadFootprints have a manual identifier. Raise an error if they
     don't.
+
+    Args:
+        no_fp_lib: If True, don't create a footprint library (only useful for testing)
     """
     from atopile.packages import KNOWN_PACKAGES_TO_FOOTPRINT
 
@@ -235,7 +238,8 @@ def create_footprint_library(app: Module) -> None:
     # Create the library it doesn't exist
     atopile_fp_dir = config.project.paths.get_footprint_lib("atopile")
     atopile_fp_dir.mkdir(parents=True, exist_ok=True)
-    ensure_footprint_lib(LIB_NAME, atopile_fp_dir)
+    if not no_fp_lib:
+        ensure_footprint_lib(LIB_NAME, atopile_fp_dir)
 
     # Cache the mapping from path to identifier and the path to the new file
     path_map: dict[Path, tuple[str, Path]] = {}

--- a/test/exporters/bom/test_bom.py
+++ b/test/exporters/bom/test_bom.py
@@ -1,0 +1,120 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+
+import faebryk.library._F as F
+from faebryk.core.module import Module
+from faebryk.core.solver.defaultsolver import DefaultSolver
+from faebryk.exporters.bom.jlcpcb import _get_bomline
+from faebryk.libs.app.designators import attach_random_designators, load_designators
+from faebryk.libs.app.pcb import create_footprint_library
+from faebryk.libs.iso_metric_screw_thread import Iso262_MetricScrewThreadSizes
+from faebryk.libs.library import L
+from faebryk.libs.picker.picker import pick_part_recursively
+from faebryk.libs.units import P
+
+
+def _build(app: Module):
+    load_designators(app.get_graph(), attach=True)
+    solver = DefaultSolver()
+    pick_part_recursively(app, solver)
+    F.has_package.standardize_footprints(app, solver)
+    create_footprint_library(app, no_fp_lib=True)
+    attach_random_designators(app.get_graph())
+
+
+def test_bom_mounting_hole():
+    mh = F.Mounting_Hole(
+        diameter=Iso262_MetricScrewThreadSizes.M10,
+        pad_type=F.Mounting_Hole.PadType.Pad,
+    )
+
+    _build(mh)
+
+    bomline = _get_bomline(mh)
+    assert bomline is None
+
+
+def test_bom_picker_pick():
+    r = F.Resistor()
+    r.resistance.constrain_subset(L.Range.from_center_rel(10 * P.kohm, 0.01))
+
+    _build(r)
+
+    bomline = _get_bomline(r)
+    assert bomline is not None
+
+
+def test_bom_explicit_pick():
+    m = Module()
+    m.add(F.can_attach_to_footprint_symmetrically())
+    m.add(F.has_explicit_part.by_supplier("C25804", pinmap={}))
+    _build(m)
+
+    bomline = _get_bomline(m)
+    assert bomline is not None
+    assert bomline.LCSC_Partnumber == "C25804"
+
+
+def test_bom_kicad_footprint_no_lcsc():
+    m = Module()
+    m.add(F.can_attach_to_footprint_symmetrically())
+    fp = F.KicadFootprint(pin_names=["1", "2"])
+    fp.add(
+        F.KicadFootprint.has_kicad_identifier(
+            "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+        )
+    )
+    m.get_trait(F.can_attach_to_footprint).attach(fp)
+    _build(m)
+
+    bomline = _get_bomline(m)
+    assert bomline is None
+
+
+def test_bom_kicad_footprint_lcsc_verbose():
+    m = Module()
+    m.add(F.can_attach_to_footprint_symmetrically())
+    fp = F.KicadFootprint(pin_names=["1", "2"])
+    fp.add(
+        F.KicadFootprint.has_kicad_identifier(
+            "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical"
+        )
+    )
+    m.get_trait(F.can_attach_to_footprint).attach(fp)
+    m.add(F.has_explicit_part.by_supplier("C18166021", pinmap={}))
+
+    _build(m)
+
+    bomline = _get_bomline(m)
+    assert bomline is not None
+    assert bomline.LCSC_Partnumber == "C18166021"
+    assert m.get_trait(F.has_footprint).get_footprint() is fp
+
+
+def test_bom_kicad_footprint_lcsc_compact():
+    m = Module()
+    m.add(F.can_attach_to_footprint_symmetrically())
+    m.add(
+        F.has_explicit_part.by_supplier(
+            "C18166021",
+            pinmap={},
+            override_footprint=(
+                F.KicadFootprint(pin_names=["1", "2"]),
+                "Connector_PinHeader_2.54mm:PinHeader_1x02_P2.54mm_Vertical",
+            ),
+        )
+    )
+
+    _build(m)
+
+    bomline = _get_bomline(m)
+    assert bomline is not None
+    assert bomline.LCSC_Partnumber == "C18166021"
+    assert (
+        m.get_trait(F.has_footprint)
+        .get_footprint()
+        .get_trait(F.has_kicad_footprint)
+        .get_kicad_footprint_name()
+        == "PinHeader_1x02_P2.54mm_Vertical"
+    )

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -33,7 +33,10 @@ def main(
         module = importlib.util.module_from_spec(spec)
         if spec.loader is None:
             continue
-        spec.loader.exec_module(module)
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            continue
         for v in vars(module).values():
             if not hasattr(v, "__name__"):
                 continue


### PR DESCRIPTION
Adds way to specify overriden footprint when specifying explicit part.
Useful for parts without fp data in lcsc.

Also:
- Add tests for bom output

