### PR TITLE
VSCE: Fix `stat` on non-existent watched files

### DIFF
--- a/src/vscode-atopile/src/common/file-resource-watcher.ts
+++ b/src/vscode-atopile/src/common/file-resource-watcher.ts
@@ -56,7 +56,7 @@ class FileWatcher implements vscode.Disposable {
     private last_mtime: number | undefined;
     private checkForChangesAndSave(): FileEventType {
         // TODO handle mTime missing
-        const mtime = fs.statSync(this.file_path).mtimeMs;
+        const mtime = fs.existsSync(this.file_path) ? fs.statSync(this.file_path).mtimeMs : undefined;
         if (mtime === this.last_mtime) {
             return FileEventType.Unchanged;
         }


### PR DESCRIPTION
Fixes repeated `ENOENT` errors in "Window" output pane. Occurs e.g. when a layout file path is implied by a manifest but hasn't yet been created.