### PR TITLE
Expose the unnamed interfaces in an ato compatible way

### DIFF
--- a/src/faebryk/library/Fuse.py
+++ b/src/faebryk/library/Fuse.py
@@ -44,3 +44,14 @@ class Fuse(Module):
     designator_prefix = L.f_field(F.has_designator_prefix)(
         F.has_designator_prefix.Prefix.F
     )
+
+    # TODO: remove @https://github.com/atopile/atopile/issues/727
+    @property
+    def p1(self) -> F.Electrical:
+        """One side of the fuse."""
+        return self.unnamed[0]
+
+    @property
+    def p2(self) -> F.Electrical:
+        """The other side of the fuse."""
+        return self.unnamed[1]


### PR DESCRIPTION
# Expose the unnamed interfaces in an ato compatible way

## Description

Quick fix to be able to use the fuse component till the ato language supports lists.

Fixes # (issue)

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules