### PR TITLE
CLI: Tidier DRC error messages

### DIFF
--- a/src/faebryk/library/PCB.py
+++ b/src/faebryk/library/PCB.py
@@ -71,12 +71,12 @@ class PCB(Node):
                 self.unconnected = unconnected
                 self.units = units
                 super().__init__(
-                    f"{type(self).__name__} ("
-                    f"{len(self.shorts)} shorts,"
-                    f"{len(self.unconnected)} unconnected"
-                    f")",
-                    # TODO
-                    nodes=[pcb],
+                    (
+                        f"{type(self).__name__} "
+                        f"({len(self.shorts)} shorts, "
+                        f"{len(self.unconnected)} unconnected)"
+                    ),
+                    nodes=[],
                 )
 
             def pretty_violation(self, violation: Violation):

--- a/src/faebryk/libs/exceptions.py
+++ b/src/faebryk/libs/exceptions.py
@@ -103,8 +103,10 @@ class UserDesignCheckException(UserException):
     @classmethod
     def from_nodes(cls, message: str, nodes: Sequence["Node"]) -> Self:
         nodes = sorted(nodes, key=lambda n: str(n))
-        nodes_fmt = md_list(f"`{node}`" for node in nodes)
-        msg = f"{message}\n\nFor nodes: \n{nodes_fmt}"
+        msg = message
+        if nodes:
+            nodes_fmt = md_list(f"`{node}`" for node in nodes)
+            msg += f"{msg}\n\nFor nodes: \n{nodes_fmt}"
         return cls(msg)
 
 


### PR DESCRIPTION
Removes trailing `Nodes: [<PCB>]` from DRC messages.