### PR TITLE
Library: Add suggested net names

### DIFF
--- a/src/faebryk/exporters/netlist/graph.py
+++ b/src/faebryk/exporters/netlist/graph.py
@@ -133,7 +133,7 @@ class _NetName:
         """
         base_name = self.base_name or "net"
         prefix = f"{self.prefix}-" if self.prefix else ""
-        suffix = f"-{self.suffix}" if self.suffix else ""
+        suffix = f"-{self.suffix}" if self.suffix is not None else ""
         required_prefix = self.required_prefix or ""
         required_suffix = self.required_suffix or ""
 
@@ -196,359 +196,538 @@ def _name_shittiness(name: str | None) -> float:
     return 1
 
 
-def attach_net_names(nets: Iterable[F.Net]) -> None:
-    """
-    Generate good net names, assuming that we're passed all the nets in a design
-    """
+def _get_stable_node_name(mif: ModuleInterface) -> str:
+    """Get a stable hierarchical name for a module interface."""
+    return ".".join([p_name for p, p_name in mif.get_hierarchy() if p.get_parent()])
 
-    names = FuncDict[F.Net, _NetName]()
 
-    # Ignore nets with names already
+def _collect_unnamed_nets(nets: Iterable[F.Net]) -> dict[F.Net, list[F.Electrical]]:
+    """Collect nets without overridden names and their connected interfaces."""
     unnamed_nets = {
         n: sorted(n.get_connected_interfaces(), key=lambda m: m.get_full_name())
         for n in nets
         if not n.has_trait(F.has_overriden_name)
     }
-    # sort nets by
-    # 1. name of first connected interface (remove hex)
-    # 2. number of connected interfaces
 
-    def stable_node_name(m: ModuleInterface) -> str:
-        return ".".join([p_name for p, p_name in m.get_hierarchy() if p.get_parent()])
-
-    unnamed_nets = dict(
+    # Sort nets by stable node names for deterministic ordering
+    return dict(
         sorted(
             unnamed_nets.items(),
-            key=lambda it: [stable_node_name(m) for m in it[1]],
+            key=lambda it: [_get_stable_node_name(m) for m in it[1]],
         )
     )
 
-    # Capture already-named nets for conflict checking
+
+def _register_named_nets(
+    nets: Iterable[F.Net], names: FuncDict[F.Net, _NetName]
+) -> None:
+    """Register nets that already have overridden names."""
     for net in nets:
         if net.has_trait(F.has_overriden_name):
             names[net] = _NetName(
                 base_name=net.get_trait(F.has_overriden_name).get_name()
             )
 
-    # First generate candidate base names
-    def _decay(depth: int) -> float:
-        return 1 / (depth + 1)
 
-    # FIXME: overriden names will be modified if multiple nets are in conflict
-    # FIXME: the errors for this deserve vast improvement. Attaching an origin trait
-    # to has_net_name is a start, but we need a generic way to raise those as
-    # well-formed errors
+def _calculate_suggested_name_rank(mif: ModuleInterface, base_depth: int) -> int:
+    """Calculate rank for a suggested name based on hierarchy."""
+    rank = base_depth
+
+    owner_iface = mif.get_parent_of_type(L.ModuleInterface)
+    if owner_iface and not isinstance(owner_iface, F.Electrical):
+        rank -= 1
+
+    if L.Node.nearest_common_ancestor(mif):
+        rank -= 1
+
+    return rank
+
+
+def _extract_net_name_info(
+    mif: ModuleInterface,
+) -> tuple[set[str], list[tuple[str, int]], dict[str, float]]:
+    """Extract naming information from an interface."""
+    required_names: set[str] = set()
+    suggested_names: list[tuple[str, int]] = []
+    implicit_candidates: dict[str, float] = {}
+
+    depth = len(mif.get_hierarchy())
+
+    # Handle explicit net naming traits
+    if trait := mif.try_get_trait(F.has_net_name):
+        if trait.level == F.has_net_name.Level.EXPECTED:
+            required_names.add(trait.name)
+            return required_names, suggested_names, implicit_candidates
+
+        if trait.level == F.has_net_name.Level.SUGGESTED:
+            rank = _calculate_suggested_name_rank(mif, depth)
+            suggested_names.append((trait.name, rank))
+            return required_names, suggested_names, implicit_candidates
+
+    # Handle implicit names
+    try:
+        name = mif.get_name()
+    except NodeNoParent:
+        return required_names, suggested_names, implicit_candidates
+
+    # Adjust depth for interfaces on the same level
+    if mif.get_parent_of_type(L.ModuleInterface):
+        depth -= 1
+
+    # Calculate implicit name score
+    score = (1 / (depth + 1)) * _name_shittiness(name.lower())
+    implicit_candidates[name] = score
+
+    return required_names, suggested_names, implicit_candidates
+
+
+def _collect_naming_info_from_interfaces(
+    mifs: list[F.Electrical],
+) -> tuple[set[str], list[tuple[str, int]], dict[str, float]]:
+    """Aggregate naming information from multiple interfaces."""
+    all_required: set[str] = set()
+    all_suggested: list[tuple[str, int]] = []
+    all_implicit: dict[str, float] = defaultdict(float)
+
+    for mif in mifs:
+        required, suggested, implicit = _extract_net_name_info(mif)
+        all_required.update(required)
+        all_suggested.extend(suggested)
+        for name, score in implicit.items():
+            all_implicit[name] += score
+
+    return all_required, all_suggested, all_implicit
+
+
+def _determine_base_name(
+    suggested: list[tuple[str, int]], implicit: dict[str, float]
+) -> str | None:
+    """Determine the best base name from suggested and implicit candidates."""
+    if suggested:
+        # Use the suggestion with the lowest rank (highest priority)
+        return min(suggested, key=lambda x: x[1])[0]
+
+    if implicit:
+        # Use the implicit name with the highest score
+        return max(implicit, key=implicit.get)  # type: ignore
+
+    return None
+
+
+def _process_unnamed_nets(
+    unnamed_nets: dict[F.Net, list[F.Electrical]], names: FuncDict[F.Net, _NetName]
+) -> None:
+    """Process nets without names, determining their base names."""
     for net, mifs in unnamed_nets.items():
-        net_required_names: set[str] = set()
-        net_suggested_names: list[tuple[str, int]] = []
-        implicit_name_candidates: Mapping[str, float] = defaultdict(float)
-        case_insensitive_map: Mapping[str, str] = {}
+        # Collect all naming information
+        required, suggested, implicit = _collect_naming_info_from_interfaces(mifs)
 
-        for mif in mifs:
-            # If there's net info, use it
-            depth = len(mif.get_hierarchy())
-
-            if t := mif.try_get_trait(F.has_net_name):
-                if t.level == F.has_net_name.Level.EXPECTED:
-                    net_required_names.add(t.name)
-                elif t.level == F.has_net_name.Level.SUGGESTED:
-                    # Weight suggestions by hierarchy: higher up (shallower) wins.
-                    # Apply small bonuses for coming from owner iface/module
-                    # and for well-known labels.
-                    rank = len(mif.get_hierarchy())
-                    owner_iface = mif.get_parent_of_type(L.ModuleInterface)
-                    if owner_iface is not None and not isinstance(
-                        owner_iface, F.Electrical
-                    ):
-                        rank -= 1
-                    if L.Node.nearest_common_ancestor(mif):
-                        rank -= 1
-                    net_suggested_names.append((t.name, rank))
-                continue
-
-            # Rate implicit names
-            # lower case so we are not case sensitive
-            try:
-                name = mif.get_name()
-            except NodeNoParent:
-                # Skip no names
-                continue
-
-            lower_name = name.lower()
-            case_insensitive_map[lower_name] = name
-
-            if mif.get_parent_of_type(L.ModuleInterface):
-                # Give interfaces on the same level a fighting chance
-                depth -= 1
-
-            implicit_name_candidates[case_insensitive_map[lower_name]] += _decay(
-                depth
-            ) * _name_shittiness(lower_name)
-
-        # Check required names
-        if net_required_names:
-            if len(set(net_required_names)) > 1:
+        # Handle required names (highest priority)
+        if required:
+            if len(required) > 1:
                 raise UserException(
-                    f"Multiple conflicting required net names: {net_required_names}"
+                    f"Multiple conflicting required net names: {required}"
                 )
-            net.add(F.has_overriden_name_defined(net_required_names.pop()))
+            net.add(F.has_overriden_name_defined(required.pop()))
             continue
 
-        # Initialize the net name for the remaining processing
+        # Create net name entry and determine base name
         names[net] = _NetName()
+        names[net].base_name = _determine_base_name(suggested, implicit)
 
-        if net_suggested_names:
-            names[net].base_name = min(net_suggested_names, key=lambda x: x[1])[0]
 
-        elif implicit_name_candidates:
-            # Type ignored on this because they typing on both max and defaultdict.get
-            # is poor. This is actually correct, and supposed to return None sometimes
-            names[net].base_name = max(
-                implicit_name_candidates,
-                key=implicit_name_candidates.get,  # type: ignore
-            )
+def _is_generic_name(name: str | None) -> bool:
+    """Check if a name is generic and should be replaced."""
+    if name is None:
+        return True
 
-        # Apply required affixes from connected interfaces
-        prefixes: list[str] = []
-        suffixes: list[str] = []
-        for mif in mifs:
-            if affix := mif.try_get_trait(F.has_net_name_affix):
-                if getattr(affix, "required_prefix", None):
-                    prefixes.append(str(affix.required_prefix))
-                if getattr(affix, "required_suffix", None):
-                    suffixes.append(str(affix.required_suffix))
-        if prefixes:
-            names[net].required_prefix = prefixes[0]
-        if suffixes:
-            names[net].required_suffix = suffixes[0]
+    generic_names = {"line", "hv"}
+    generic_patterns = [
+        lambda n: n.startswith("unnamed"),
+        lambda n: re.match(r"^(_\d+|p\d+)$", n) is not None,
+    ]
 
-        # If we have an affix and the base name is generic (e.g. 'line', 'hv'),
-        # prefer the interface instance name as the base (e.g. 'iso_spi').
-        def _best_iface_name_from_mifs(mifs: Iterable[F.Electrical]) -> str | None:
-            candidates: list[tuple[str, int]] = []
-            for mif in mifs:
-                try:
-                    chosen_name: str | None = None
-                    chosen_depth: int | None = None
-                    for node, name_in_parent in mif.get_hierarchy():
-                        if not node.get_parent():
-                            continue
-                        if isinstance(node, L.ModuleInterface) and not isinstance(
-                            node, F.Electrical
-                        ):
-                            chosen_name = name_in_parent
-                            chosen_depth = len(node.get_hierarchy())
-                            break
-                    if chosen_name is None:
-                        continue
-                    candidates.append((chosen_name, int(chosen_depth or 0)))
-                except NodeNoParent:
-                    continue
-            if not candidates:
-                return None
-            return min(candidates, key=lambda x: x[1])[0]
+    return name in generic_names or any(pattern(name) for pattern in generic_patterns)
 
-        base = names[net].base_name
-        if (names[net].required_suffix or names[net].required_prefix) and (
-            base is None
-            or base == "line"
-            or base == "hv"
-            or base.startswith("unnamed")
-            or re.match(r"^(_\d+|p\d+)$", base or "")
-        ):
-            if (iface_name := _best_iface_name_from_mifs(mifs)) is not None:
-                names[net].base_name = iface_name
 
-        # Do not apply diff-pair affixes to well-known power rails
-        base_lower = (names[net].base_name or "").lower()
-        if base_lower in {"gnd", "vcc", "vdd", "vss"}:
-            names[net].required_prefix = None
-            names[net].required_suffix = None
+def _is_power_rail_name(name: str | None) -> bool:
+    """Check if a name is a well-known power rail."""
+    if name is None:
+        return False
+    return name.lower() in {"gnd", "vcc", "vdd", "vss"}
 
-    for conflict_nets in _conflicts(names):
-        # Prefer to add interface-based prefixes to ALL nets in the group and
-        # make them unique by minimally qualifying with ancestor names
-        def _interface_name_path_for_net(net: F.Net) -> list[str] | None:
-            """Pick the best interface path for prefixing a net.
 
