### PR TITLE
Patch bug introduced breaking templated type-hints in 0.11.2

### DIFF
--- a/src/atopile/front_end.py
+++ b/src/atopile/front_end.py
@@ -2454,7 +2454,6 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
 
         callable_ = getattr(constructor, "__original_init__", constructor)
         constructor_signature = inspect.signature(callable_)
-        type_hints = typing.get_type_hints(callable_)
 
         for arg_name, arg_value in kwargs.items():
             if arg_name not in constructor_signature.parameters:
@@ -2467,7 +2466,7 @@ class Bob(BasicsMixin, SequenceMixin, AtoParserVisitor):  # type: ignore  # Over
             if isinstance(arg_value, str):
                 try:
                     kwargs[arg_name] = _try_upgrade_str_to_enum(
-                        type_hints, arg_name, arg_value
+                        callable_, arg_name, arg_value
                     )
                 except _EnumUpgradeError as ex:
                     raise errors.UserInvalidValueError.from_ctx(


### PR DESCRIPTION
`typing.get_type_hints(callable_)` is called twice; once in `_try_upgrade_str_to_enum` and once on the deleted line.

This fixes the model build of the reg - though it now fails on a "no data error w/ LCSC" (out of scope)

<img width="854" height="173" alt="Screenshot 2025-08-10 at 4 50 40 PM" src="https://github.com/user-attachments/assets/ae519adf-8b34-4d86-b1aa-01d774f358c2" />
