### PR TITLE
Fix: CLI part create table titles

### DIFF
--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -632,8 +632,8 @@ def part(
             continue
 
         component_table = Table()
-        component_table.add_column("Part Number")
         component_table.add_column("Manufacturer")
+        component_table.add_column("Part Number")
         component_table.add_column("Description")
         component_table.add_column("Supplier ID")
         component_table.add_column("Stock")


### PR DESCRIPTION
Switched Manufacturer & Part no

```
❯ ato 'create' 'part' '--search' 'C2688883'                  
[16:13:54] INFO     Using project /home/needspeed/workspace/atopile/examples/ch3_0_simple_led                                                                                                              
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━┓
┃ Manufacturer ┃ Part Number  ┃ Description                     ┃ Supplier ID ┃ Stock ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━┩
│ NXP Semicon  │ PCA9536D,118 │ 400kHz SO-8  I/O Expanders ROHS │ C2688883    │ 5     │
└──────────────┴──────────────┴─────────────────────────────────┴─────────────┴───────┘
```
