### PR TITLE
Improve version parsing and unit fallbacks

### DIFF
--- a/src/atopile/version.py
+++ b/src/atopile/version.py
@@ -42,9 +42,15 @@ def parse(version_str: str) -> Version:
         version = Version.parse(version_str)
     except ValueError:
         dot_split = version_str.split(".")
-        version_str = "-".join(
-            ".".join(fragments) for fragments in (dot_split[:3], dot_split[3:])
-        )
+
+        # pad short versions (e.g. "0.0") to valid semver length
+        if len(dot_split) < 3:
+            dot_split += ["0"] * (3 - len(dot_split))
+
+        base = ".".join(dot_split[:3])
+        remainder = ".".join(dot_split[3:]).strip("-")
+        version_str = base if not remainder else f"{base}-{remainder}"
+
         version = Version.parse(version_str)
 
     return version


### PR DESCRIPTION
## Summary
- make version parsing tolerant of short version strings so update checks succeed in development environments
- guard unit access against missing pointers with a dimensionless fallback and diagnostic logging
- allow dimensionless numeric literals to be converted and intersected alongside unitful values instead of crashing

## Testing
- `ato build examples/quickstart/quickstart.ato:App` *(fails: proxy 403 when fetching parts from the picker service)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69408a6b8eb48331b074e1f1eb7970a4)