### PR TITLE
CLI: Fix build stage display issues

### DIFF
--- a/src/atopile/cli/logging.py
+++ b/src/atopile/cli/logging.py
@@ -404,6 +404,9 @@ class LoggingStage(Advancable):
             if col is not None
         )
 
+    def _update_columns(self) -> None:
+        self._progress.columns = self._get_columns()
+
     def alert(self, message: str) -> None:
         message = f"[bold][yellow]![/yellow] {message}[/bold]"
 
@@ -430,7 +433,7 @@ class LoggingStage(Advancable):
 
     def set_total(self, total: int | None) -> None:
         self.steps = total
-        self._progress.columns = self._get_columns()
+        self._update_columns()
         self._progress.update(self._task_id, total=total)
         self.refresh()
 
@@ -440,6 +443,7 @@ class LoggingStage(Advancable):
 
     def __enter__(self) -> "LoggingStage":
         self._setup_logging()
+        self._update_columns()
         self._progress.start()
         self._task_id = self._progress.add_task(
             self.description, total=self.steps if self.steps is not None else 1


### PR DESCRIPTION
Fixes:
- timer stops prematurely (when internal `Progress` is advanced to completion, rather than when context exits)
- missing log file paths