### PR TITLE
VSCE: Fix trailing comment syntax highlighting

### DIFF
--- a/src/vscode-atopile/syntaxes/ato.tmLanguage.json
+++ b/src/vscode-atopile/syntaxes/ato.tmLanguage.json
@@ -279,6 +279,9 @@
 				},
 				{
 					"include": "#operators"
+				},
+				{
+					"include": "#comments"
 				}
 			]
 		},
@@ -314,8 +317,12 @@
 	],
 	"repository": {
 		"comments": {
-			"name": "comment.line.number-sign.ato",
-			"match": "#(?!pragma\\b).*"
+			"patterns": [
+				{
+					"name": "comment.line.number-sign.ato",
+					"match": "(#(?!pragma\\b).*)$"
+				}
+			]
 		},
 		"strings": {
 			"name": "string.quoted.double.ato",
@@ -684,6 +691,9 @@
 							"name": "entity.name.type.class.ato"
 						}
 					}
+				},
+				{
+					"include": "#comments"
 				}
 			]
 		},
@@ -779,6 +789,9 @@
 				{
 					"match": "\\b([a-zA-Z_][a-zA-Z_0-9]*(?:\\.(?:[a-zA-Z_][a-zA-Z_0-9]*|\\d+))*)\\b",
 					"name": "variable.other.ato"
+				},
+				{
+					"include": "#comments"
 				}
 			]
 		}


### PR DESCRIPTION
Before:

<img width="341" alt="image" src="https://github.com/user-attachments/assets/7dfa1401-cb80-40a1-b9c6-953ff8f10197" />

After:

<img width="341" alt="image" src="https://github.com/user-attachments/assets/40ea470a-445b-4229-b2f6-81169b71ba7c" />