-            Prefer ElectricPower interface instance names and include the nearest
-            owning module name to minimally qualify when needed, e.g.:
-            - power_5v
-            - sensor-power_5v
-            Avoid generic names like 'pins' or 'unnamed'.
-            """
-            best: tuple[int, list[str]] | None = None
-            for mif in net.get_connected_interfaces():
-                try:
-                    hierarchy = [
-                        (node, name)
-                        for node, name in mif.get_hierarchy()
-                        if node.get_parent()
-                    ]
-                    # Find first non-Electrical ModuleInterface in chain
-                    anchor_idx = None
-                    for idx, (node, name) in enumerate(hierarchy):
-                        if isinstance(node, L.ModuleInterface) and not isinstance(
-                            node, F.Electrical
-                        ):
-                            anchor_idx = idx
-                            break
-                    if anchor_idx is None:
-                        continue
+def _extract_interface_candidate(mif: F.Electrical) -> tuple[str, int] | None:
+    """Extract a naming candidate from a single interface."""
+    try:
+        for node, name_in_parent in mif.get_hierarchy():
+            if not node.get_parent():
+                continue
 
-                    anchor_node, anchor_name = hierarchy[anchor_idx]
-                    # Find nearest owning Module before the anchor
-                    owner_name = None
-                    for j in range(anchor_idx - 1, -1, -1):
-                        node_j, name_j = hierarchy[j]
-                        if isinstance(node_j, Module):
-                            owner_name = name_j
-                            break
+            is_interface = isinstance(node, L.ModuleInterface)
+            is_not_electrical = not isinstance(node, F.Electrical)
 
-                    # Compose path
-                    path: list[str] = (
-                        [owner_name, anchor_name] if owner_name else [anchor_name]
-                    )
+            if is_interface and is_not_electrical:
+                return (name_in_parent, len(node.get_hierarchy()))
+    except NodeNoParent:
+        pass
 
-                    # Score candidates
-                    score = 0
-                    if isinstance(anchor_node, F.ElectricPower):
-                        score += 2
-                    if owner_name:
-                        score += 1
-                    if anchor_name.startswith("pins") or anchor_name.startswith(
-                        "unnamed"
-                    ):
-                        score -= 2
+    return None
 
-                    cand = (score, path)
-                    if best is None or cand > best:
-                        best = cand
 
-                except NodeNoParent:
-                    continue
+def _find_best_interface_name(mifs: Iterable[F.Electrical]) -> str | None:
+    """Find the best interface name from connected interfaces."""
+    candidates = [
+        candidate
+        for mif in mifs
+        if (candidate := _extract_interface_candidate(mif)) is not None
+    ]
 
-            return None if best is None else best[1]
+    if not candidates:
+        return None
 
-        paths: dict[F.Net, list[str] | None] = {
-            net: _interface_name_path_for_net(net) for net in conflict_nets
-        }
+    # Return the name with the smallest depth (highest in hierarchy)
+    return min(candidates, key=lambda x: x[1])[0]
 
-        if any(p for p in paths.values()):
-            # Compute minimal unique suffix per path
-            suffix_len: dict[F.Net, int] = {
-                net: 1 for net in conflict_nets if paths[net]
-            }
 
-            def _keys() -> dict[F.Net, tuple[str, ...]]:
-                keys: dict[F.Net, tuple[str, ...]] = {}
-                for net in conflict_nets:
-                    p = paths[net]
-                    if not p:
-                        continue
-                    keys[net] = tuple(p[-suffix_len[net] :])
-                return keys
+def _collect_affixes(mifs: list[F.Electrical]) -> tuple[str | None, str | None]:
+    """Collect prefix and suffix from interfaces."""
+    prefixes: list[str] = []
+    suffixes: list[str] = []
 
-            keys = _keys()
-            # Increase suffix length for colliding keys until unique or max depth
-            progressed = True
-            while progressed:
-                progressed = False
-                # group by key
-                groups: dict[tuple[str, ...], list[F.Net]] = {}
-                for net, key in keys.items():
-                    groups.setdefault(key, []).append(net)
-                for key, nets_in_key in groups.items():
-                    if len(nets_in_key) <= 1:
-                        continue
-                    for net in nets_in_key:
-                        p = paths[net]
-                        if not p:
-                            continue
-                        if suffix_len[net] < len(p):
-                            suffix_len[net] += 1
-                            progressed = True
-                if progressed:
-                    keys = _keys()
+    for mif in mifs:
+        affix = mif.try_get_trait(F.has_net_name_affix)
+        if not affix:
+            continue
 
-            # Assign per-net prefixes
-            for net in conflict_nets:
+        if prefix := getattr(affix, "required_prefix", None):
+            prefixes.append(str(prefix))
+        if suffix := getattr(affix, "required_suffix", None):
+            suffixes.append(str(suffix))
+
+    # Return first prefix and suffix found
+    return prefixes[0] if prefixes else None, suffixes[0] if suffixes else None
+
+
+def _should_replace_generic_name(net_name: _NetName) -> bool:
+    """Check if a generic base name should be replaced."""
+    has_affixes = bool(net_name.required_suffix or net_name.required_prefix)
+    return _is_generic_name(net_name.base_name) and has_affixes
+
+
+def _apply_affixes(
+    unnamed_nets: dict[F.Net, list[F.Electrical]], names: FuncDict[F.Net, _NetName]
+) -> None:
+    """Apply prefixes and suffixes from net name affixes."""
+    for net, mifs in unnamed_nets.items():
+        if net not in names:
+            continue
+
+        net_name = names[net]
+
+        # Apply affixes
+        prefix, suffix = _collect_affixes(mifs)
+        net_name.required_prefix = prefix
+        net_name.required_suffix = suffix
+
+        # Replace generic names when affixes are present
+        if _should_replace_generic_name(net_name):
+            if better_name := _find_best_interface_name(mifs):
+                net_name.base_name = better_name
+
+        # Protect power rails from affixes
+        if _is_power_rail_name(net_name.base_name):
+            net_name.required_prefix = None
+            net_name.required_suffix = None
+
+
+def _find_anchor_interface(hierarchy: list[tuple]) -> tuple[int, tuple] | None:
+    """Find the first non-Electrical ModuleInterface in hierarchy."""
+    for idx, (node, name) in enumerate(hierarchy):
+        is_interface = isinstance(node, L.ModuleInterface)
+        is_not_electrical = not isinstance(node, F.Electrical)
+
+        if is_interface and is_not_electrical:
+            return idx, (node, name)
+
+    return None
+
+
+def _find_owner_module(hierarchy: list[tuple], before_idx: int) -> str | None:
+    """Find the nearest owning Module before the given index."""
+    for j in range(before_idx - 1, -1, -1):
+        node, name = hierarchy[j]
+        if isinstance(node, Module):
+            return name
+    return None
+
+
+def _score_interface_path(anchor_node, anchor_name: str, has_owner: bool) -> int:
+    """Calculate score for an interface path."""
+    score = 0
+
+    if isinstance(anchor_node, F.ElectricPower):
+        score += 2
+
+    if has_owner:
+        score += 1
+
+    if anchor_name.startswith("pins") or anchor_name.startswith("unnamed"):
+        score -= 2
+
+    return score
+
+
+def _process_single_interface(mif: F.Electrical) -> tuple[int, list[str]] | None:
+    """Process a single interface to get its path and score."""
+    try:
+        hierarchy = [
+            (node, name) for node, name in mif.get_hierarchy() if node.get_parent()
+        ]
+
+        # Find anchor interface
+        anchor_result = _find_anchor_interface(hierarchy)
+        if not anchor_result:
+            return None
+
+        anchor_idx, (anchor_node, anchor_name) = anchor_result
+
+        # Find owner module
+        owner_name = _find_owner_module(hierarchy, anchor_idx)
+
+        # Build path
+        path = [owner_name, anchor_name] if owner_name else [anchor_name]
+
+        # Calculate score
+        score = _score_interface_path(anchor_node, anchor_name, bool(owner_name))
+
+        return score, path
+
+    except NodeNoParent:
+        return None
+
+
+def _get_interface_path_for_net(net: F.Net) -> list[str] | None:
+    """Get the best interface path for prefixing a net."""
+    candidates = [
+        result
+        for mif in net.get_connected_interfaces()
+        if (result := _process_single_interface(mif)) is not None
+    ]
+
+    if not candidates:
+        return None
+
+    # Return the path with the highest score
+    _, best_path = max(candidates, key=lambda x: x[0])
+    return best_path
+
+
+def _get_owner_module_name(net: F.Net) -> str | None:
+    """Get the name of the owning module for a net."""
+    for mif in net.get_connected_interfaces():
+        try:
+            hierarchy = mif.get_hierarchy()
+            for node, name_in_parent in hierarchy:
+                if node.get_parent() and isinstance(node, Module):
+                    return name_in_parent
+        except NodeNoParent:
+            continue
+    return None
+
+
+def _compute_minimal_unique_prefixes(
+    paths: dict[F.Net, list[str] | None], conflict_nets: list[F.Net]
+) -> dict[F.Net, int]:
+    """Compute minimal suffix lengths to make paths unique."""
+    suffix_len: dict[F.Net, int] = {net: 1 for net in conflict_nets if paths[net]}
+
+    def get_keys() -> dict[F.Net, tuple[str, ...]]:
+        return {net: tuple(p[-suffix_len[net] :]) for net, p in paths.items() if p}
+
+    keys = get_keys()
+
+    # Increase suffix length until all keys are unique
+    while True:
+        # Group nets by their current key
+        groups: dict[tuple[str, ...], list[F.Net]] = {}
+        for net, key in keys.items():
+            groups.setdefault(key, []).append(net)
+
+        # Check if any groups have conflicts
+        has_conflict = False
+        for key, nets_in_key in groups.items():
+            if len(nets_in_key) <= 1:
+                continue
+
+            # Increase suffix length for conflicting nets
+            for net in nets_in_key:
                 p = paths[net]
-                if p:
-                    # If the chosen path is too generic (e.g., starts with 'pins' or
-                    # 'unnamed') and there are no required affixes influencing
-                    # semantics, prefer owner name
-                    leaf = p[-1] if p else None
-                    if (
-                        leaf
-                        and (leaf.startswith("pins") or leaf.startswith("unnamed"))
-                        and not names[net].required_prefix
-                        and not names[net].required_suffix
-                    ):
-                        owner_mod_name: str | None = None
-                        for mif in net.get_connected_interfaces():
-                            try:
-                                for node, name_in_parent in mif.get_hierarchy():
-                                    if not node.get_parent():
-                                        continue
-                                    if isinstance(node, Module):
-                                        owner_mod_name = name_in_parent
-                                        break
-                                if owner_mod_name:
-                                    break
-                            except NodeNoParent:
-                                continue
-                        if owner_mod_name:
-                            names[net].prefix = owner_mod_name
-                        else:
-                            names[net].prefix = "-".join(p[-suffix_len[net] :])
-                    else:
-                        names[net].prefix = "-".join(p[-suffix_len[net] :])
-                else:
-                    # Fallback to owning module instance name if available
-                    owner_name: str | None = None
-                    for mif in net.get_connected_interfaces():
-                        try:
-                            for node, name_in_parent in mif.get_hierarchy():
-                                if not node.get_parent():
-                                    continue
-                                if isinstance(node, Module):
-                                    owner_name = name_in_parent
-                                    break
-                            if owner_name:
-                                break
-                        except NodeNoParent:
-                            continue
-                    if owner_name:
-                        names[net].prefix = owner_name
-                    else:
-                        if lcn := L.Node.nearest_common_ancestor(
-                            *net.get_connected_interfaces()
-                        ):
-                            names[net].prefix = lcn[0].get_full_name()
+                if p and suffix_len[net] < len(p):
+                    suffix_len[net] += 1
+                    has_conflict = True
 
-    # Resolve remaining conflicts by prefixing on
-    # the lowest common node's full name
+        if not has_conflict:
+            break
+
+        keys = get_keys()
+
+    return suffix_len
+
+
+def _is_generic_path_leaf(path: list[str] | None) -> bool:
+    """Check if the leaf of a path is generic."""
+    if not path:
+        return False
+
+    leaf = path[-1]
+    return leaf.startswith("pins") or leaf.startswith("unnamed")
+
+
+def _get_fallback_prefix(net: F.Net) -> str | None:
+    """Get a fallback prefix for a net without a path."""
+    # Try owner module name
+    if owner_name := _get_owner_module_name(net):
+        return owner_name
+
+    # Try lowest common ancestor
+    interfaces = net.get_connected_interfaces()
+    if lcn := L.Node.nearest_common_ancestor(*interfaces):
+        return lcn[0].get_full_name()
+
+    return None
+
+
+def _assign_prefix_for_net(
+    net: F.Net,
+    path: list[str] | None,
+    suffix_len: dict[F.Net, int],
+    names: FuncDict[F.Net, _NetName],
+) -> None:
+    """Assign a prefix to a single net."""
+    net_name = names[net]
+
+    if not path:
+        # No path available, use fallback
+        net_name.prefix = _get_fallback_prefix(net)
+        return
+
+    # Check if we should use owner name instead of generic path
+    should_use_owner = (
+        _is_generic_path_leaf(path)
+        and not net_name.required_prefix
+        and not net_name.required_suffix
+    )
+
+    if should_use_owner:
+        if owner_name := _get_owner_module_name(net):
+            net_name.prefix = owner_name
+            return
+
+    # Use the computed suffix from the path
+    net_name.prefix = "-".join(path[-suffix_len[net] :])
+
+
+def _resolve_conflicts_with_prefixes(names: FuncDict[F.Net, _NetName]) -> None:
+    """Resolve naming conflicts by adding interface-based prefixes."""
+    for conflict_nets in _conflicts(names):
+        # Get interface paths for all conflicting nets
+        paths = {net: _get_interface_path_for_net(net) for net in conflict_nets}
+
+        # Skip if no paths available
+        if not any(paths.values()):
+            continue
+
+        # Compute minimal unique prefixes
+        suffix_len = _compute_minimal_unique_prefixes(paths, list(conflict_nets))
+
+        # Assign prefixes to each net
+        for net in conflict_nets:
+            _assign_prefix_for_net(net, paths[net], suffix_len, names)
+
+
+def _resolve_conflicts_with_lca(names: FuncDict[F.Net, _NetName]) -> None:
+    """Resolve remaining conflicts using lowest common ancestor."""
     for conflict_nets in _conflicts(names):
         for net in conflict_nets:
-            if names[net].prefix is None:
-                if lcn := L.Node.nearest_common_ancestor(
-                    *net.get_connected_interfaces()
-                ):
-                    names[net].prefix = lcn[0].get_full_name()
+            # Skip if already has a prefix
+            if names[net].prefix is not None:
+                continue
 
-    # Resolve remaining conflicts by suffixing on a number
+            # Try to use lowest common ancestor
+            interfaces = net.get_connected_interfaces()
+            lcn = L.Node.nearest_common_ancestor(*interfaces)
+
+            if lcn:
+                names[net].prefix = lcn[0].get_full_name()
+
+
+def _resolve_conflicts_with_suffixes(names: FuncDict[F.Net, _NetName]) -> None:
+    """Resolve remaining conflicts by adding numeric suffixes."""
     for conflict_nets in _conflicts(names):
         for i, net in enumerate(conflict_nets):
             names[net].suffix = i
 
-    # Override the net names we've derived
-    for net, name in names.items():
-        # Limit name length to 255 chars
-        if len(name.name) > 255:
-            name_str = name.name[:200] + "..." + name.name[-50:]
-        else:
-            name_str = name.name
-        net.add(F.has_overriden_name_defined(name_str))
+
+def _truncate_long_name(name: str, max_length: int = 255) -> str:
+    """Truncate a long name to fit within the maximum length."""
+    if len(name) <= max_length:
+        return name
+
+    # Keep first 200 chars and last 50 chars
+    return name[:200] + "..." + name[-50:]
+
+
+def _apply_names_to_nets(names: FuncDict[F.Net, _NetName]) -> None:
+    """Apply the computed names to nets, with length limiting."""
+    for net, net_name in names.items():
+        final_name = _truncate_long_name(net_name.name)
+        net.add(F.has_overriden_name_defined(final_name))
+
+
+def attach_net_names(nets: Iterable[F.Net]) -> None:
+    """
+    Generate good net names for all nets in a design.
+
+    This function assigns meaningful names to nets based on:
+    1. Required names from has_net_name traits (highest priority)
+    2. Suggested names from has_net_name traits
+    3. Implicit names from connected interfaces
+    4. Conflict resolution through prefixing and suffixing
+
+    The naming process follows these steps:
+    - Collect and sort unnamed nets
+    - Register already-named nets
+    - Process unnamed nets to determine base names
+    - Apply affixes (prefixes/suffixes) from traits
+    - Resolve conflicts through hierarchical prefixing
+    - Apply numeric suffixes for remaining conflicts
+    - Apply final names to nets
+    """
+    names = FuncDict[F.Net, _NetName]()
+
+    # Collect unnamed nets
+    unnamed_nets = _collect_unnamed_nets(nets)
+
+    # Register already-named nets
+    _register_named_nets(nets, names)
+
+    # Process unnamed nets
+    _process_unnamed_nets(unnamed_nets, names)
+
+    # Apply affixes
+    _apply_affixes(unnamed_nets, names)
+
+    # Resolve conflicts through prefixing
+    _resolve_conflicts_with_prefixes(names)
+
+    # Resolve remaining conflicts with lowest common ancestor
+    _resolve_conflicts_with_lca(names)
+
+    # Final conflict resolution with numeric suffixes
+    _resolve_conflicts_with_suffixes(names)
+
+    # Apply the computed names to nets
+    _apply_names_to_nets(names)
 
     assert all(n.has_trait(F.has_overriden_name) for n in nets)

--- a/src/faebryk/exporters/netlist/graph.py
+++ b/src/faebryk/exporters/netlist/graph.py
@@ -131,20 +131,13 @@ class _NetName:
         There must always be some base, and if it's not provided, it's just 'net'
         Prefixes and suffixes are joined with a "-" if they exist.
         """
