### PR TITLE
Test: Fix inductor pick

### DIFF
--- a/test/front_end/test_front_end_pick.py
+++ b/test/front_end/test_front_end_pick.py
@@ -145,7 +145,7 @@ def test_ato_pick_capacitor(bob: Bob, repo_root: Path):
     "package,package_str",
     [
         (SMDSize.I0402, "L0402"),
-        (SMDSize.SMD0_6x1_2mm, "SMD0_6x1_2mm"),
+        (SMDSize.SMD1_1x1_8mm, "SMD1_1x1_8mm"),
     ],
 )
 def test_ato_pick_inductor(


### PR DESCRIPTION
Previous pick is no longer stocked. Might be worth setting up a separate and less-volatile picker backend for tests.