### PR TITLE
Disable required check for top level modules

### DIFF
--- a/src/faebryk/library/requires_external_usage.py
+++ b/src/faebryk/library/requires_external_usage.py
@@ -22,6 +22,9 @@ class requires_external_usage(Trait.decless()):
         # no shared parent possible
         if parent is None:
             return True
+        # TODO: disables checks for floating modules
+        if parent[0].get_parent() is None:
+            return True
         parent, _ = parent
 
         for c in connected_to:


### PR DESCRIPTION
Required was failing builds for packages where the interfaces cannot be connected to externally because there is no module one level up.

Now checks for parent.parent of a MIF, if none, disables check