### PR TITLE
Core: Fix pad primitives

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# 0.14 Staging branch
+
+This release will contain deep core changes. 
+Primarily using zig and the new graph language.
+Also restructuring of what faebryk means.
+
+Primary goals:
+- speed
+- maintainability
+- understanding of the core
+- more powerful graph
+- serializable graph
+
+
+TODO: Fill more in about the zig architecture and core architecture for the LLMs.

--- a/src/faebryk/core/zig/pcb.pyi
+++ b/src/faebryk/core/zig/pcb.pyi
@@ -549,6 +549,15 @@ class FpText:
     def __field_names__() -> list[str]: ...
     def __zig_address__(self) -> int: ...
 
+class PadPrimitives:
+    gr_polys: list[Polygon]
+
+    def __init__(self, *, gr_polys: list[Polygon]) -> None: ...
+    def __repr__(self) -> str: ...
+    @staticmethod
+    def __field_names__() -> list[str]: ...
+    def __zig_address__(self) -> int: ...
+
 class PadDrill:
     shape: str | None
     size_x: float | None
@@ -611,6 +620,7 @@ class Pad:
     options: PadOptions | None
     tenting: PadTenting | None
     uuid: str | None
+    primitives: PadPrimitives | None
 
     def __init__(
         self,
@@ -638,6 +648,7 @@ class Pad:
         options: PadOptions | None,
         tenting: PadTenting | None,
         uuid: str | None,
+        primitives: PadPrimitives | None,
     ) -> None: ...
     def __repr__(self) -> str: ...
     @staticmethod

--- a/src/faebryk/core/zig/src/sexp/kicad/pcb.zig
+++ b/src/faebryk/core/zig/src/sexp/kicad/pcb.zig
@@ -524,6 +524,18 @@ pub const FpText = struct {
 // Pad structures
 pub const Drill = f64;
 
+pub const PadPrimitive = union(enum) {
+    gr_poly: Polygon,
+};
+
+pub const PadPrimitives = struct {
+    gr_polys: list(Polygon) = .{},
+
+    pub const fields_meta = .{
+        .gr_polys = structure.SexpField{ .multidict = true, .sexp_name = "gr_poly" },
+    };
+};
+
 // PadDrill can be either a simple number (drill 1.2) or a structured drill with shape/size/offset
 pub const PadDrill = struct {
     shape: ?E_pad_drill_shape = null,
@@ -576,11 +588,13 @@ pub const Pad = struct {
     options: ?PadOptions = null,
     tenting: ?PadTenting = null,
     uuid: ?str = null,
+    primitives: ?PadPrimitives = null,
 
     pub const fields_meta = .{
         .name = structure.SexpField{ .positional = true },
         .type = structure.SexpField{ .positional = true },
         .shape = structure.SexpField{ .positional = true },
+        .primitives = structure.SexpField{ .sexp_name = "primitives" },
     };
 };
 


### PR DESCRIPTION
Description of issue:
Custom footprint geometries not supported in zig schema causing some footprints to be malformed.

Changes:
- Extend the Zig KiCad schema (sexp/kicad/pcb.zig) to model custom pad primitives by adding a PadPrimitives struct (with the canonical gr_poly list today) and the PadPrimitive union. Pads now surface an optional primitives field with the correct S-expression metadata, so custom geometry survives load/save on the staging branch.
- Update the generated Python stubs (faebryk/core/zig/pcb.pyi) to expose Pad.primitives, keeping the Python-facing API aligned with the Zig schema

Testing:
Re-installed LCSC part C19190416 via ato add on stage/0.14.x and compared the resulting footprint against the main-branch export—custom pads now retain the gr_poly point lists exactly.

<img width="1094" height="505" alt="Screenshot 2025-10-06 at 3 48 59 PM" src="https://github.com/user-attachments/assets/9566f9dd-9e91-46d4-8441-8e3e8ca47e80" />
<img width="1094" height="505" alt="Screenshot 2025-10-06 at 3 48 35 PM" src="https://github.com/user-attachments/assets/6ed97a47-e6f6-479b-acdb-0f6171759400" />

