### PR TITLE
Fix: create project

### DIFF
--- a/src/vscode-atopile/src/ui/buttons.ts
+++ b/src/vscode-atopile/src/ui/buttons.ts
@@ -91,8 +91,8 @@ let cmdLaunchKicad = new Command(atoLaunchKicad, 'atopile.launch_kicad');
 let cmdKicanvasPreview = new Command(atoKicanvasPreview, 'atopile.kicanvas_preview');
 let cmdModelViewerPreview = new Command(atoModelViewerPreview, 'atopile.modelviewer_preview');
 
-let buttonShell = new Button('terminal', cmdShell, 'Shell', 'Open ato shell', true);
-let buttonCreateProject = new Button('new-file', cmdCreateProject, 'Create Project', 'Create new project', true);
+let buttonShell = new Button('terminal', cmdShell, 'Shell', 'Open ato shell', true, true);
+let buttonCreateProject = new Button('new-file', cmdCreateProject, 'Create Project', 'Create new project', true, true);
 // Need project;
 let buttonAddPart = new Button('file-binary', cmdAddPart, 'Add Part', 'Add part to project');
 let buttonAddPackage = new Button('package', cmdAddPackage, 'Add Package', 'Add package dependency');
@@ -344,7 +344,7 @@ async function atoRemovePackage() {
 }
 
 async function atoCreateProject() {
-    await _runInTerminalWithBuildTarget('create project', ['create', 'project'], false);
+    await _runInTerminal('create project', undefined, ['create', 'project'], false);
 
     captureEvent('vsce:project_create');
 }


### PR DESCRIPTION
Create project was expecting a build target, which doesnt make much sense. Now uses _runInTerminal instead which has fixed the behavior for me.

Also updated the buttons for shell and create project such that they are visible even if there is no ato project in your editior.
