### PR TITLE
Fix: warn on step failure

### DIFF
--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -416,6 +416,8 @@ def generate_bom(app: Module, solver: Solver) -> None:
 def generate_3d_model(app: Module, solver: Solver) -> None:
     """Generate PCBA 3D model as GLB. Used for 3D preview in extension."""
 
+    # TODO: This try/except should be removed once 3D model generation is stable
+    # For now, we log a warning and continue instead of failing the build
     try:
         export_glb(
             config.build.paths.layout,
@@ -423,7 +425,9 @@ def generate_3d_model(app: Module, solver: Solver) -> None:
             project_dir=config.build.paths.layout.parent,
         )
     except KicadCliExportError as e:
-        raise UserExportError(f"Failed to generate 3D model: {e}") from e
+        logger.warning(
+            f"Failed to generate 3D model (GLB): {e}. Continuing build."
+        )
 
 
 @muster.register("mfg-data", default=False, requires_kicad=True)
@@ -444,6 +448,8 @@ def generate_manufacturing_data(app: Module, solver: Solver) -> None:
             Path(tmpdir) / config.build.paths.layout.name,
         )
 
+        # TODO: This try/except should be removed once 3D model generation is stable
+        # For now, we log a warning and continue instead of failing the build
         try:
             export_step(
                 tmp_layout,

--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -451,7 +451,9 @@ def generate_manufacturing_data(app: Module, solver: Solver) -> None:
                 project_dir=config.build.paths.layout.parent,
             )
         except KicadCliExportError as e:
-            raise UserExportError(f"Failed to generate STEP file: {e}") from e
+            logger.warning(
+                f"Failed to generate STEP file: {e}. Continuing with remaining manufacturing data generation."
+            )
 
         try:
             export_dxf(

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -72,7 +72,7 @@ PRINT_START = ConfigFlag("SPRINT_START", default=False, descr="Print start of so
 MAX_ITERATIONS_HEURISTIC = int(
     ConfigFlagInt("SMAX_ITERATIONS", default=40, descr="Max iterations")
 )
-TIMEOUT = ConfigFlagFloat("STIMEOUT", default=150, descr="Solver timeout").get()
+TIMEOUT = ConfigFlagFloat("STIMEOUT", default=5000, descr="Solver timeout").get()
 ALLOW_PARTIAL_STATE = ConfigFlag("SPARTIAL", default=True, descr="Allow partial state")
 # --------------------------------------------------------------------------------------
 

--- a/src/faebryk/core/solver/utils.py
+++ b/src/faebryk/core/solver/utils.py
@@ -72,7 +72,7 @@ PRINT_START = ConfigFlag("SPRINT_START", default=False, descr="Print start of so
 MAX_ITERATIONS_HEURISTIC = int(
     ConfigFlagInt("SMAX_ITERATIONS", default=40, descr="Max iterations")
 )
-TIMEOUT = ConfigFlagFloat("STIMEOUT", default=5000, descr="Solver timeout").get()
+TIMEOUT = ConfigFlagFloat("STIMEOUT", default=150, descr="Solver timeout").get()
 ALLOW_PARTIAL_STATE = ConfigFlag("SPARTIAL", default=True, descr="Allow partial state")
 # --------------------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
This PR changes the behavior of STEP and GLB 3D model exports to be non-blocking. When these exports fail, the build will now log a warning and continue with the remaining outputs instead of failing entirely.

## Motivation
Currently, if 3D model generation fails (e.g., due to missing 3D models for components), the entire build fails. This is problematic when users need other manufacturing outputs (Gerber files, Pick & Place, BOM, etc.) but don't necessarily need the 3D models.

## Changes
- Modified `generate_manufacturing_data()` to catch `KicadCliExportError` for STEP exports and log a warning instead of failing
- Modified `generate_3d_model()` to catch `KicadCliExportError` for GLB exports and log a warning instead of failing
- Added TODO comments indicating this is a temporary solution until 3D model generation becomes more stable

## Example Output
When a 3D export fails, users will now see:
```
WARNING: Failed to generate STEP file: <error details>. Continuing with remaining manufacturing data generation.
```

Instead of the build failing completely.

## Future Work
As noted in the TODO comments, this error handling should be removed once 3D model generation is stable and reliable. At that point, we'll want builds to fail if 3D exports fail, as it would indicate a real issue that needs to be addressed.

## Testing

## Breaking Changes
None - this makes the build process more permissive, not less.