### PR TITLE
Add module name to PickError

### DIFF
--- a/src/faebryk/libs/picker/api/picker_lib.py
+++ b/src/faebryk/libs/picker/api/picker_lib.py
@@ -201,7 +201,11 @@ def _find_modules(
                 raise ExceptionGroup(
                     "Failed to fetch one or more parts",
                     [
-                        PickError(f"{error['message']}\n{query.pretty_str()}", module)
+                        PickError(
+                            f"{error['message']} for {module.get_full_name()}"
+                            f"\n{query.pretty_str()}",
+                            module,
+                        )
                         for module, (query, error) in _map_response(
                             list(zip(queries, errors))
                         ).items()
@@ -313,7 +317,7 @@ def _check_candidates_compatible(
     mappings = [_get_compatible_parameters(m, c, solver) for m, c in module_candidates]
 
     if LOG_PICK_SOLVE:
-        logger.info(f"Solving for modules:" f" {[m for m, _ in module_candidates]}")
+        logger.info(f"Solving for modules: {[m for m, _ in module_candidates]}")
 
     predicates = (
         Is(m_param, c_range)


### PR DESCRIPTION
# Add module name to PickError

## Description

Quick fix to print out the module where the exception is coming from.

Before:
![image](https://github.com/user-attachments/assets/1e0e0079-e189-431b-85a9-a1f980a48e7f)

After:
![image](https://github.com/user-attachments/assets/6c32388c-2b1f-46cd-8afd-ced03648152c)

Might be worth to have a look at how `ExceptionGroup` is being printed by the logger. It currently does not use the `__repr__` or `__str__` of the errors in the group, so a lot of the info is missing. 

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules