### PR TITLE
Libs: Checks: Disable external check if root module

### DIFF
--- a/src/faebryk/libs/app/checks.py
+++ b/src/faebryk/libs/app/checks.py
@@ -18,7 +18,7 @@ class CheckException(Exception): ...
 
 def run_checks(app: Module, G: Graph):
     # TODO should make a Trait Trait: `implements_design_check`
-    check_requires_external_usage(G)
+    check_requires_external_usage(app, G)
     simple_erc(G)
 
 
@@ -31,10 +31,13 @@ class RequiresExternalUsageNotFulfilled(CheckException):
         )
 
 
-def check_requires_external_usage(G: Graph):
+def check_requires_external_usage(app: Module, G: Graph):
     unfulfilled = []
     for node, trait in GraphFunctions(G).nodes_with_trait(F.requires_external_usage):
         if not trait.fulfilled:
+            # Don't check the app module itself
+            if app is node:
+                continue
             unfulfilled.append(node)
     if unfulfilled:
         raise RequiresExternalUsageNotFulfilled(unfulfilled)

--- a/test/libs/test_checks.py
+++ b/test/libs/test_checks.py
@@ -34,18 +34,18 @@ def test_requires_external_usage():
 
     # no connections
     with pytest.raises(RequiresExternalUsageNotFulfilled):
-        check_requires_external_usage(app.get_graph())
+        check_requires_external_usage(app, app.get_graph())
 
     # internal connection
     app.outer1.a.connect(app.outer1.inner.b)
     with pytest.raises(RequiresExternalUsageNotFulfilled):
-        check_requires_external_usage(app.get_graph())
+        check_requires_external_usage(app, app.get_graph())
 
     # path to external
     app.outer1.inner.b.connect(app.outer2.a)
     with pytest.raises(RequiresExternalUsageNotFulfilled):
-        check_requires_external_usage(app.get_graph())
+        check_requires_external_usage(app, app.get_graph())
 
     # direct external connection
     app.outer1.a.connect(app.outer2.inner.b)
-    check_requires_external_usage(app.get_graph())
+    check_requires_external_usage(app, app.get_graph())


### PR DESCRIPTION
Root modules can't have external usage by definition.
Disable check for those.
