### PR TITLE
Exporters: PCB: Add testpoint location and information

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -35,6 +35,7 @@ from faebryk.exporters.pcb.kicad.transformer import PCB_Transformer
 from faebryk.exporters.pcb.pick_and_place.jlcpcb import (
     convert_kicad_pick_and_place_to_jlcpcb,
 )
+from faebryk.exporters.pcb.testpoints.testpoints import export_testpoints
 from faebryk.library import _F as F
 from faebryk.libs.app.checks import run_checks
 from faebryk.libs.app.designators import (
@@ -281,7 +282,15 @@ def generate_bom(app: Module, solver: Solver) -> None:
 
 @muster.register("mfg-data", default=False)
 def generate_manufacturing_data(app: Module, solver: Solver) -> None:
-    """Generate a designator map for the project."""
+    """
+    Generate manufacturing artifacts for the project.
+    - STEP
+    - GLB
+    - DXF
+    - Gerber zip
+    - Pick and place (default and JLCPCB)
+    - Testpoint-location
+    """
     export_step(
         config.build.paths.layout,
         step_file=config.build.paths.output_base.with_suffix(".pcba.step"),
@@ -305,6 +314,11 @@ def generate_manufacturing_data(app: Module, solver: Solver) -> None:
     convert_kicad_pick_and_place_to_jlcpcb(
         pnp_file,
         config.build.paths.output_base.with_suffix(".jlcpcb_pick_and_place.csv"),
+    )
+
+    export_testpoints(
+        app,
+        testpoints_file=config.build.paths.output_base.with_suffix(".testpoints.json"),
     )
 
 

--- a/src/faebryk/exporters/pcb/testpoints/testpoints.py
+++ b/src/faebryk/exporters/pcb/testpoints/testpoints.py
@@ -1,0 +1,69 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import json
+import logging
+from pathlib import Path
+
+import faebryk.library._F as F
+from faebryk.core.module import Module
+from faebryk.exporters.pcb.kicad.transformer import PCB_Transformer
+from faebryk.exporters.pcb.routing.util import get_internal_nets_of_node
+
+logger = logging.getLogger(__name__)
+
+
+def _get_testpoints(app: Module) -> list[F.TestPoint]:
+    return [
+        testpoint
+        for testpoint in app.get_children_modules(
+            types=F.TestPoint,
+            include_root=True,
+        )
+        if testpoint.has_trait(F.has_footprint)
+        and testpoint.get_trait(F.has_footprint)
+        .get_footprint()
+        .has_trait(F.has_kicad_footprint)
+    ]
+
+
+def export_testpoints(
+    app: Module,
+    testpoints_file: Path,
+):
+    """
+    Get all testpoints from the application and export their information to a JSON file
+    """
+    testpoint_data: dict[str, dict] = {}
+    testpoints = _get_testpoints(app)
+
+    for testpoint in testpoints:
+        designator = testpoint.get_trait(F.has_designator).get_designator()
+        full_name = testpoint.get_full_name()
+        fp = testpoint.get_trait(F.has_footprint).get_footprint()
+        footprint = PCB_Transformer.get_fp(fp)  # get KiCad footprint
+        position = footprint.at
+        layer = footprint.layer
+        library_name = footprint.name
+
+        # Get single connected net name
+        nets = get_internal_nets_of_node(testpoint)
+        net_name = next(
+            (
+                net.get_trait(F.has_overriden_name).get_name()
+                for net, _ in nets.items()
+                if net
+            ),
+            "no-net",
+        )
+
+        testpoint_data[designator] = {
+            "testpoint_name": full_name,
+            "net_name": net_name,
+            "footprint_name": library_name,
+            "position": {"x": position.x, "y": position.y, "rotation": position.r},
+            "layer": layer,
+        }
+
+    with open(testpoints_file, "w") as f:
+        json.dump(obj=testpoint_data, fp=f, indent=4)


### PR DESCRIPTION
# Exporters: PCB: Add testpoint location and information

## Description

Exporter for testpoint location and information. Can be used for bed-of-pins, other test hardware setups and flying probe testing.

Example JSON output

```json
{
    "TP1": {
        "testpoint_name": "output_voltage_feedback.resistor_control_loop_measurement.testpoint[0]",
        "net_name": "output_voltage_feedback-contact-1",
        "footprint_name": "TestPoint:TestPoint_Pad_D1.0mm",
        "position": {
            "x": 3.5,
            "y": -10.0,
            "rotation": 180.0
        },
        "layer": "B.Cu"
    },
    "TP2": {
        "testpoint_name": "output_voltage_feedback.resistor_control_loop_measurement.testpoint[1]",
        "net_name": "output_voltage_feedback-contact",
        "footprint_name": "TestPoint:TestPoint_Pad_D1.0mm",
        "position": {
            "x": -0.25,
            "y": -10.0,
            "rotation": 180.0
        },
        "layer": "B.Cu"
    }
}
```

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
