### PR TITLE
Core: robustly get arch on Apple silicon

### DIFF
--- a/src/faebryk/core/zig/CMakeLists.txt
+++ b/src/faebryk/core/zig/CMakeLists.txt
@@ -30,7 +30,18 @@ set(ZIG_BUILD_STAMP "${ZIG_WORKDIR}/zig-out/pyzig.build.stamp")
 set(ZIG_ENV_PREFIX "")
 set(ZIG_TARGET_ARG "")
 if (APPLE)
-  if (CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+  # Prefer the active build architecture; fall back to the host CPU when
+  # CMAKE_OSX_ARCHITECTURES is unspecified (the default on local dev
+  # machines).
+  set(_CM_ARCH "")
+  if (CMAKE_OSX_ARCHITECTURES)
+    list(GET CMAKE_OSX_ARCHITECTURES 0 _CM_ARCH)
+  else()
+    set(_CM_ARCH "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+  endif()
+
+  string(TOLOWER "${_CM_ARCH}" _CM_ARCH_LOWER)
+  if (_CM_ARCH_LOWER MATCHES "arm64" OR _CM_ARCH_LOWER MATCHES "aarch64")
     set(_ZIG_ARCH "aarch64")
     set(_MAC_DEPLOY "11.0")      # first macOS with arm64
   else()


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

fixes issue where `CMAKE_OSX_ARCHITECTURES` is not set (default) on macos. now gets arch from host CPU and falls back to x86.

## Motivation

building ato fails if the wrong (default x86) arch is selected as build target on non x86
