### PR TITLE
GitHub: Add: Auto sorting of release notes based on PR-label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 # \<Prefix\>: \<Title\>
 
-# Description
+## Description
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
 Fixes # (issue)
 
-# Checklist
+## Checklist
 
 Please read and execute the following:
 

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,36 @@
+changelog:
+  categories:
+    - title: Library 📖
+      labels:
+        - library
+    - title: ato 📜
+      labels:
+        - ato
+    - title: faebryk 🏭
+      labels:
+        - faebryk
+        - fabll
+    - title: CI 🤖
+      labels:
+        - ci
+    - title: Tests 🧪
+      labels:
+        - tests
+    - title: CLI 🖥
+      labels:
+        - cli
+    - title: Documentation 🗎
+      labels:
+        - documentation
+    - title: Component Picker 🏗️
+      labels:
+        - picker
+    - title: Exciting New Features 🎉
+      labels:
+        - enhancement
+    - title: Other Bug fixes 🐛
+      labels:
+        - bug
+    - title: Other Changes ✨
+      labels:
+        - "*"


### PR DESCRIPTION
# GitHub: Add: Auto sorting of release notes based on PR-label

## Description

Auto sort/generate release notes based on PR-label.
Maybe auto-label or enforce tagging of the PRs.

Also fixed heading in PR template

### Todo:

- [ ] Clean up labels on GitHub @iopapamanoglou 

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
