### PR TITLE
Fix: Save & Load params

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -52,7 +52,7 @@ from faebryk.libs.app.pcb import (
     ensure_footprint_lib,
     load_net_names,
 )
-from faebryk.libs.app.picking import load_descriptive_properties
+from faebryk.libs.app.picking import load_descriptive_properties, save_parameters
 from faebryk.libs.exceptions import (
     UserResourceException,
     accumulate,
@@ -133,6 +133,7 @@ def build(app: Module) -> None:
                 "Failed to pick parts for some modules",
                 [UserPickError(str(e)) for e in iter_leaf_exceptions(ex)],
             ) from ex
+        save_parameters(G())
 
     with LoggingStage("footprints", "Handling footprints"):
         # Use standard footprints for known packages regardless of

--- a/src/faebryk/core/node.py
+++ b/src/faebryk/core/node.py
@@ -162,8 +162,7 @@ class NodeAlreadyBound(NodeException):
         super().__init__(
             node,
             *args,
-            f"Node {other} already bound to"
-            f" {other.get_parent()}, can't bind to {node}",
+            f"Node {other} already bound to {other.get_parent()}, can't bind to {node}",
         )
 
 
@@ -578,8 +577,7 @@ class Node(CNode):
             for p in self.get_children(direct_only=True, types=Parameter)
         }
         params_str = "\n".join(
-            f"{k}: {solver.inspect_get_known_supersets(v)
-                    if solver else v}"
+            f"{k}: {solver.inspect_get_known_supersets(v) if solver else v}"
             for k, v in params.items()
         )
 
@@ -716,6 +714,17 @@ class Node(CNode):
         return {gif.node for gif in gifs}
         # TODO what is faster
         # return {n.node for n in gifs if isinstance(n, GraphInterfaceSelf)}
+
+    def get_child_by_name(self, name: str) -> "Node":
+        if hasattr(self, name):
+            return cast(Node, getattr(self, name))
+        for p in self.get_children(direct_only=True, types=Node):
+            if p.get_name() == name:
+                return p
+        raise KeyErrorNotFound(f"No child with name {name} found")
+
+    def __getitem__(self, name: str) -> "Node":
+        return self.get_child_by_name(name)
 
     # Hierarchy queries ----------------------------------------------------------------
 

--- a/src/faebryk/exporters/pcb/kicad/transformer.py
+++ b/src/faebryk/exporters/pcb/kicad/transformer.py
@@ -62,6 +62,7 @@ from faebryk.libs.util import (
     find,
     groupby,
     hash_string,
+    re_in,
     yield_missing,
 )
 
@@ -1721,6 +1722,7 @@ class PCB_Transformer:
         "Partnumber",
         "Manufacturer",
         "JLCPCB description",
