### PR TITLE
CLI: Improve formatting for syntax errors

### DIFF
--- a/src/atopile/parse.py
+++ b/src/atopile/parse.py
@@ -26,10 +26,8 @@ class ErrorListenerConverter(ErrorListener):
         msg: str,
         e: Exception | None,
     ):
-        if e is None:
-            msg = msg
-        else:
-            msg = f"{str(e)} '{msg}'"
+        if e is not None and e.args != (None,):
+            msg = f"{e} {msg}"
 
         input_stream: CommonTokenStream = recognizer.getInputStream()
         # This fill is required to get context past the offending symbol


### PR DESCRIPTION
Before:

<img width="421" alt="image" src="https://github.com/user-attachments/assets/46513e90-2f19-436a-b855-ddd12df7ed0a" />

After:

<img width="421" alt="image" src="https://github.com/user-attachments/assets/d37b565b-358b-49df-ab6f-e59d95f5e802" />
