### PR TITLE
Buildutil: Enable `hide_designators` option

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -182,6 +182,8 @@ def build(app: Module) -> None:
         apply_layouts(app)
         transformer.move_footprints()
         apply_routing(app, transformer)
+        if config.build.hide_designators:
+            transformer.hide_all_designators()
 
         if pcb == original_pcb:
             if config.build.frozen:

--- a/src/atopile/cli/build.py
+++ b/src/atopile/cli/build.py
@@ -39,6 +39,7 @@ def build(
     keep_picked_parts: bool | None = None,
     keep_net_names: bool | None = None,
     keep_designators: bool | None = None,
+    hide_designators: bool | None = None,
     standalone: bool = False,
     open_layout: Annotated[
         bool | None, typer.Option("--open", envvar="ATO_OPEN_LAYOUT")
@@ -65,6 +66,7 @@ def build(
         keep_picked_parts=keep_picked_parts,
         keep_net_names=keep_net_names,
         keep_designators=keep_designators,
+        hide_designators=hide_designators,
     )
 
     check_missing_deps_or_offer_to_install()

--- a/src/atopile/cli/build.py
+++ b/src/atopile/cli/build.py
@@ -39,7 +39,6 @@ def build(
     keep_picked_parts: bool | None = None,
     keep_net_names: bool | None = None,
     keep_designators: bool | None = None,
-    hide_designators: bool | None = None,
     standalone: bool = False,
     open_layout: Annotated[
         bool | None, typer.Option("--open", envvar="ATO_OPEN_LAYOUT")
@@ -66,7 +65,6 @@ def build(
         keep_picked_parts=keep_picked_parts,
         keep_net_names=keep_net_names,
         keep_designators=keep_designators,
-        hide_designators=hide_designators,
     )
 
     check_missing_deps_or_offer_to_install()

--- a/src/atopile/config.py
+++ b/src/atopile/config.py
@@ -379,6 +379,7 @@ class BuildTargetConfig(BaseConfigModel, validate_assignment=True):
     keep_picked_parts: bool | None = Field(default=None)
     keep_net_names: bool | None = Field(default=None)
     frozen: bool = Field(default=False)
+    hide_designators: bool | None = Field(default=False)
     paths: BuildTargetPaths
 
     def __init__(self, **data: Any):


### PR DESCRIPTION
# Add hide designators to the build CLI

## Description

@jrhrsmit made this nice feature, but it was not accessible at the build process

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