-        # Build parts explicitly so empty-string prefixes don't create a leading dash
-        parts: list[str] = []
-        if self.prefix is not None and self.prefix != "":
-            parts.append(str(self.prefix))
-        # Combine required affixes directly onto the base segment without hyphens
-        base = str(self.base_name or "net")
-        if self.required_prefix:
-            base = f"{self.required_prefix}{base}"
-        if self.required_suffix:
-            base = f"{base}{self.required_suffix}"
-        parts.append(base)
-        if self.suffix is not None:
-            parts.append(str(self.suffix))
-        return "-".join(parts)
+        base_name = self.base_name or "net"
+        prefix = f"{self.prefix}-" if self.prefix else ""
+        suffix = f"-{self.suffix}" if self.suffix else ""
+        required_prefix = self.required_prefix or ""
+        required_suffix = self.required_suffix or ""
+
+        return f"{prefix}{required_prefix}{base_name}{required_suffix}{suffix}"
 
 
 def _conflicts(

--- a/src/faebryk/library/Addressor.py
+++ b/src/faebryk/library/Addressor.py
@@ -44,3 +44,10 @@ class Addressor(ModuleInterface):
                 lambda line=line: line.set(True),
                 lambda line=line: line.set(False),
             )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        for i, line in enumerate(self.address_lines):
