### PR TITLE
Libs: Parts: hide value text on fab layer

### DIFF
--- a/src/faebryk/libs/part_lifecycle.py
+++ b/src/faebryk/libs/part_lifecycle.py
@@ -650,8 +650,8 @@ class PartLifecycle:
                         )
                         pcb_fp.propertys[prop_name].value = prop_value
 
-                    # Always hide Value properties to prevent fab layer text
-                    if prop_name == "Value":
+                    # Hide fab layer properties
+                    if prop.layer == "F.Fab":
                         pcb_fp.propertys[prop_name].hide = True
 
                 ### If it's a new property, add it


### PR DESCRIPTION
Remove value text on fab layer because its ugly
 Eg: "1µF ±10% 25V X5R"
 