+        "PARAM_.*",
     }
 
     def _update_footprint_from_node(
@@ -1796,7 +1798,7 @@ class PCB_Transformer:
         # Take any descriptive properties defined on the component
         if c_props_t := component.try_get_trait(F.has_descriptive_properties):
             for prop_name, prop_value in c_props_t.get_properties().items():
-                if prop_name in self.INCLUDE_DESCRIPTIVE_PROPERTIES_FROM_PCB:
+                if re_in(prop_name, self.INCLUDE_DESCRIPTIVE_PROPERTIES_FROM_PCB):
                     property_values[prop_name] = prop_value
 
         if c_props_t := component.try_get_trait(F.has_datasheet):

--- a/src/faebryk/library/has_descriptive_properties.py
+++ b/src/faebryk/library/has_descriptive_properties.py
@@ -10,3 +10,9 @@ class has_descriptive_properties(Module.TraitT):
 
     def add_properties(self, properties: dict[str, str]):
         raise NotImplementedError()
+
+    @staticmethod
+    def get_from(obj: Module, key: str) -> str | None:
+        if not obj.has_trait(has_descriptive_properties):
+            return None
+        return obj.get_trait(has_descriptive_properties).get_properties().get(key)

--- a/src/faebryk/libs/app/picking.py
+++ b/src/faebryk/libs/app/picking.py
@@ -1,11 +1,15 @@
 # This file is part of the faebryk project
 # SPDX-License-Identifier: MIT
 
+import json
 import logging
 
 import faebryk.library._F as F
 from faebryk.core.graph import Graph, GraphFunctions
+from faebryk.core.module import Module
+from faebryk.core.parameter import Parameter
 from faebryk.exporters.pcb.kicad.transformer import PCB_Transformer
+from faebryk.libs.sets.sets import P_Set
 
 NO_LCSC_DISPLAY = "No LCSC number"
 
@@ -14,30 +18,55 @@ logger = logging.getLogger(__name__)
 
 def load_descriptive_properties(G: Graph):
     """
-    Load descriptive properties from footprints.
+    Load descriptive properties from footprints and saved parameters.
     """
-
     nodes = GraphFunctions(G).nodes_with_trait(
         PCB_Transformer.has_linked_kicad_footprint
     )
 
     for node, trait in nodes:
+        assert isinstance(node, Module)
         if node.has_trait(F.has_part_picked):
-            continue
-        if (
-            node.has_trait(F.has_descriptive_properties)
-            and "LCSC" in node.get_trait(F.has_descriptive_properties).get_properties()
-        ):
             continue
 
         fp = trait.get_fp()
-        lcsc_display_prop = fp.propertys.get("LCSC")
-        if not lcsc_display_prop:
-            continue
+        props = fp.propertys
 
-        lcsc_display = lcsc_display_prop.value
-        if lcsc_display == NO_LCSC_DISPLAY:
-            continue
+        # Load LCSC number from descriptive properties
+        if (
+            F.has_descriptive_properties.get_from(node, "LCSC") is None
+            and (lcsc_display_prop := props.get("LCSC")) is not None
+            and (lcsc_display := lcsc_display_prop.value) != NO_LCSC_DISPLAY
+        ):
+            # node.add(F.has_explicit_part.by_supplier(lcsc_display,supplier_id="lcsc"))
+            node.add(F.has_descriptive_properties_defined({"LCSC": lcsc_display}))
 
-        # node.add(F.has_explicit_part.by_supplier(lcsc_display, supplier_id="lcsc"))
-        node.add(F.has_descriptive_properties_defined({"LCSC": lcsc_display}))
+        # Load saved parameters from descriptive properties
+        for key, value in props.items():
+            if not key.startswith("PARAM_"):
+                continue
+
+            param_name = key.removeprefix("PARAM_")
+            param_value = json.loads(value.value)
+            param_value = P_Set.deserialize(param_value)
+            param = node[param_name]
+            assert isinstance(param, Parameter)
+            param.alias_is(param_value)
+
+
+def save_parameters(G: Graph):
+    """
+    Save parameters to footprints (by copying them to descriptive properties).
+    """
+
+    nodes = GraphFunctions(G).nodes_with_trait(F.has_part_picked)
+
+    for node, _ in nodes:
+        for p in node.get_children(direct_only=True, types=Parameter):
+            lit = p.try_get_literal()
+            if lit is None:
+                continue
+            lit = P_Set.from_value(lit)
+            key = f"PARAM_{p.get_name()}"
+            value = json.dumps(lit.serialize())
+            node.add(F.has_descriptive_properties_defined({key: value}))

--- a/src/faebryk/libs/app/picking.py
+++ b/src/faebryk/libs/app/picking.py
@@ -26,6 +26,8 @@ def load_descriptive_properties(G: Graph):
 
     for node, trait in nodes:
         assert isinstance(node, Module)
+        if isinstance(node, F.Footprint):
+            continue
         if node.has_trait(F.has_part_picked):
             continue
 

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -9,6 +9,7 @@ import itertools
 import json
 import logging
 import os
+import re
 import select
 import shutil
 import stat
@@ -2036,3 +2037,7 @@ def pretty_type(t: object | type) -> str:
         return t.__qualname__
     except Exception:
         return str(t)
+
+
+def re_in(value: str, patterns: Iterable[str]) -> bool:
+    return any(re.match(pattern, value) for pattern in patterns)


### PR DESCRIPTION
Dump parameter aliases of picked modules to pcb attributes, so when building with `--keep-picked-parts` we can load the values for verification.