### PR TITLE
CLI: Fix error when creating component outside of project directory

### DIFF
--- a/src/atopile/cli/cli.py
+++ b/src/atopile/cli/cli.py
@@ -20,6 +20,7 @@ from faebryk.libs.logging import FLOG_FMT
 app = typer.Typer(
     no_args_is_help=True,
     pretty_exceptions_enable=bool(FLOG_FMT),  # required to override the excepthook
+    rich_markup_mode="rich",
 )
 
 

--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -320,9 +320,7 @@ def build_target(
         src_path = config.project.paths.src
         config.project_dir  # touch property to ensure config's loaded from a project
     except ValueError:
-        raise errors.UserException(
-            "Could not find the project directory, are you within an ato project?"
-        )
+        raise errors.UserNoProjectException()
 
     if backup_name is None:
         if build_target:
@@ -474,10 +472,7 @@ def component(
     from faebryk.libs.picker.api.picker_lib import client
     from faebryk.libs.pycodegen import sanitize_name
 
-    try:
-        config.apply_options(None)
-    except errors.UserBadParameterError:
-        config.apply_options(None, standalone=True)
+    config.apply_options(None)
 
     # Find a component --------------------------------------------------------
 

--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -43,7 +43,7 @@ logger.setLevel(logging.INFO)
 
 PROJECT_TEMPLATE = "https://github.com/atopile/project-template"
 
-create_app = typer.Typer()
+create_app = typer.Typer(rich_markup_mode="rich")
 
 
 def help(text: str) -> None:  # pylint: disable=redefined-builtin

--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -582,7 +582,7 @@ def component(
         assert filename is not None
 
         filepath = Path(filename)
-        if filepath.absolute():
+        if filepath.is_absolute():
             out_path = filepath.resolve()
         else:
             out_path = (config.project.paths.src / filename).resolve()

--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -35,6 +35,7 @@ from atopile.errors import (
     UserBadParameterError,
     UserException,
     UserFileNotFoundError,
+    UserNoProjectException,
     UserNotImplementedError,
 )
 from atopile.version import DISTRIBUTION_NAME, get_installed_atopile_version
@@ -910,6 +911,9 @@ class Config:
         else:
             if config_file_path := _find_project_config_file(entry_arg_file_path):
                 self.project_dir = config_file_path.parent
+            elif entry is None:
+                raise UserNoProjectException()
+
             else:
                 raise UserBadParameterError(
                     f"Specified entry path is not a file or directory: "

--- a/src/atopile/errors.py
+++ b/src/atopile/errors.py
@@ -305,3 +305,19 @@ class UserAlreadyExistsError(UserException):
     """
     Raised when something already exists.
     """
+
+
+class UserNoProjectException(UserException):
+    """
+    Raised when the project directory is not found.
+    """
+
+    def __init__(
+        self,
+        msg: str = (
+            "Could not find the project directory, are you within an ato project?"
+        ),
+        *args,
+        **kwargs,
+    ):
+        super().__init__(msg, *args, **kwargs)


### PR DESCRIPTION
Before:

<img width="628" alt="image" src="https://github.com/user-attachments/assets/4e040c00-8715-422d-959b-01be822f7f9c" />

After:

<img width="637" alt="image" src="https://github.com/user-attachments/assets/8b48f7ec-b50a-4f5f-82af-f9bbac479c79" />


Also enables Typer's `rich_markup_mode`, to render newlines in `ato create` help text.