### PR TITLE
Buildutil: Fix KiCad DRCs not running

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -242,6 +242,7 @@ def build(app: Module) -> None:
 
     if any(t.name == generate_manufacturing_data.name for t in targets):
         with LoggingStage("checks-post-pcb", "Running post-pcb checks"):
+            pcb.add(F.PCB.requires_drc_check())
             try:
                 check_design(
                     G(),

--- a/src/faebryk/library/PCB.py
+++ b/src/faebryk/library/PCB.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import faebryk.library._F as F
 from faebryk.core.module import Module
 from faebryk.core.node import Node
+from faebryk.core.reference import reference
 from faebryk.core.trait import Trait
 from faebryk.libs.kicad.fileformats_latest import (
     C_kicad_drc_report_file,
@@ -106,6 +107,9 @@ class PCB(Node):
                     )
                 return out
 
+            def __str__(self):
+                return self.pretty()
+
         design_check: F.implements_design_check
 
         @F.implements_design_check.register_post_pcb_check
@@ -129,6 +133,9 @@ class PCB(Node):
                 )
 
     class has_pcb(Module.TraitT.decless()):
+        class has_pcb_ref(F.has_reference.decless()):
+            reference: "PCB" = reference()
+
         def __init__(self, pcb: "PCB"):
             super().__init__()
             self.pcb = pcb
@@ -136,4 +143,6 @@ class PCB(Node):
         def on_obj_set(self):
             assert self.pcb.app is None
             self.pcb.app = self.get_obj(Module)
+            self.pcb.app.add(self.has_pcb_ref(self.pcb))
+
             return super().on_obj_set()

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -29,8 +29,8 @@ from faebryk.library.is_optional_defined import is_optional_defined
 from faebryk.library.has_footprint import has_footprint
 from faebryk.library.Mechanical import Mechanical
 from faebryk.library.has_overriden_name import has_overriden_name
-from faebryk.library.has_linked_pad import has_linked_pad
 from faebryk.library.has_reference import has_reference
+from faebryk.library.has_linked_pad import has_linked_pad
 from faebryk.library.has_pcb_position import has_pcb_position
 from faebryk.library.has_part_picked import has_part_picked
 from faebryk.library.is_auto_generated import is_auto_generated
@@ -65,8 +65,8 @@ from faebryk.library.Logic import Logic
 from faebryk.library.has_single_electric_reference_defined import has_single_electric_reference_defined
 from faebryk.library.Footprint import Footprint
 from faebryk.library.has_overriden_name_defined import has_overriden_name_defined
-from faebryk.library.has_linked_pad_defined import has_linked_pad_defined
 from faebryk.library.Symbol import Symbol
+from faebryk.library.has_linked_pad_defined import has_linked_pad_defined
 from faebryk.library.has_pcb_position_defined import has_pcb_position_defined
 from faebryk.library.has_pcb_position_defined_relative import has_pcb_position_defined_relative
 from faebryk.library.has_pcb_position_defined_relative_to_parent import has_pcb_position_defined_relative_to_parent
@@ -93,8 +93,8 @@ from faebryk.library.can_attach_to_footprint import can_attach_to_footprint
 from faebryk.library.can_attach_via_pinmap import can_attach_via_pinmap
 from faebryk.library.has_footprint_impl import has_footprint_impl
 from faebryk.library.has_kicad_footprint import has_kicad_footprint
-from faebryk.library.Pad import Pad
 from faebryk.library.has_symbol_layout import has_symbol_layout
+from faebryk.library.Pad import Pad
 from faebryk.library.PCB import PCB
 from faebryk.library.requires_external_usage import requires_external_usage
 from faebryk.library.GDT import GDT
@@ -103,12 +103,12 @@ from faebryk.library.Diode import Diode
 from faebryk.library.MOSFET import MOSFET
 from faebryk.library.LogicGate import LogicGate
 from faebryk.library.has_footprint_defined import has_footprint_defined
+from faebryk.library.has_symbol_layout_defined import has_symbol_layout_defined
 from faebryk.library.Net import Net
 from faebryk.library.can_attach_via_pinmap_pinlist import can_attach_via_pinmap_pinlist
 from faebryk.library.has_equal_pins import has_equal_pins
 from faebryk.library.has_kicad_manual_footprint import has_kicad_manual_footprint
 from faebryk.library.has_pcb_routing_strategy_greedy_direct_line import has_pcb_routing_strategy_greedy_direct_line
-from faebryk.library.has_symbol_layout_defined import has_symbol_layout_defined
 from faebryk.library.TVS import TVS
 from faebryk.library.NFET import NFET
 from faebryk.library.PFET import PFET

--- a/src/faebryk/libs/exceptions.py
+++ b/src/faebryk/libs/exceptions.py
@@ -103,7 +103,8 @@ class UserDesignCheckException(UserException):
     @classmethod
     def from_nodes(cls, message: str, nodes: Sequence["Node"]) -> Self:
         nodes = sorted(nodes, key=lambda n: str(n))
-        msg = f"{message}\n{md_list(f'`{node}`' for node in nodes)}"
+        nodes_fmt = md_list(f"`{node}`" for node in nodes)
+        msg = f"{message}\n\nFor nodes: \n{nodes_fmt}"
         return cls(msg)
 
 


### PR DESCRIPTION
Fixes `F.PCB.requires_drc_check` missing from app's graph, so DRCs now run when `mfg-data` is present in build targets (i.e. in CI).

TODO: have `app.pcb.get_full_name()` resolve to something sensible