### PR TITLE
Library: Add bridgable trait to regulator

### DIFF
--- a/src/faebryk/library/Regulator.py
+++ b/src/faebryk/library/Regulator.py
@@ -3,6 +3,7 @@
 
 import faebryk.library._F as F
 from faebryk.core.module import Module
+from faebryk.libs.library import L
 
 
 class Regulator(Module):
@@ -12,3 +13,7 @@ class Regulator(Module):
     def __preinit__(self):
         self.power_out.add(F.Power.is_power_source.impl()())
         self.power_in.add(F.Power.is_power_sink.impl()())
+
+    @L.rt_field
+    def can_bridge(self):
+        return F.can_bridge_defined(self.power_in, self.power_out)


### PR DESCRIPTION
Adds bridgeable trait to base definition of regulator, which allows you to do:

power_in ~> regulator ~> power_out

Which is pretty nice!