### PR TITLE
Tests: Add a `require_network` marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "not_in_ci: marks tests that should not be run in CI",
     "regression: marks tests that are used for deeper regression testing. May be slow and flaky.",
+    "require_network: marks tests that depends on the runner to be online."
 ]
 
 [tool.ruff]

--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -803,6 +803,7 @@ def test_inspect_enum_led():
 
 
 @pytest.mark.usefixtures("setup_project_config")
+@pytest.mark.require_network
 def test_simple_pick():
     led = F.LED()
 
@@ -836,6 +837,7 @@ def test_simple_pick():
 
 
 @pytest.mark.usefixtures("setup_project_config")
+@pytest.mark.require_network
 def test_simple_negative_pick():
     led = F.LED()
     led.color.constrain_subset(L.EnumSet(F.LED.Color.RED, F.LED.Color.BLUE))
@@ -883,6 +885,7 @@ def test_simple_negative_pick():
     )
 
 
+@pytest.mark.require_network
 def test_jlcpcb_pick_resistor():
     resistor = F.Resistor()
     resistor.resistance.constrain_subset(L.Range(10 * P.ohm, 100 * P.ohm))
@@ -894,6 +897,7 @@ def test_jlcpcb_pick_resistor():
     print(resistor.get_trait(F.has_part_picked).get_part())
 
 
+@pytest.mark.require_network
 def test_jlcpcb_pick_capacitor():
     capacitor = F.Capacitor()
     capacitor.capacitance.constrain_subset(L.Range(100 * P.nF, 1 * P.uF))

--- a/test/core/test_mif_connect.py
+++ b/test/core/test_mif_connect.py
@@ -1207,6 +1207,7 @@ def test_regression_rp2040_usb_diffpair():
 
 
 @pytest.mark.slow
+@pytest.mark.require_network
 def test_regression_rp2040_usb_diffpair_full():
     app = RP2040_ReferenceDesign()
     rp2040_2 = RP2040()

--- a/test/libs/test_lcsc.py
+++ b/test/libs/test_lcsc.py
@@ -15,6 +15,7 @@ INTERACTIVE_TESTING = False
 
 
 @pytest.mark.usefixtures("setup_project_config")
+@pytest.mark.require_network
 class TestLCSC(unittest.TestCase):
     def test_model_translations(self):
         test_parts = {


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

Introduces a new marker for tests that can only be run in a online environment.

<!--
What does this PR change?
-->

## Motivation

This change is meant to simplify the exclusion list on nixpkgs side, which run the tests without network, to ensure reproducibility

<!--
Why is this change necessary?
Which #issue does it fix?
-->
