### PR TITLE
VSCE: Specify embedded packages site variant

### DIFF
--- a/src/vscode-atopile/src/ui/packagexplorer.ts
+++ b/src/vscode-atopile/src/ui/packagexplorer.ts
@@ -3,6 +3,8 @@ import { getLogoUri } from '../common/logo';
 
 let _packagesPanel: vscode.WebviewPanel | undefined;
 
+const packagesUrl = 'https://packages.atopile.io';
+
 function _getPackageExplorerHTML(): string {
     return `<!DOCTYPE html>
 <html>
@@ -25,9 +27,49 @@ function _getPackageExplorerHTML(): string {
     </style>
 </head>
 <body>
-    <iframe src="https://packages.atopile.io"></iframe>
+    <iframe id="packages-iframe" src="${packagesUrl}?embedded=true"></iframe>
+    <script>
+        const vscode = acquireVsCodeApi();
+        const iframe = document.getElementById('packages-iframe');
+
+        // forward messages from VSCode to iframe
+        window.addEventListener('message', (event) => {
+            if (event.data.type === 'vscode-theme') {
+                iframe.contentWindow.postMessage(event.data, '*');
+            }
+        });
+
+        // forward messages from iframe to VSCode
+        window.addEventListener('message', (event) => {
+            if (event.source === iframe.contentWindow && event.data.type === 'request-theme') {
+                vscode.postMessage(event.data);
+            }
+        });
+    </script>
 </body>
 </html>`;
+}
+
+function _getVSCodeTheme(): string {
+    const theme = vscode.window.activeColorTheme;
+    // VSCode ColorThemeKind: Light = 1, Dark = 2, HighContrast = 3, HighContrastLight = 4
+    switch (theme.kind) {
+        case vscode.ColorThemeKind.Light:
+        case vscode.ColorThemeKind.HighContrastLight:
+            return 'light';
+        case vscode.ColorThemeKind.Dark:
+        case vscode.ColorThemeKind.HighContrast:
+        default:
+            return 'dark';
+    }
+}
+
+function _sendThemeToWebview(webview: vscode.Webview) {
+    const theme = _getVSCodeTheme();
+    webview.postMessage({
+        type: 'vscode-theme',
+        theme: theme
+    });
 }
 
 export async function openPackageExplorer() {
@@ -44,8 +86,29 @@ export async function openPackageExplorer() {
     _packagesPanel.webview.html = _getPackageExplorerHTML();
     _packagesPanel.iconPath = getLogoUri();
 
+    // send initial theme
+    _sendThemeToWebview(_packagesPanel.webview);
+
+    // listen for theme changes
+    const themeChangeDisposable = vscode.window.onDidChangeActiveColorTheme(() => {
+        console.log('VSCode theme changed');
+        if (_packagesPanel) {
+            _sendThemeToWebview(_packagesPanel.webview);
+        }
+    });
+
+    // handle webview theme requests
+    const messageDisposable = _packagesPanel.webview.onDidReceiveMessage(message => {
+        console.log('Received message from webview:', message);
+        if (message.type === 'request-theme' && _packagesPanel) {
+            _sendThemeToWebview(_packagesPanel.webview);
+        }
+    });
+
     // cleanup
     _packagesPanel.onDidDispose(() => {
         _packagesPanel = undefined;
+        themeChangeDisposable.dispose();
+        messageDisposable.dispose();
     });
 }


### PR DESCRIPTION
Switches the extension to use a variant of the packages site which is optimized for the extension-embedded context.