### PR TITLE
Build: Add sort within list 

### DIFF
--- a/src/faebryk/libs/part_lifecycle.py
+++ b/src/faebryk/libs/part_lifecycle.py
@@ -631,7 +631,9 @@ class PartLifecycle:
                 property_values["atopile_subaddresses"] = (
                     "["
                     + ", ".join(
-                        subaddress.serialize() for subaddress in sub_pcb_t.addresses
+                        sorted(
+                            subaddress.serialize() for subaddress in sub_pcb_t.addresses
+                        )
                     )
                     + "]"
                 )


### PR DESCRIPTION
Some builds will switch values within lists causing frozen failures with no real change to layout.

Added sorting within lists to increase CI reliability.