### PR TITLE
Fileformats: Fix KiCad part checksum verification legacy fallback logic

### DIFF
--- a/src/faebryk/libs/kicad/fileformats_common.py
+++ b/src/faebryk/libs/kicad/fileformats_common.py
@@ -250,7 +250,12 @@ class HasPropertiesMixin:
 
     def _hashable(self, remove_uuid: bool = True) -> str:
         copy = deepcopy(self)
-        del copy.propertys["checksum"]
+
+        try:
+            del copy.propertys["checksum"]
+        except KeyError:
+            pass
+
         out = dump_single(copy)
 
         if remove_uuid:


### PR DESCRIPTION
Mutating `self` to avoid hashing the checksum value meant that the legacy with-UUID pathway always failed. Fixed by mutating a copy instead.