### PR TITLE
Library: JTAG/SWD: Add better example, add missing interface

### DIFF
--- a/src/faebryk/library/JTAG.py
+++ b/src/faebryk/library/JTAG.py
@@ -12,6 +12,7 @@ class JTAG(ModuleInterface):
     tdi: F.ElectricLogic
     tms: F.ElectricLogic
     tck: F.ElectricLogic
+    rtck: F.ElectricLogic
     n_trst: F.ElectricLogic
     n_reset: F.ElectricLogic
     vtref: F.ElectricPower
@@ -31,6 +32,7 @@ class JTAG(ModuleInterface):
         self.tdi.line.add(F.has_net_name("TDI", level=F.has_net_name.Level.SUGGESTED))
         self.tms.line.add(F.has_net_name("TMS", level=F.has_net_name.Level.SUGGESTED))
         self.tck.line.add(F.has_net_name("TCK", level=F.has_net_name.Level.SUGGESTED))
+        self.rtck.line.add(F.has_net_name("RTCK", level=F.has_net_name.Level.SUGGESTED))
         self.n_trst.line.add(
             F.has_net_name("N_TRST", level=F.has_net_name.Level.SUGGESTED)
         )

--- a/src/faebryk/library/JTAG.py
+++ b/src/faebryk/library/JTAG.py
@@ -45,40 +45,36 @@ class JTAG(ModuleInterface):
         example="""
         import JTAG, ElectricPower, Resistor
 
+        from "x/y/y.ato" import SomeMCU
+        from "a/b/c.ato" import SomeDebugger
+
         jtag = new JTAG
+        microcontroller = new SomeMCU
+        debugger = new SomeDebugger
 
         # Connect voltage reference for all logic signals
         power_3v3 = new ElectricPower
         assert power_3v3.voltage within 3.3V +/- 5%
         jtag.vtref ~ power_3v3
 
-        # All logic signals use same reference
-        jtag.tdo.reference ~ power_3v3
-        jtag.tdi.reference ~ power_3v3
-        jtag.tms.reference ~ power_3v3
-        jtag.tck.reference ~ power_3v3
-        jtag.n_trst.reference ~ power_3v3
-        jtag.n_reset.reference ~ power_3v3
-        jtag.dbgrq.reference ~ power_3v3
+        # Connect to microcontroller specific pins (mcu has no JTAG interface)
+        microcontroller.gpio[0] ~ jtag.tdo
+        microcontroller.gpio[1] ~ jtag.tdi
+        microcontroller.gpio[2] ~ jtag.tms
+        microcontroller.gpio[3] ~ jtag.tck
+        microcontroller.reset ~ jtag.n_reset
 
-        # Connect to microcontroller JTAG interface
-        microcontroller.jtag_tdo ~ jtag.tdo.line
-        microcontroller.jtag_tdi ~ jtag.tdi.line
-        microcontroller.jtag_tms ~ jtag.tms.line
-        microcontroller.jtag_tck ~ jtag.tck.line
-        microcontroller.jtag_trst ~ jtag.n_trst.line
-        microcontroller.reset_n ~ jtag.n_reset.line
-
-        # Connect to JTAG debugger/programmer
+        # Connect to JTAG debugger (has JTAG interface)
         debugger.jtag ~ jtag
 
         # Pullup resistors for reset lines
+        # mostly only on target side, not debugger side
         trst_pullup = new Resistor
         reset_pullup = new Resistor
         trst_pullup.resistance = 10kohm +/- 5%
         reset_pullup.resistance = 10kohm +/- 5%
-        jtag.n_trst.line ~> trst_pullup ~> power_3v3.hv
-        jtag.n_reset.line ~> reset_pullup ~> power_3v3.hv
+        jtag.n_trst.line ~> trst_pullup ~> jtag.n_trst.reference.hv
+        jtag.n_reset.line ~> reset_pullup ~> jtag.n_reset.reference.hv
         """,
         language=F.has_usage_example.Language.ato,
     )

--- a/src/faebryk/library/SWD.py
+++ b/src/faebryk/library/SWD.py
@@ -37,29 +37,32 @@ class SWD(ModuleInterface):
         example="""
         import SWD, ElectricPower, Resistor
 
+        from "x/y/y.ato" import SomeMCU
+        from "a/b/c.ato" import SomeDebugger
+
         swd = new SWD
+        microcontroller = new SomeMCU
+        debugger = new SomeDebugger
 
         # Connect power reference for logic levels
         power_3v3 = new ElectricPower
         assert power_3v3.voltage within 3.3V +/- 5%
-        swd.clk.reference ~ power_3v3
-        swd.dio.reference ~ power_3v3
-        swd.swo.reference ~ power_3v3
-        swd.reset.reference ~ power_3v3
+        swd.reference_shim ~ power_3v3
 
-        # Connect to microcontroller SWD interface
-        microcontroller.swd_clk ~ swd.clk.line
-        microcontroller.swd_dio ~ swd.dio.line
-        microcontroller.swd_swo ~ swd.swo.line
-        microcontroller.reset_n ~ swd.reset.line
+        # Connect to microcontroller specific pins (mcu has no SWD interface)
+        microcontroller.gpio[0] ~ swd.clk
+        microcontroller.gpio[1] ~ swd.dio
+        microcontroller.gpio[2] ~ swd.swo
+        microcontroller.reset ~ swd.reset
 
-        # Connect to debugger/programmer
+        # Connect to debugger (has SWD interface)
         debugger.swd ~ swd
 
         # Optional pullup resistors for robust operation
+        # mostly only on target side, not debugger side
         reset_pullup = new Resistor
         reset_pullup.resistance = 10kohm +/- 5%
-        swd.reset.line ~> reset_pullup ~> power_3v3.hv
+        swd.reset.line ~> reset_pullup ~> swd.reset.reference.hv
 
         # SWD is commonly used for ARM Cortex-M debugging and programming
         """,


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

- add missing RTCK (return clock) interface to JTAG
- makes the ato examples of JTAG and SWD a bit better/more clear

<!--
What does this PR change?
-->

## Motivation

Needed the missing interface in JTAG. 

<!--
Why is this change necessary?
Which #issue does it fix?
-->