### PR TITLE
add setter/getter for suggested_net_name in ato

### DIFF
--- a/src/atopile/attributes.py
+++ b/src/atopile/attributes.py
@@ -261,6 +261,20 @@ class GlobalAttributes(L.Module):
     def override_net_name(self, name: str):
         self.add(F.has_net_name(name, level=F.has_net_name.Level.EXPECTED))
 
+    @property
+    def suggested_net_name(self):
+        """
+        Suggested net name which will have a higher priority than generated net names.
+        """
+        return self.get_trait(F.has_net_name).name
+
+    @suggested_net_name.setter
+    def suggested_net_name(self, name: str):
+        """
+        Suggested net name which will have a higher priority than generated net names.
+        """
+        self.add(F.has_net_name(name, level=F.has_net_name.Level.SUGGESTED))
+
 
 def _handle_package_shim(module: L.Module, value: str, starts_with: str):
     try:

--- a/src/atopile/attributes.py
+++ b/src/atopile/attributes.py
@@ -266,7 +266,7 @@ class GlobalAttributes(L.Module):
         """
         Suggested net name which will have a higher priority than generated net names.
         """
-        return self.get_trait(F.has_net_name).name
+        raise AttributeError("write-only")
 
     @suggested_net_name.setter
     def suggested_net_name(self, name: str):

--- a/src/atopile/attributes.py
+++ b/src/atopile/attributes.py
@@ -262,14 +262,14 @@ class GlobalAttributes(L.Module):
         self.add(F.has_net_name(name, level=F.has_net_name.Level.EXPECTED))
 
     @property
-    def suggested_net_name(self):
+    def suggest_net_name(self):
         """
         Suggested net name which will have a higher priority than generated net names.
         """
         raise AttributeError("write-only")
 
-    @suggested_net_name.setter
-    def suggested_net_name(self, name: str):
+    @suggest_net_name.setter
+    def suggest_net_name(self, name: str):
         """
         Suggested net name which will have a higher priority than generated net names.
         """


### PR DESCRIPTION
provides a way to softly set a net name in ato

Future upgrade:
- Prioritize suggested name based on project hierarchy (see below)
- Prefix suggested names with source id when there are conflicts, eg cell_1_gnd instead of gnd_8