### PR TITLE
Libs: Checks: Add requires external usage

### DIFF
--- a/src/atopile/attributes.py
+++ b/src/atopile/attributes.py
@@ -165,8 +165,7 @@ class GlobalAttributes(L.Module):
 
         if value.lower() == "dnp":
             raise DeprecatedException(
-                f"`mpn = {value}` is deprecated. "
-                "Use `exclude_from_bom = True` instead."
+                f"`mpn = {value}` is deprecated. Use `exclude_from_bom = True` instead."
             )
 
         # handles duplicates gracefully
@@ -287,6 +286,22 @@ class GlobalAttributes(L.Module):
         Suggested net name which will have a higher priority than generated net names.
         """
         self.add(F.has_net_name(name, level=F.has_net_name.Level.SUGGESTED))
+
+    @property
+    def required(self):
+        """
+        Only for ModuleInterfaces.
+        If set to `True`, require that interface is connected to something outside
+        of the module it's defined in.
+        """
+        raise AttributeError("write-only")
+
+    @required.setter
+    def required(self, value: bool):
+        if not value:
+            self.del_trait(F.requires_external_usage)
+            return
+        self.add(F.requires_external_usage())
 
 
 def _handle_package_shim(module: L.Module, value: str, starts_with: str):

--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -39,7 +39,7 @@ from faebryk.exporters.pcb.pick_and_place.jlcpcb import (
 )
 from faebryk.exporters.pcb.testpoints.testpoints import export_testpoints
 from faebryk.library import _F as F
-from faebryk.libs.app.checks import run_checks
+from faebryk.libs.app.checks import RequiresExternalUsageNotFulfilled, run_checks
 from faebryk.libs.app.designators import (
     attach_random_designators,
     load_designators,
@@ -111,7 +111,11 @@ def build(app: Module) -> None:
             logger.warning("Skipping bus parameter resolution")
 
         logger.info("Running checks")
-        run_checks(app, G())
+        try:
+            run_checks(app, G())
+        except RequiresExternalUsageNotFulfilled as ex:
+            # TODO ato code
+            raise UserException(str(ex)) from ex
 
         # Pre-pick project checks - things to look at before time is spend ---------
         # Make sure the footprint libraries we're looking for exist

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -35,6 +35,7 @@ from faebryk.library.is_pickable import is_pickable
 from faebryk.library.has_linked_pad import has_linked_pad
 from faebryk.library.has_reference import has_reference
 from faebryk.library.has_descriptive_properties import has_descriptive_properties
+from faebryk.library.requires_external_usage import requires_external_usage
 from faebryk.library.is_app_root import is_app_root
 from faebryk.library.has_layout_transform import has_layout_transform
 from faebryk.library.can_bridge import can_bridge

--- a/src/faebryk/library/requires_external_usage.py
+++ b/src/faebryk/library/requires_external_usage.py
@@ -1,0 +1,37 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+
+import logging
+
+from faebryk.core.moduleinterface import ModuleInterface
+from faebryk.core.trait import Trait
+
+logger = logging.getLogger(__name__)
+
+
+class requires_external_usage(Trait.decless()):
+    @property
+    def fullfilled(self) -> bool:
+        obj = self.get_obj(type=ModuleInterface)
+        connected_to = set(obj.connected.get_connected_nodes(types=[type(obj)]))
+        # no connections
+        if not connected_to:
+            return False
+        parent = obj.get_parent()
+        # no shared parent possible
+        if parent is None:
+            return True
+        parent, _ = parent
+
+        for c in connected_to:
+            if parent not in {p for p, _ in c.get_hierarchy()}:
+                return True
+
+        return False
+
+    def on_obj_set(self):
+        if not isinstance(self.obj, ModuleInterface):
+            raise NotImplementedError("Only supported on ModuleInterfaces")
+
+        super().on_obj_set()

--- a/src/faebryk/library/requires_external_usage.py
+++ b/src/faebryk/library/requires_external_usage.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class requires_external_usage(Trait.decless()):
     @property
-    def fullfilled(self) -> bool:
+    def fulfilled(self) -> bool:
         obj = self.get_obj(type=ModuleInterface)
         connected_to = set(obj.connected.get_connected_nodes(types=[type(obj)]))
         # no connections

--- a/src/faebryk/libs/app/checks.py
+++ b/src/faebryk/libs/app/checks.py
@@ -2,10 +2,39 @@
 # SPDX-License-Identifier: MIT
 
 
-from faebryk.core.graph import Graph
+import logging
+
+import faebryk.library._F as F
+from faebryk.core.graph import Graph, GraphFunctions
 from faebryk.core.module import Module
+from faebryk.core.node import Node
 from faebryk.libs.app.erc import simple_erc
+
+logger = logging.getLogger(__name__)
+
+
+class CheckException(Exception): ...
 
 
 def run_checks(app: Module, G: Graph):
+    # TODO should make a Trait Trait: `implements_design_check`
+    check_requires_external_usage(G)
     simple_erc(G)
+
+
+class RequiresExternalUsageNotFulfilled(CheckException):
+    def __init__(self, nodes: list[Node]):
+        self.nodes = nodes
+        super().__init__(
+            f"Nodes requiring external usage but not used externally: "
+            f"{', '.join(mif.get_full_name() for mif in nodes)}"
+        )
+
+
+def check_requires_external_usage(G: Graph):
+    unfulfilled = []
+    for node, trait in GraphFunctions(G).nodes_with_trait(F.requires_external_usage):
+        if not trait.fullfilled:
+            unfulfilled.append(node)
+    if unfulfilled:
+        raise RequiresExternalUsageNotFulfilled(unfulfilled)

--- a/src/faebryk/libs/app/checks.py
+++ b/src/faebryk/libs/app/checks.py
@@ -34,7 +34,7 @@ class RequiresExternalUsageNotFulfilled(CheckException):
 def check_requires_external_usage(G: Graph):
     unfulfilled = []
     for node, trait in GraphFunctions(G).nodes_with_trait(F.requires_external_usage):
-        if not trait.fullfilled:
+        if not trait.fulfilled:
             unfulfilled.append(node)
     if unfulfilled:
         raise RequiresExternalUsageNotFulfilled(unfulfilled)

--- a/test/front_end/test_front_end.py
+++ b/test/front_end/test_front_end.py
@@ -410,3 +410,23 @@ def test_shim_power(bob: Bob):
     assert a.lv.is_connected_to(b.lv)
     assert a.hv.is_connected_to(b.hv)
     assert not a.lv.is_connected_to(b.hv)
+
+
+def test_requires(bob: Bob):
+    text = dedent(
+        """
+        module App:
+            signal a
+            signal b
+
+            a.required = True
+        """
+    )
+
+    tree = parse_text_as_file(text)
+    node = bob.build_ast(tree, Ref(["App"]))
+
+    assert isinstance(node, L.Module)
+
+    a = _get_mif(node, "a")
+    assert a.has_trait(F.requires_external_usage)

--- a/test/libs/test_checks.py
+++ b/test/libs/test_checks.py
@@ -1,0 +1,51 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import logging
+
+import pytest
+
+import faebryk.library._F as F
+from faebryk.core.module import Module
+from faebryk.libs.app.checks import (
+    RequiresExternalUsageNotFulfilled,
+    check_requires_external_usage,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def test_requires_external_usage():
+    class App(Module):
+        class Outer(Module):
+            class Inner(Module):
+                b: F.Electrical
+
+            a: F.Electrical
+            inner: Inner
+
+            def __preinit__(self):
+                self.a.add(F.requires_external_usage())
+
+        outer1: Outer
+        outer2: Outer
+
+    app = App()
+
+    # no connections
+    with pytest.raises(RequiresExternalUsageNotFulfilled):
+        check_requires_external_usage(app.get_graph())
+
+    # internal connection
+    app.outer1.a.connect(app.outer1.inner.b)
+    with pytest.raises(RequiresExternalUsageNotFulfilled):
+        check_requires_external_usage(app.get_graph())
+
+    # path to external
+    app.outer1.inner.b.connect(app.outer2.a)
+    with pytest.raises(RequiresExternalUsageNotFulfilled):
+        check_requires_external_usage(app.get_graph())
+
+    # direct external connection
+    app.outer1.a.connect(app.outer2.inner.b)
+    check_requires_external_usage(app.get_graph())


### PR DESCRIPTION
Checks if ModuleInteface is used outside of module it's residing in. See testcase for more explanation.

Ato: Add `.requires = True`
Library: Add `requires_external_usage` trait