+            line.add(
+                F.has_net_name(f"address_bit_{i}", level=F.has_net_name.Level.SUGGESTED)
+            )

--- a/src/faebryk/library/Battery.py
+++ b/src/faebryk/library/Battery.py
@@ -30,3 +30,9 @@ class Battery(Module):
         return F.has_single_electric_reference_defined(self.power)
 
     designator = L.f_field(F.has_designator_prefix)("BAT")
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.power.hv.add(
+            F.has_net_name("BAT_VCC", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/CAN.py
+++ b/src/faebryk/library/CAN.py
@@ -18,3 +18,12 @@ class CAN(ModuleInterface):
 
     def __preinit__(self) -> None:
         self.speed.add(F.is_bus_parameter())
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.diff_pair.p.line.add(
+            F.has_net_name("CAN_H", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.diff_pair.n.line.add(
+            F.has_net_name("CAN_L", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/CapacitorElectrolytic.py
+++ b/src/faebryk/library/CapacitorElectrolytic.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class CapacitorElectrolytic(F.Capacitor):
     pickable = None  # type: ignore
-    attach_to_footprint = None
+    can_attach_to_footprint_symmetrically = None  # type: ignore
 
     anode: F.Electrical
     cathode: F.Electrical
@@ -33,4 +33,11 @@ class CapacitorElectrolytic(F.Capacitor):
             },
             accept_prefix=False,
             case_sensitive=False,
+        )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.anode.add(F.has_net_name("anode", level=F.has_net_name.Level.SUGGESTED))
+        self.cathode.add(
+            F.has_net_name("cathode", level=F.has_net_name.Level.SUGGESTED)
         )

--- a/src/faebryk/library/DifferentialPair.py
+++ b/src/faebryk/library/DifferentialPair.py
@@ -47,5 +47,5 @@ class DifferentialPair(ModuleInterface):
         """
         super().__postinit__(*args, **kwargs)
         # Apply suffixes to the electrical lines of the signals
-        self.p.line.add(F.has_net_name_affix.suffix("_p"))
-        self.n.line.add(F.has_net_name_affix.suffix("_n"))
+        self.p.line.add(F.has_net_name_affix.suffix("_P"))
+        self.n.line.add(F.has_net_name_affix.suffix("_N"))

--- a/src/faebryk/library/DifferentialPair.py
+++ b/src/faebryk/library/DifferentialPair.py
@@ -37,3 +37,15 @@ class DifferentialPair(ModuleInterface):
         self.connect_shallow(terminated_bus)
 
         return terminated_bus
+
+    def __postinit__(self, *args, **kwargs):
+        """Attach required net name suffixes for KiCad differential pair detection.
+
+        Ensures nets associated with the positive and negative lines end with
+        `_p` and `_n` respectively. The naming algorithm will append these
+        required affixes while still deconflicting names globally.
+        """
+        super().__postinit__(*args, **kwargs)
+        # Apply suffixes to the electrical lines of the signals
+        self.p.line.add(F.has_net_name_affix.suffix("_p"))
+        self.n.line.add(F.has_net_name_affix.suffix("_n"))

--- a/src/faebryk/library/Diode.py
+++ b/src/faebryk/library/Diode.py
@@ -93,3 +93,10 @@ class Diode(Module):
         self, input_voltage_V: ParameterOperatable
     ):
         return (input_voltage_V - self.forward_voltage) / self.current
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.anode.add(F.has_net_name("anode", level=F.has_net_name.Level.SUGGESTED))
+        self.cathode.add(
+            F.has_net_name("cathode", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/ElectricPower.py
+++ b/src/faebryk/library/ElectricPower.py
@@ -131,3 +131,9 @@ class ElectricPower(F.Power):
     def gnd(self) -> F.Electrical:
         """Lower-voltage side of the power interface."""
         return self.lv
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        # Apply suffixes to the electrical lines of the signals
+        self.hv.add(F.has_net_name("VCC", level=F.has_net_name.Level.SUGGESTED))
+        self.lv.add(F.has_net_name("GND", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/EnablePin.py
+++ b/src/faebryk/library/EnablePin.py
@@ -35,3 +35,9 @@ class EnablePin(ModuleInterface):
     def get_enable_signal(self):
         self.make_required()
         return self.enable.line
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.enable.line.add(
+            F.has_net_name("ENABLE", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/Ethernet.py
+++ b/src/faebryk/library/Ethernet.py
@@ -26,3 +26,19 @@ class Ethernet(ModuleInterface):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.led_speed.line.add(
+            F.has_net_name("ETH_LED_SPEED", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.led_link.line.add(
+            F.has_net_name("ETH_LED_LINK", level=F.has_net_name.Level.SUGGESTED)
+        )
+        for i, pair in enumerate(self.pairs):
+            pair.p.line.add(
+                F.has_net_name(f"ETH_P{i}", level=F.has_net_name.Level.SUGGESTED)
+            )
+            pair.n.line.add(
+                F.has_net_name(f"ETH_P{i}", level=F.has_net_name.Level.SUGGESTED)
+            )

--- a/src/faebryk/library/HDMI.py
+++ b/src/faebryk/library/HDMI.py
@@ -33,3 +33,14 @@ class HDMI(ModuleInterface):
 
     def __preinit__(self) -> None:
         pass
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        for i in range(3):
+            net_name = f"HDMI_D{i}"
+            self.data[i].p.line.add(
+                F.has_net_name(net_name, level=F.has_net_name.Level.SUGGESTED)
+            )
+            self.data[i].n.line.add(
+                F.has_net_name(net_name, level=F.has_net_name.Level.SUGGESTED)
+            )

--- a/src/faebryk/library/I2C.py
+++ b/src/faebryk/library/I2C.py
@@ -21,13 +21,9 @@ class I2C(ModuleInterface):
     scl: F.ElectricLogic
     sda: F.ElectricLogic
 
-    address = L.p_field(
-        within=L.Range(0, 0x7F),
-        domain=L.Domains.Numbers.NATURAL(),
-    )
+    address = L.p_field(within=L.Range(0, 0x7F), domain=L.Domains.Numbers.NATURAL())
     bus_addresses = L.p_field(
-        within=L.Range(0, 0x7F),
-        domain=L.Domains.Numbers.NATURAL(),
+        within=L.Range(0, 0x7F), domain=L.Domains.Numbers.NATURAL()
     )
 
     frequency = L.p_field(
@@ -91,6 +87,11 @@ class I2C(ModuleInterface):
     def __preinit__(self) -> None:
         self.frequency.add(F.is_bus_parameter())
         # self.bus_addresses.add(F.is_bus_parameter(reduce=(self.address, Union)))
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.scl.line.add(F.has_net_name("SCL", level=F.has_net_name.Level.SUGGESTED))
+        self.sda.line.add(F.has_net_name("SDA", level=F.has_net_name.Level.SUGGESTED))
 
     def _hack_get_connected(self):
         """

--- a/src/faebryk/library/I2S.py
+++ b/src/faebryk/library/I2S.py
@@ -24,3 +24,9 @@ class I2S(ModuleInterface):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.sd.line.add(F.has_net_name("SD", level=F.has_net_name.Level.SUGGESTED))
+        self.ws.line.add(F.has_net_name("WS", level=F.has_net_name.Level.SUGGESTED))
+        self.sck.line.add(F.has_net_name("SCK", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/JTAG.py
+++ b/src/faebryk/library/JTAG.py
@@ -21,3 +21,20 @@ class JTAG(ModuleInterface):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.dbgrq.line.add(
+            F.has_net_name("DBGRQ", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.tdo.line.add(F.has_net_name("TDO", level=F.has_net_name.Level.SUGGESTED))
+        self.tdi.line.add(F.has_net_name("TDI", level=F.has_net_name.Level.SUGGESTED))
+        self.tms.line.add(F.has_net_name("TMS", level=F.has_net_name.Level.SUGGESTED))
+        self.tck.line.add(F.has_net_name("TCK", level=F.has_net_name.Level.SUGGESTED))
+        self.n_trst.line.add(
+            F.has_net_name("N_TRST", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.n_reset.line.add(
+            F.has_net_name("N_RESET", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.vtref.add(F.has_net_name("VTREF", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/MOSFET.py
+++ b/src/faebryk/library/MOSFET.py
@@ -64,3 +64,9 @@ class MOSFET(Module):
             accept_prefix=False,
             case_sensitive=False,
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.source.add(F.has_net_name("source", level=F.has_net_name.Level.SUGGESTED))
+        self.gate.add(F.has_net_name("gate", level=F.has_net_name.Level.SUGGESTED))
+        self.drain.add(F.has_net_name("drain", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/MultiSPI.py
+++ b/src/faebryk/library/MultiSPI.py
@@ -24,3 +24,14 @@ class MultiSPI(ModuleInterface):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.clock.line.add(
+            F.has_net_name("clock", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.chip_select.line.add(
+            F.has_net_name("chip_select", level=F.has_net_name.Level.SUGGESTED)
+        )
+        for i, line in enumerate(self.data):
+            line.add(F.has_net_name(f"data_{i}", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/PDM.py
+++ b/src/faebryk/library/PDM.py
@@ -25,3 +25,13 @@ class PDM(ModuleInterface):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.data.line.add(F.has_net_name("DATA", level=F.has_net_name.Level.SUGGESTED))
+        self.clock.line.add(
+            F.has_net_name("CLOCK", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.select.line.add(
+            F.has_net_name("SELECT", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/ResistorVoltageDivider.py
+++ b/src/faebryk/library/ResistorVoltageDivider.py
@@ -77,3 +77,9 @@ class ResistorVoltageDivider(Module):
         v_out.alias_is(v_in * ratio)
         max_current.alias_is(abs(v_in) / r_total)
         ratio.alias_is(r_bottom / r_total)
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.output.line.add(
+            F.has_net_name("VDIV_OUTPUT", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/SPI.py
+++ b/src/faebryk/library/SPI.py
@@ -16,3 +16,9 @@ class SPI(ModuleInterface):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.sclk.line.add(F.has_net_name("SCLK", level=F.has_net_name.Level.SUGGESTED))
+        self.miso.line.add(F.has_net_name("MISO", level=F.has_net_name.Level.SUGGESTED))
+        self.mosi.line.add(F.has_net_name("MOSI", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/SWD.py
+++ b/src/faebryk/library/SWD.py
@@ -17,3 +17,18 @@ class SWD(ModuleInterface):
         return F.has_single_electric_reference_defined(
             F.ElectricLogic.connect_all_module_references(self)
         )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.clk.line.add(
+            F.has_net_name("SWD_CLK", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.dio.line.add(
+            F.has_net_name("SWD_DIO", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.swo.line.add(
+            F.has_net_name("SWD_SWO", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.reset.line.add(
+            F.has_net_name("SWD_RESET", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/UART.py
+++ b/src/faebryk/library/UART.py
@@ -20,3 +20,12 @@ class UART(ModuleInterface):
     #    return F.has_single_electric_reference_defined(
     #       F.ElectricLogic.connect_all_module_references(self)
     #   )
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.rts.line.add(F.has_net_name("RTS", level=F.has_net_name.Level.SUGGESTED))
+        self.cts.line.add(F.has_net_name("CTS", level=F.has_net_name.Level.SUGGESTED))
+        self.dtr.line.add(F.has_net_name("DTR", level=F.has_net_name.Level.SUGGESTED))
+        self.dsr.line.add(F.has_net_name("DSR", level=F.has_net_name.Level.SUGGESTED))
+        self.dcd.line.add(F.has_net_name("DCD", level=F.has_net_name.Level.SUGGESTED))
+        self.ri.line.add(F.has_net_name("RI", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/UART_Base.py
+++ b/src/faebryk/library/UART_Base.py
@@ -21,3 +21,8 @@ class UART_Base(ModuleInterface):
 
     def __preinit__(self) -> None:
         self.baud.add(F.is_bus_parameter())
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.rx.line.add(F.has_net_name("RX", level=F.has_net_name.Level.SUGGESTED))
+        self.tx.line.add(F.has_net_name("TX", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/USB2_0_IF.py
+++ b/src/faebryk/library/USB2_0_IF.py
@@ -23,3 +23,11 @@ class USB2_0_IF(ModuleInterface):
 
     d: Data
     buspower: F.ElectricPower
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.d.p.line.add(F.has_net_name("USB_D", level=F.has_net_name.Level.SUGGESTED))
+        self.d.n.line.add(F.has_net_name("USB_D", level=F.has_net_name.Level.SUGGESTED))
+        self.buspower.hv.add(
+            F.has_net_name("USB_VBUS", level=F.has_net_name.Level.SUGGESTED)
+        )

--- a/src/faebryk/library/USB_C.py
+++ b/src/faebryk/library/USB_C.py
@@ -13,3 +13,14 @@ class USB_C(ModuleInterface):
     sbu2: F.Electrical
     rx: F.DifferentialPair
     tx: F.DifferentialPair
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.cc1.add(F.has_net_name("CC1", level=F.has_net_name.Level.SUGGESTED))
+        self.cc2.add(F.has_net_name("CC2", level=F.has_net_name.Level.SUGGESTED))
+        self.sbu1.add(F.has_net_name("SBU1", level=F.has_net_name.Level.SUGGESTED))
+        self.sbu2.add(F.has_net_name("SBU2", level=F.has_net_name.Level.SUGGESTED))
+        self.rx.p.line.add(F.has_net_name("RX", level=F.has_net_name.Level.SUGGESTED))
+        self.rx.n.line.add(F.has_net_name("RX", level=F.has_net_name.Level.SUGGESTED))
+        self.tx.p.line.add(F.has_net_name("TX", level=F.has_net_name.Level.SUGGESTED))
+        self.tx.n.line.add(F.has_net_name("TX", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/XtalIF.py
+++ b/src/faebryk/library/XtalIF.py
@@ -36,3 +36,9 @@ class XtalIF(ModuleInterface):
         #          parametrization
         # ------------------------------------
         pass
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.xin.add(F.has_net_name("XIN", level=F.has_net_name.Level.SUGGESTED))
+        self.xout.add(F.has_net_name("XOUT", level=F.has_net_name.Level.SUGGESTED))
+        self.gnd.add(F.has_net_name("GND", level=F.has_net_name.Level.SUGGESTED))

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -15,6 +15,7 @@ This way we can add new modules without changing this file
 # flake8: noqa: I001
 # flake8: noqa: E501
 
+from faebryk.library.has_net_name import has_net_name
 from faebryk.library.Electrical import Electrical
 from faebryk.library.has_designator_prefix import has_designator_prefix
 from faebryk.library.is_bus_parameter import is_bus_parameter
@@ -22,7 +23,6 @@ from faebryk.library.has_package_requirements import has_package_requirements
 from faebryk.library.can_specialize_defined import can_specialize_defined
 from faebryk.library.Power import Power
 from faebryk.library.can_be_surge_protected import can_be_surge_protected
-from faebryk.library.has_net_name import has_net_name
 from faebryk.library.Signal import Signal
 from faebryk.library.has_single_electric_reference import has_single_electric_reference
 from faebryk.library.is_optional_defined import is_optional_defined

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -57,6 +57,7 @@ from faebryk.library.is_esphome_bus import is_esphome_bus
 from faebryk.library.is_pickable import is_pickable
 from faebryk.library.is_representable_by_single_value import is_representable_by_single_value
 from faebryk.library.XtalIF import XtalIF
+from faebryk.library.has_net_name_affix import has_net_name_affix
 from faebryk.library.has_pin_association_heuristic import has_pin_association_heuristic
 from faebryk.library.Filter import Filter
 from faebryk.library.Logic import Logic

--- a/src/faebryk/library/has_net_name_affix.py
+++ b/src/faebryk/library/has_net_name_affix.py
@@ -1,0 +1,60 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+from faebryk.core.trait import TraitImpl
+from faebryk.libs.library import L
+
+
+class has_net_name_affix(L.Trait.decless()):
+    """Require a fixed prefix/suffix to be applied to a derived net name.
+
+    This does not set or suggest the base name, it enforces that when a name is
+    generated it is of the form: `${required_prefix}${base}${required_suffix}`.
+
+    Typical usage is for differential pairs, e.g. enforce `_p` / `_n` suffixes.
+    Attach to an `F.Electrical` interface (e.g. a `.line`).
+    """
+
+    def __init__(
+        self, required_prefix: str | None = None, required_suffix: str | None = None
+    ):
+        super().__init__()
+        self.required_prefix = required_prefix
+        self.required_suffix = required_suffix
+
+    @classmethod
+    def prefix(cls, value: str) -> "has_net_name_affix":
+        return cls(required_prefix=value, required_suffix=None)
+
+    @classmethod
+    def suffix(cls, value: str) -> "has_net_name_affix":
+        return cls(required_prefix=None, required_suffix=value)
+
+    @classmethod
+    def both(cls, prefix: str, suffix: str) -> "has_net_name_affix":
+        return cls(required_prefix=prefix, required_suffix=suffix)
+
+    def handle_duplicate(self, old: TraitImpl, node: L.Node) -> bool:
+        # If re-added, keep the more specific (non-None) values; error on conflicts
+        assert isinstance(old, has_net_name_affix)
+        # Merge if compatible
+        if (
+            self.required_prefix
+            and old.required_prefix
+            and self.required_prefix != old.required_prefix
+        ):
+            # Different required prefixes are incompatible; let caller decide
+            return super().handle_duplicate(old, node)
+        if (
+            self.required_suffix
+            and old.required_suffix
+            and self.required_suffix != old.required_suffix
+        ):
+            return super().handle_duplicate(old, node)
+
+        # Prefer new non-None values
+        if self.required_prefix is not None:
+            old.required_prefix = self.required_prefix
+        if self.required_suffix is not None:
+            old.required_suffix = self.required_suffix
+        return False

--- a/test/end_to_end/test_net_naming.py
+++ b/test/end_to_end/test_net_naming.py
@@ -53,3 +53,48 @@ def test_agreeing_net_names(build_app: EXEC_T, save_tmp_path_on_failure: None):
     )
 
     assert p.returncode == 0
+
+
+def test_duplicate_suggested_net_names(
+    build_app: EXEC_T, save_tmp_path_on_failure: None
+):
+    """
+    Two different nets with the same suggested name should not error.
+    They should be deconflicted by the naming algorithm.
+    """
+    _, _, p = build_app(
+        """
+        import Resistor
+        module App:
+            a = new Resistor
+            b = new Resistor
+            a.p1.suggest_net_name = "net"
+            b.p1.suggest_net_name = "net"
+        """,
+        [],
+    )
+
+    assert p.returncode == 0
+
+
+def test_conflicting_suggested_names_on_same_net(
+    build_app: EXEC_T, save_tmp_path_on_failure: None
+):
+    """
+    If multiple suggested names exist on the same electrical net, the build
+    should succeed. One suggestion will win and no error should be raised.
+    """
+    _, _, p = build_app(
+        """
+        import Resistor
+        module App:
+            a = new Resistor
+            b = new Resistor
+            a.p1 ~ b.p1
+            a.p1.suggest_net_name = "net1"
+            b.p1.suggest_net_name = "net2"
+        """,
+        [],
+    )
+
+    assert p.returncode == 0

--- a/test/end_to_end/test_net_naming.py
+++ b/test/end_to_end/test_net_naming.py
@@ -98,3 +98,22 @@ def test_conflicting_suggested_names_on_same_net(
     )
 
     assert p.returncode == 0
+
+
+def test_differential_pair_suffixes(build_app: EXEC_T, save_tmp_path_on_failure: None):
+    """
+    DifferentialPair should enforce `_p` and `_n` suffixes on the nets.
+    """
+    _, stdout, p = build_app(
+        """
+        import DifferentialPair
+        module App:
+            dp = new DifferentialPair
+            # Connect each side to a unique signal to force separate nets
+            signal a ~ dp.p.line
+            signal b ~ dp.n.line
+        """,
+        [],
+    )
+
+    assert p.returncode == 0

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -21,10 +21,10 @@ def from_temp_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("config", ["ato", "fab"])
+@pytest.mark.parametrize("config", ["default"])
 def test_app(config):
     _, stderr, _ = run_live(
-        [sys.executable, "-m", "atopile", "build", "examples", "-b", config],
+        [sys.executable, "-m", "atopile", "build", "examples/quickstart", "-b", config],
         env={**os.environ, "NONINTERACTIVE": "1"},
         stdout=print,
         stderr=print,

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -11,60 +11,24 @@ from faebryk.libs.util import run_live
 # Get the examples directory relative to this test file
 EXAMPLES_DIR = _repo_root() / "examples"
 
-FABLL_EXAMPLES = [p for p in EXAMPLES_DIR.glob("*.py") if p.is_file()]
-ATO_EXAMPLES = [p for p in EXAMPLES_DIR.glob("*.ato") if p.is_file()]
-
-SLOW = {"ch2_8_mcu"}
-XFAILURES = {"ch2_8_mcu": "Pin matching issues"}
-
-
-def _get_marks(example: Path):
-    return [
-        *(
-            [pytest.mark.xfail(reason=XFAILURES[example.stem])]
-            if example.stem in XFAILURES
-            else []
-        ),
-        *([pytest.mark.slow] if example.stem in SLOW else []),
-    ]
-
 
 @pytest.mark.parametrize(
     "example",
-    [
-        pytest.param(example, marks=_get_marks(example))
-        for example in FABLL_EXAMPLES + ATO_EXAMPLES
-    ],
+    [pytest.param(manifest.parent) for manifest in EXAMPLES_DIR.glob("*/ato.yaml")],
     ids=lambda p: p.stem,
 )
 def test_examples_build(
     example: Path, tmp_path: Path, repo_root: Path, save_tmp_path_on_failure: None
 ):
-    assert example.exists()
-
     example_copy = tmp_path / example.name
-    example_copy.write_text(example.read_text(encoding="utf-8"), encoding="utf-8")
-    example = example_copy
+    shutil.copytree(example, example_copy)
 
-    # Copy dependencies to the tmp dir directly because standalone mode doens't include
-    example_modules = repo_root / "test" / "common" / "resources" / ".ato" / "modules"
-    for item in example_modules.glob("*"):
-        if item.is_dir():
-            shutil.copytree(item, tmp_path / item.name)
-        else:
-            shutil.copy(item, tmp_path / item.name)
+    assert example_copy.exists()
 
     _, stderr, _ = run_live(
-        [
-            sys.executable,
-            "-m",
-            "atopile",
-            "build",
-            "--standalone",
-            f"{example}:App",
-        ],
+        [sys.executable, "-m", "atopile", "build"],
         env={**os.environ, "NONINTERACTIVE": "1"},
-        cwd=tmp_path,
+        cwd=example_copy,
         stdout=print,
         stderr=print,
     )


### PR DESCRIPTION
## Summary

This PR improves net naming and adds differential pair support:
Introduces suggested net names in ato (suggest_net_name) that strongly influence naming while deconflicting.
Adds required net name affixes (prefix/suffix) for cases like differential pairs.
Refines the net naming algorithm: better deconfliction, no leading dashes, and smarter base-name selection.

## Key changes

- Add suggest_net_name setter in src/atopile/attributes.py using F.has_net_name(Level.SUGGESTED).
- Net naming algorithm updates (src/faebryk/exporters/netlist/graph.py)
- Respect suggested and expected names as hints/requirements.
- Avoid leading “-” when no prefix is present.
- Prefer interface instance name for conflict prefixing.
- Support required affixes via F.has_net_name_affix; affixes are concatenated directly to the base (no extra hyphen).
- If a required affix exists and the base name is too generic (e.g. “line”), use the interface instance name as base (e.g. iso_spi).


## New trait: required affixes

- src/faebryk/library/has_net_name_affix.py: F.has_net_name_affix(required_prefix=None, required_suffix=None)

Differential pairs

-src/faebryk/library/DifferentialPair.py: Enforce _p/_n suffixes on p.line/n.line using F.has_net_name_affix.suffix("_p") and suffix("_n").

Example outcome: iso_spi_p, iso_spi_n instead of line_p/line_n.


## Tests

test/end_to_end/test_net_naming.py
Added:
test_duplicate_suggested_net_names
test_conflicting_suggested_names_on_same_net
test_differential_pair_suffixes
All net naming tests pass locally.

## Before/After examples
<img width="432" height="531" alt="Screenshot 2025-08-13 at 12 59 11 PM" src="https://github.com/user-attachments/assets/1ac9e59d-0957-4021-b83a-dee1d773e89f" />

Leading dash removed: -gnd-0 → gnd-0
Diff pair nets: line-0/line-1 → iso_spi_p/iso_spi_n
Power nets preserved: power_3v3-vcc, power_5v-vcc

<img width="510" height="294" alt="Screenshot 2025-08-13 at 12 45 39 PM" src="https://github.com/user-attachments/assets/3a8cc16e-2f75-4b21-986e-052b70d8ba25" />


<img width="507" height="276" alt="Screenshot 2025-08-13 at 12 56 59 PM" src="https://github.com/user-attachments/assets/730cfe3b-3f4d-4259-92b7-0953ae67a9f9" />


## Notes

Behavior is backward compatible for typical nets; explicit overrides still enforced.
Suggested names are deconflicted automatically; required names must agree, or error.