### PR TITLE
add .line to sda and scl to remove warning

### DIFF
--- a/src/faebryk/library/resistors.ato
+++ b/src/faebryk/library/resistors.ato
@@ -13,5 +13,5 @@ module I2CPullup:
     r_sda.package = "R0402"
     r_scl.package = "R0402"
 
-    i2c.sda ~ r_sda.p1; r_sda.p2 ~ power.vcc
-    i2c.scl ~ r_scl.p1; r_scl.p2 ~ power.vcc
+    i2c.sda.line ~ r_sda.p1; r_sda.p2 ~ power.vcc
+    i2c.scl.line ~ r_scl.p1; r_scl.p2 ~ power.vcc


### PR DESCRIPTION
Tiny bug fix, we get a warning when connecting an Electrical to an ElectricLogic/ElectricSignal.