### PR TITLE
CI: Disable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,30 +1,31 @@
 version: 2
-enable-beta-ecosystems: true  # required for uv
+enable-beta-ecosystems: true # required for uv
 
-updates:
-  - package-ecosystem: 'github-actions'
-    directory: "/"
-    schedule:
-      interval: weekly
-    labels:
-      - 'no-changelog'
-
-  # TODO: reenable, for now more annoying than useful
-  # need to take uv.lock into account
-  #- package-ecosystem: 'uv'
-  #  directory: /
-  #  schedule:
-  #    interval: daily
-  #  labels:
-  #    - 'no-changelog'
-
-  - package-ecosystem: 'npm'
-    directory: /src/vscode-atopile/
-    schedule:
-      interval: monthly
-    labels:
-      - 'no-changelog'
-    ignore:
-      - dependency-name: '@types/vscode'
-      - dependency-name: '@types/node'
-      - dependency-name: 'vscode-languageclient'
+# Dependabot is currently disabled because it can't run pytest
+#updates:
+#  - package-ecosystem: 'github-actions'
+#    directory: "/"
+#    schedule:
+#      interval: weekly
+#    labels:
+#      - 'no-changelog'
+#
+#  # TODO: reenable, for now more annoying than useful
+#  # need to take uv.lock into account
+#  #- package-ecosystem: 'uv'
+#  #  directory: /
+#  #  schedule:
+#  #    interval: daily
+#  #  labels:
+#  #    - 'no-changelog'
+#
+#  - package-ecosystem: 'npm'
+#    directory: /src/vscode-atopile/
+#    schedule:
+#      interval: monthly
+#    labels:
+#      - 'no-changelog'
+#    ignore:
+#      - dependency-name: '@types/vscode'
+#      - dependency-name: '@types/node'
+#      - dependency-name: 'vscode-languageclient'


### PR DESCRIPTION
Doesn't do anything useful at the monent due to
- lacking uv.lock support
- can't run pytest (some aws credential problem)
