### PR TITLE
fix lcsc picker: don't assume a part has a 3d model

### DIFF
--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -372,11 +372,14 @@ class EasyEDAPart:
             download_raw_3d_model=False,
         ).output
 
-        model_name = easyeda_footprint.model_3d.name
-        model_path = lifecycle.easyeda2kicad.get_model_path(
-            data.lcsc.number, model_name
-        )
-        kicad_model_path = str(Gcfg.project.get_relative_to_kicad_project(model_path))
+        if easyeda_footprint.model_3d:
+            model_name = easyeda_footprint.model_3d.name
+            model_path = lifecycle.easyeda2kicad.get_model_path(
+                data.lcsc.number, model_name
+            )
+            kicad_model_path = str(Gcfg.project.get_relative_to_kicad_project(model_path))
+        else:
+            kicad_model_path = None
 
         part = cls(
             lcsc_id=data.lcsc.number,


### PR DESCRIPTION
# fix lcsc picker: don't assume a part has a 3d model

## Description

This guards the 3d model path building for the case that a footprint doesn't have a 3d model attached.

Fixes #1279

## Checklist

Please read and execute the following:

- [x] My code follows the [coding guidelines](/faebryk/faebryk/blob/main/docs/CODING_GUIDELINES.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [ ] Any dependent changes have been merged and published in downstream modules
