### PR TITLE
Fix: Don't shim floating powers in cap

### DIFF
--- a/src/atopile/attributes.py
+++ b/src/atopile/attributes.py
@@ -471,6 +471,7 @@ class CapacitorElectrolytic(CommonCapacitor):
             power = self.get_trait(self._has_power).power
         else:
             power = F.ElectricPower()
+            self.add(power, name="power_shim")
             power.hv.connect(self.anode)
             power.lv.connect(self.cathode)
             self.add(self._has_power(power))

--- a/src/faebryk/library/Capacitor.py
+++ b/src/faebryk/library/Capacitor.py
@@ -124,6 +124,7 @@ class Capacitor(Module):
             power = self.get_trait(self._has_power).power
         else:
             power = ElectricPower()
+            self.add(power, name="power_shim")
             power.hv.connect_via(self, power.lv)
             self.add(self._has_power(power))
 


### PR DESCRIPTION
- prevented `requires_external_usage` checks to trigger
