### PR TITLE
Fix: VSCE: Handle current build gone

### DIFF
--- a/src/vscode-atopile/src/ui/buttons.ts
+++ b/src/vscode-atopile/src/ui/buttons.ts
@@ -101,7 +101,12 @@ let buttonBuild = new Button('play', cmdBuild, 'Build', 'Build project');
 let buttonLaunchKicad = new Button('circuit-board', cmdLaunchKicad, 'Launch KiCad', 'Open board in KiCad');
 let buttonPackageExplorer = new Button('symbol-misc', cmdPackageExplorer, 'Package Explorer', 'Open Package Explorer');
 let buttonKicanvasPreview = new Button('eye', cmdKicanvasPreview, 'Layout Preview', 'Open Layout Preview');
-let buttonModelViewerPreview = new Button('symbol-constructor', cmdModelViewerPreview, '3D Preview', 'Open 3D Model Preview');
+let buttonModelViewerPreview = new Button(
+    'symbol-constructor',
+    cmdModelViewerPreview,
+    '3D Preview',
+    'Open 3D Model Preview',
+);
 let dropdownChooseBuild = new Button('gear', cmdChooseBuild, 'Choose Build Target', 'Select active build target');
 const NO_BUILD = '';
 // replace icon with empty text
@@ -188,7 +193,12 @@ async function _displayButtons() {
         }
     }
 
-    if (builds.length > 0 && !_buildStrToBuild(dropdownChooseBuild.statusbar_item.text)) {
+    let current_build = undefined;
+    try {
+        current_build = _buildStrToBuild(dropdownChooseBuild.statusbar_item.text);
+    } catch (error) {}
+
+    if (builds.length > 0 && !current_build) {
         _setBuildTarget(builds[0]);
     }
     if (builds.length === 0) {


### PR DESCRIPTION
Choose first valid build if current build target lost
