### PR TITLE
Rebuild atopile editable installed package when invoking uv sync

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -276,3 +276,6 @@ extend-exclude = "atopile/parser/"
 
 [tool.uv.sources]
 atopile-mkdocs-plugin = { path = "tools/atopile_mkdocs_plugin", editable = true }
+
+[tool.uv]
+cache-keys = [{ git = { commit = false, tags = true}}]


### PR DESCRIPTION
# Rebuild atopile editable installed package when invoking uv sync

- Rebuild only happens if a new git tag is found
- This will update the ato package version of your editable/development installation with the latest verion tag
- Fixes ato version check mismatch for editable installations

## Checklist

Please read and execute the following:

- [ ] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
