### PR TITLE
Fixes 1131: Unfriendly error on poor module name

### DIFF
--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -147,10 +147,12 @@ def query_helper[T: str | Path | bool](
     # Ensure the default provided is valid
     if default is not None and validate_default:
         if not validator_func(clarifier(default)):
-            raise ValueError(f"Default value {default} is invalid")
+            logger.debug(f"Default value {default} is invalid")
 
         if clarifier(default) != upgrader(clarifier(default)):
-            raise ValueError(f"Default value {default} doesn't meet best-practice")
+            logger.debug(f"Default value {default} doesn't meet best-practice")
+
+        default = upgrader(clarifier(default))
 
     # When running non-interactively, we expect the value to be provided
     # at the command level, so we don't need to query the user for it


### PR DESCRIPTION
Honestly more hacks around it but 🤷‍♂️

## Pudding 🍮

```
(atopile) hil_tester % ato create build-target
faebryk is installed as editable package, compiling c++ code
[10:31:13] WARNING  Your version of atopile (0.3.17) is out-of-date. Latest version: 0.3.23.                                                                                                                                                         
                    You can find upgrade instructions here: https://atopile.io/#installation                                                                                                                                                         
           INFO     Using project /Users/mattwildoer/Projects/atopile-workspace/atopile/tmp/hil_tester                                                                                                                                               
🚀 What's the build-target name?
?  100cell-sim
Build-target names must start with a letter and contain only letters, numbers, dashes and underscores.
?  cell-sim-100-channel
🚀 What file should we add the module to?
?  /Users/mattwildoer/Projects/atopile-workspace/atopile/tmp/hil_tester/cell_sim_100_channel.ato
🚀 What module should we add to the file?
?  CellSim100channel
[10:32:11] INFO     Adding build-target to /Users/mattwildoer/Projects/atopile-workspace/atopile/tmp/hil_tester/ato.yaml                                                                                                                             
✨ Successfully created a new build configuration cell-sim-100-channel at /Users/mattwildoer/Projects/atopile-workspace/atopile/tmp/hil_tester/cell_sim_100_channel.ato! ✨
```