### PR TITLE
CLI: Fix subsequent builds overwriting logs for previous build

### DIFF
--- a/src/atopile/cli/logging.py
+++ b/src/atopile/cli/logging.py
@@ -356,7 +356,7 @@ class LoggingStage:
 
         try:
             build_cfg = config.build
-            log_dir = log_dir / build_cfg.name
+            log_dir = log_dir / pathvalidate.sanitize_filename(build_cfg.name)
         except RuntimeError:
             pass
 


### PR DESCRIPTION
If there's a build active, puts log files within a subdirectory of the same name.