### PR TITLE
Library: Fix: add back RS485 half duplex

### DIFF
--- a/src/faebryk/library/RS485HalfDuplex.py
+++ b/src/faebryk/library/RS485HalfDuplex.py
@@ -15,14 +15,16 @@ class RS485HalfDuplex(ModuleInterface):
 
     diff_pair: F.DifferentialPair
 
+    @L.rt_field
+    def single_electric_reference(self):
+        return F.has_single_electric_reference_defined(
+            F.ElectricSignal.connect_all_module_references(self)
+        )
+
     def __postinit__(self, *args, **kwargs):
         super().__postinit__(*args, **kwargs)
-        self.diff_pair.p.line.add(
-            F.has_net_name("A", level=F.has_net_name.Level.SUGGESTED)
-        )
-        self.diff_pair.n.line.add(
-            F.has_net_name("B", level=F.has_net_name.Level.SUGGESTED)
-        )
+        self.diff_pair.p.line.add(F.has_net_name_affix.suffix("_A"))
+        self.diff_pair.n.line.add(F.has_net_name_affix.suffix("_B"))
 
     usage_example = L.f_field(F.has_usage_example)(
         example="""
@@ -33,8 +35,10 @@ class RS485HalfDuplex(ModuleInterface):
         # Connect to rs485 transceiver
         rs485_transceiver.rs485 ~ rs485_bus
 
-        # Connect to rs485 connector
-        rs485_connector.rs485 ~ rs485_bus
+        # Connect to connector pins
+        rs485_connector.1 ~ rs485_bus.diff_pair.p.line
+        rs485_connector.2 ~ rs485_bus.diff_pair.n.line
+        rs485_connector.3 ~ rs485_bus.reference_shim.lv
         """,
         language=F.has_usage_example.Language.ato,
     )

--- a/src/faebryk/library/RS485HalfDuplex.py
+++ b/src/faebryk/library/RS485HalfDuplex.py
@@ -1,0 +1,40 @@
+# This file is part of the faebryk project
+# SPDX-License-Identifier: MIT
+
+import faebryk.library._F as F
+from faebryk.core.moduleinterface import ModuleInterface
+from faebryk.libs.library import L
+
+
+class RS485HalfDuplex(ModuleInterface):
+    """
+    Half-duplex RS485 interface
+    A = p
+    B = n
+    """
+
+    diff_pair: F.DifferentialPair
+
+    def __postinit__(self, *args, **kwargs):
+        super().__postinit__(*args, **kwargs)
+        self.diff_pair.p.line.add(
+            F.has_net_name("A", level=F.has_net_name.Level.SUGGESTED)
+        )
+        self.diff_pair.n.line.add(
+            F.has_net_name("B", level=F.has_net_name.Level.SUGGESTED)
+        )
+
+    usage_example = L.f_field(F.has_usage_example)(
+        example="""
+        import RS485HalfDuplex
+
+        rs485_bus = new RS485HalfDuplex
+
+        # Connect to rs485 transceiver
+        rs485_transceiver.rs485 ~ rs485_bus
+
+        # Connect to rs485 connector
+        rs485_connector.rs485 ~ rs485_bus
+        """,
+        language=F.has_usage_example.Language.ato,
+    )

--- a/src/faebryk/library/_F.py
+++ b/src/faebryk/library/_F.py
@@ -156,6 +156,7 @@ from faebryk.library.ResistorVoltageDivider import ResistorVoltageDivider
 from faebryk.library.has_single_electric_reference_shared import has_single_electric_reference_shared
 from faebryk.library.requires_pulls import requires_pulls
 from faebryk.library.CAN import CAN
+from faebryk.library.RS485HalfDuplex import RS485HalfDuplex
 from faebryk.library.Addressor import Addressor
 from faebryk.library.CAN_TTL import CAN_TTL
 from faebryk.library.EnablePin import EnablePin


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

Add back RS485HalfDuplex that was deleted in https://github.com/atopile/atopile/pull/1488
Also add suggested net name, an example to bring it up to standard, and connected reference


## Motivation

I'm using it in almost all my projects :sweat_smile: