### PR TITLE
CLI: Add package report-status command

### DIFF
--- a/src/atopile/cli/package.py
+++ b/src/atopile/cli/package.py
@@ -654,7 +654,7 @@ def report_status(
     api.report_build_status(
         identifier=config.project.package.identifier,
         version=config.project.package.version,
-        atopile_release="0.12.3",  # str(get_installed_atopile_version()),
+        atopile_release=str(get_installed_atopile_version()),
         atopile_githash=git_hash,
         builder_metadata=builder_metadata,
         is_building=success,

--- a/src/faebryk/libs/backend/packages/api.py
+++ b/src/faebryk/libs/backend/packages/api.py
@@ -400,7 +400,7 @@ class PackagesAPIClient:
 
     @property
     @once
-    def _headers(self) -> dict[str, str]:
+    def _base_headers(self) -> dict[str, str]:
         return {
             "User-Agent": (
                 f"atopile/{get_package_version('atopile')} "
@@ -409,13 +409,26 @@ class PackagesAPIClient:
             ),
         }
 
+    @property
+    @once
+    def _auth_headers(self) -> dict[str, str]:
+        """
+        Currently, the only supported authentication method is Github Actions OIDC.
+        """
+        try:
+            from github_oidc.client import get_actions_header
+
+            return get_actions_header(urlparse(self._cfg.api_url).netloc)
+        except Exception as e:
+            raise Errors.AuthenticationError(e) from e
+
     def _get(
         self,
         url: str,
         timeout: float = 10,
     ) -> Response:
         with http_client(
-            self._headers,
+            self._base_headers,
             verify=not config.project.dangerously_skip_ssl_verification,
         ) as client:
             response = client.get(f"{self._cfg.api_url}{url}", timeout=timeout)
@@ -434,14 +447,10 @@ class PackagesAPIClient:
         url: str,
         data: Any,
         timeout: float = 10,
-        authenticate: bool = False,
+        skip_auth: bool = False,
     ) -> Response:
-        headers = {}
-        if authenticate:
-            headers |= self._authenticate()
-
         with http_client(
-            self._headers,
+            self._base_headers | ({} if skip_auth else self._auth_headers),
             verify=not config.project.dangerously_skip_ssl_verification,
         ) as client:
             response = client.post(
@@ -467,7 +476,7 @@ class PackagesAPIClient:
         skip_verify: bool = False,
     ) -> Response:
         with http_client(
-            self._headers,
+            self._base_headers,
             verify=(not skip_verify)
             or config.project.dangerously_skip_ssl_verification,
         ) as client:
@@ -489,17 +498,6 @@ class PackagesAPIClient:
                 detail = response.text
             raise Errors.PackagesApiHTTPError(e, detail) from e
         return response
-
-    def _authenticate(self) -> dict[str, str]:
-        """
-        Currently, the only supported authentication method is Github Actions OIDC.
-        """
-        try:
-            from github_oidc.client import get_actions_header
-
-            return get_actions_header(urlparse(self._cfg.api_url).netloc)
-        except Exception as e:
-            raise Errors.AuthenticationError(e) from e
 
     def publish(
         self,
@@ -527,7 +525,7 @@ class PackagesAPIClient:
                     artifacts_size=artifacts.bytes if artifacts else None,
                     manifest=dist.manifest.model_dump(mode="json"),
                 ).to_dict(),  # type: ignore
-                authenticate=not skip_auth,
+                skip_auth=skip_auth,
             )
         except Errors.PackagesApiHTTPError as e:
             if e.code == 409:
@@ -566,7 +564,7 @@ class PackagesAPIClient:
                 data=_Endpoints.PublishUploadComplete.Request(
                     release_id=response.release_id,
                 ).to_dict(),  # type: ignore
-                authenticate=not skip_auth,
+                skip_auth=skip_auth,
             )
         except Errors.PackagesApiHTTPError:
             raise
