### PR TITLE
Core: Solver: Fix finding duplicates by hash generating spurious contradictions

### DIFF
--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -1464,7 +1464,7 @@ class Mutator:
 
         ops = self.get_literal_aliases(new_only=new_only)
         mapping = {self.utils.get_lit_mapping_from_lit_expr(op) for op in ops}
-        dupes = duplicates(mapping, lambda x: x[0])
+        dupes = duplicates(mapping, lambda x: x[0], by_eq=True)
         if dupes:
             raise ContradictionByLiteral(
                 "Literal contradictions",

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -116,8 +116,17 @@ def unique_ref[T](it: Iterable[T]) -> list[T]:
     return unique(it, id)
 
 
-def duplicates[T, U](it: Iterable[T], key: Callable[[T], U]) -> dict[U, list[T]]:
-    return {k: v for k, v in groupby(it, key).items() if len(v) > 1}
+def duplicates[T, U](
+    it: Iterable[T], key: Callable[[T], U], by_eq: bool = False
+) -> dict[U, list[T]]:
+    if by_eq:
+        return {
+            k: uv
+            for k, v in groupby(it, key).items()
+            if len(uv := unique(v, key=lambda x: x)) > 1
+        }
+    else:
+        return {k: v for k, v in groupby(it, key).items() if len(v) > 1}
 
 
 def get_dict(obj, key, default):


### PR DESCRIPTION
Fixes rounding error when comparing literals. Previously we were comparing hashes of the two numbers, now we use the equals operator.