### PR TITLE
Fix: Non-Canonicalized get wrong units

### DIFF
--- a/examples/ch2_1_fab.py
+++ b/examples/ch2_1_fab.py
@@ -30,23 +30,23 @@ class App(Module):
         )
 
         self.battery.add(F.has_designator_prefix("B"))
-        self.battery.power.voltage.constrain_superset(
-            L.Range(2.5 * P.volt, 4.2 * P.volt)
-        )
-        self.battery.add(F.has_descriptive_properties_defined({"LCSC": "C5239862"}))
+        self.battery.power.voltage.constrain_superset(L.Range(2.5 * P.V, 4.2 * P.V))
         self.battery.add(
-            F.can_attach_to_footprint_via_pinmap(
-                {
+            F.has_explicit_part.by_supplier(
+                "C5239862",
+                pinmap={
                     "1": self.battery.power.lv,
                     "2": self.battery.power.hv,
-                }
+                },
             )
         )
 
-        self.led.add(F.has_designator_prefix("D"))
-        self.led.add(F.has_descriptive_properties_defined({"LCSC": "C72038"}))
         self.led.add(
-            F.can_attach_to_footprint_via_pinmap(
-                {"1": self.led.led.cathode, "2": self.led.led.anode},
+            F.has_explicit_part.by_supplier(
+                "C72038",
+                pinmap={
+                    "1": self.led.led.cathode,
+                    "2": self.led.led.anode,
+                },
             )
         )

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -801,8 +801,11 @@ class MutationMap:
         if lit is None:
             return _default()
         lit = as_lit(lit)
-        if isinstance(lit, Quantity_Set):
-            fac = quantity(1, HasUnit.get_units(param))
+        param_units = HasUnit.get_units(param)
+        if isinstance(lit, Quantity_Set) and not lit.units.is_compatible_with(
+            param_units
+        ):
+            fac = quantity(1, param_units)
             return lit * fac / fac.to_base_units().m
         return lit
 

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -801,7 +801,7 @@ class MutationMap:
         if lit is None:
             return _default()
         lit = as_lit(lit)
-        param_units = HasUnit.get_units(param)
+        param_units = HasUnit.get_units_or_dimensionless(param)
         if isinstance(lit, Quantity_Set) and not lit.units.is_compatible_with(
             param_units
         ):


### PR DESCRIPTION
When solver doesn't run through canonicalization no need to reattach units to lits.