### PR TITLE
Fix: Net names determinism

### DIFF
--- a/src/faebryk/exporters/netlist/graph.py
+++ b/src/faebryk/exporters/netlist/graph.py
@@ -208,12 +208,14 @@ def attach_net_names(nets: Iterable[F.Net]) -> None:
     # sort nets by
     # 1. name of first connected interface (remove hex)
     # 2. number of connected interfaces
+
+    def stable_node_name(m: ModuleInterface) -> str:
+        return ".".join([p_name for p, p_name in m.get_hierarchy() if p.get_parent()])
+
     unnamed_nets = dict(
         sorted(
             unnamed_nets.items(),
-            key=lambda it: [
-                re.sub(r"^\*[0-9A-F]+\.", "", m.get_full_name()) for m in it[1]
-            ],
+            key=lambda it: [stable_node_name(m) for m in it[1]],
         )
     )
 

--- a/test/end_to_end/test_pcb_export.py
+++ b/test/end_to_end/test_pcb_export.py
@@ -52,7 +52,7 @@ module App:
 
 SIMPLE_APP_PCB_SUMMARY = PcbSummary(
     num_layers=29,
-    nets=["", "a-net", "a-net-1"],
+    nets=["", "a-net-0", "a-net-1"],
     footprints=["R1"],
 )
 
@@ -108,7 +108,7 @@ def test_pcb_file_addition(tmpdir: Path):
     assert p.returncode == 0
     assert "Creating new layout" not in stderr
     assert (
-        SIMPLE_APP_PCB_SUMMARY.add_net("b-net").add_net("b-net-1").add_footprint("R2")
+        SIMPLE_APP_PCB_SUMMARY.add_net("b-net-0").add_net("b-net-1").add_footprint("R2")
     ) == summarize_pcb_file(pcb_file)
 
 
@@ -124,7 +124,7 @@ def test_pcb_file_removal(tmpdir: Path):
     assert p.returncode == 0
     assert "Creating new layout" in stderr
     assert (
-        SIMPLE_APP_PCB_SUMMARY.add_net("b-net").add_net("b-net-1").add_footprint("R2")
+        SIMPLE_APP_PCB_SUMMARY.add_net("b-net-0").add_net("b-net-1").add_footprint("R2")
     ) == summarize_pcb_file(pcb_file)
 
     _, stderr, p = dump_and_run(SIMPLE_APP, [], working_dir=tmpdir)


### PR DESCRIPTION
If mif connected without parent was still undeterministic.
- also fixed '-0' not being appended in duplicates
