### PR TITLE
Split build targets into their own directory

### DIFF
--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -270,7 +270,8 @@ class BuildTargetPaths(BaseConfigModel):
         if output_base_data := data.get("output_base"):
             data["output_base"] = Path(output_base_data)
         else:
-            data["output_base"] = project_paths.build / name
+            data["output_base"] = project_paths.build / "builds" / name / name
+            data["output_base"].parent.mkdir(parents=True, exist_ok=True)
 
         data.setdefault("netlist", data["output_base"] / f"{name}.net")
         data.setdefault("fp_lib_table", data["layout"].parent / "fp-lib-table")

--- a/src/faebryk/library/regulators.ato
+++ b/src/faebryk/library/regulators.ato
@@ -12,6 +12,7 @@ module AdjustableRegulator from Regulator:
     assert feedback_div.v_in is v_out
     assert feedback_div.v_out is v_ref
     assert feedback_div.max_current is i_q
+    assert i_q is feedback_div.max_current
 
 module Buck from AdjustableRegulator:
     pass

--- a/src/faebryk/library/regulators.ato
+++ b/src/faebryk/library/regulators.ato
@@ -12,7 +12,6 @@ module AdjustableRegulator from Regulator:
     assert feedback_div.v_in is v_out
     assert feedback_div.v_out is v_ref
     assert feedback_div.max_current is i_q
-    assert i_q is feedback_div.max_current
 
 module Buck from AdjustableRegulator:
     pass


### PR DESCRIPTION
Much cleaner output of build artifacts.
<img width="317" alt="Screenshot 2025-03-11 at 3 33 08 PM" src="https://github.com/user-attachments/assets/f7db97fc-504e-4967-a43f-ec73d90af498" />
