### PR TITLE
Ato: Better error for attempted non-mif connection

### DIFF
--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -1309,13 +1309,23 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
         elif name_or_attr_ctx := ctx.name_or_attr():
             ref = self.visitName_or_attr(name_or_attr_ctx)
             node = self._get_referenced_node(ref, ctx)
-            assert isinstance(node, L.ModuleInterface)
+            if not isinstance(node, L.ModuleInterface):
+                raise errors.UserTypeError.from_ctx(
+                    ctx,
+                    f"Can't connect `{node}` because it's not a `ModuleInterface`",
+                    traceback=self.get_traceback(),
+                )
             return node
         elif numerical_ctx := ctx.numerical_pin_ref():
             pin_name = numerical_ctx.getText()
             ref = Ref(pin_name.split("."))
             node = self._get_referenced_node(ref, ctx)
-            assert isinstance(node, L.ModuleInterface)
+            if not isinstance(node, L.ModuleInterface):
+                raise errors.UserTypeError.from_ctx(
+                    ctx,
+                    f"Can't connect `{node}` because it's not a `ModuleInterface`",
+                    traceback=self.get_traceback(),
+                )
             return node
         else:
             raise ValueError(f"Unhandled connectable type `{ctx}`")


### PR DESCRIPTION
<img width="591" alt="image" src="https://github.com/user-attachments/assets/5bf60c9f-f365-4aad-994f-42df945ca74b" />

---

This pull request updates error handling in the `visitConnectable` method of `src/atopile/front_end.py` to replace assertions with user-friendly error messages. This change improves the robustness and clarity of error reporting for invalid `ModuleInterface` connections.

### Error handling improvements:
* Replaced `assert` statements with `UserTypeError` exceptions to provide detailed error messages when a node is not a `ModuleInterface`. The error messages include the context and a traceback for easier debugging.