### PR TITLE
libs: fix broken deps error message

### DIFF
--- a/src/faebryk/libs/project/dependencies.py
+++ b/src/faebryk/libs/project/dependencies.py
@@ -271,9 +271,9 @@ class ProjectDependencies:
             (None, dep) for dep in self.direct_deps
         ]
 
-        acc_errors = []
+        acc_errors: list[BrokenDependencyError] = []
         while deps_to_process:
-            to_add = []
+            to_add: list[tuple[ProjectDependency, ProjectDependency]] = []
             for parent, dep in deps_to_process:
                 try:
                     dups = all_deps.intersection({dep})


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

`error.message` does not seem to exists. Added typed lists to prevent future mistakes

## Motivation

was crashing