### PR TITLE
Fix: STEP parser aborts on invalid utf-8 in header

### DIFF
--- a/src/faebryk/libs/kicad/fileformats_latest.py
+++ b/src/faebryk/libs/kicad/fileformats_latest.py
@@ -2149,8 +2149,10 @@ class C_kicad_model_file:
     def header(self) -> str:
         # Extract header section between HEADER; and ENDSEC; using regex
 
-        # Read till DATA; token
-        non_data = first(lazy_split(self._raw, b"DATA;")).decode("utf-8")
+        # Read till DATA; token, replace any invalid UTF-8 characters that may occur
+        non_data = first(lazy_split(self._raw, b"DATA;")).decode(
+            "utf-8", errors="replace"
+        )
 
         pattern = r"HEADER;(.*?)ENDSEC;"
         match = re.search(pattern, non_data, re.DOTALL)


### PR DESCRIPTION
# Replace invalid UTF-8 characters when decoding STEP files

## Description

This patch instructs the utf-8 decoder to replace any invalid characters according to https://docs.python.org/3/library/codecs.html#error-handlers.
I'm not 100% sure this is the best approach, e.g. one option would be to try different code-pages to decode it into something meaningful, but also not sure how relevant/useful this would be for the STEP file header, KiCad parses it just fine after replacement and the user first and foremost expects this operation not to fail due to some slightly malformed data.

An example where this previously failed to generate the part is C2060364.

Fixes #1266

## Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