@@ -625,7 +623,7 @@ class PackagesAPIClient:
         filepath.parent.mkdir(parents=True, exist_ok=True)
         # download the file to output_path
         with http_client(
-            self._headers,
+            self._base_headers,
             verify=not config.project.dangerously_skip_ssl_verification,
         ) as client:
             response = client.get(url)

--- a/src/faebryk/libs/backend/packages/api.py
+++ b/src/faebryk/libs/backend/packages/api.py
@@ -691,7 +691,7 @@ class PackagesAPIClient:
             r = self._post(
                 _Endpoints.ReportBuildStatus.url(request=request),
                 data=request.to_dict(),  # type: ignore
-                authenticate=not skip_auth,
+                skip_auth=skip_auth,
             )
         except Errors.PackagesApiHTTPError as e:
             if e.code == 409:

--- a/src/faebryk/libs/backend/packages/api.py
+++ b/src/faebryk/libs/backend/packages/api.py
@@ -217,6 +217,22 @@ class _Schemas:
     class PackageReleases:
         releases: list["_Schemas.PackageReleaseInfo"]
 
+    @dataclass_json
+    @dataclass(frozen=True)
+    class ReportBuildStatusRequest:
+        identifier: str
+        version: str
+        atopile_release: str
+        atopile_githash: str
+        builder_metadata: dict
+        is_building: bool
+        built_at: str
+
+    @dataclass_json
+    @dataclass(frozen=True)
+    class SuccessResponse:
+        status: Literal["ok"] = "ok"
+
 
 class _Endpoints:
     class PackageReleases:
@@ -295,6 +311,16 @@ class _Endpoints:
 
         Request = _Schemas.UploadCompleteRequest
         Response = _Schemas.PublishCompletedResponse
+
+    class ReportBuildStatus:
+        TYPE = _Type.POST
+
+        @staticmethod
+        def url(request: "_Endpoints.ReportBuildStatus.Request") -> str:
+            return f"/v1/package/{request.identifier}/releases/{request.version}/build-status"
+
+        Request = _Schemas.ReportBuildStatusRequest
+        Response = _Schemas.SuccessResponse
 
 
 class Errors:
@@ -639,3 +665,41 @@ class PackagesAPIClient:
     def query_packages(self, query: str) -> _Endpoints.Packages.Response:
         r = self._get(_Endpoints.Packages.url(_Endpoints.Packages.Request(query)))
         return _Endpoints.Packages.Response.from_dict(r.json())  # type: ignore
+
+    def report_build_status(
+        self,
+        identifier: str,
+        version: str,
+        atopile_release: str,
+        atopile_githash: str,
+        builder_metadata: dict,
+        is_building: bool,
+        built_at: datetime,
+        skip_auth: bool = False,
+    ) -> _Endpoints.ReportBuildStatus.Response:
+        """
+        Report build status to the package registry.
+        """
+        request = _Endpoints.ReportBuildStatus.Request(
+            identifier=identifier,
+            version=version,
+            atopile_release=atopile_release,
+            atopile_githash=atopile_githash,
+            is_building=is_building,
+            builder_metadata=builder_metadata,
+            built_at=built_at.isoformat(),
+        )
+        try:
+            r = self._post(
+                _Endpoints.ReportBuildStatus.url(request=request),
+                data=request.to_dict(),  # type: ignore
+                authenticate=not skip_auth,
+            )
+        except Errors.PackagesApiHTTPError as e:
+            if e.code == 409:
+                raise Errors.ReleaseAlreadyExistsError.from_http(e) from e
+            raise
+
+        response = _Endpoints.ReportBuildStatus.Response.from_dict(r.json())  # type: ignore
+
+        return response


### PR DESCRIPTION
Add report-status CLI command that takes pass fail argument and uses github auth similar to publish cmd.

* Reports some basic information about the computer running the build
* Reports atopile version used to build
* Reports build success bool param
* Reports built_at which is really the reported time.