### PR TITLE
Compiler: add handling of field-to-field assignment

### DIFF
--- a/src/atopile/compiler/ast_types.py
+++ b/src/atopile/compiler/ast_types.py
@@ -29,7 +29,7 @@ class is_assignable(fabll.Node):
 
     def switch_cast(
         self,
-    ) -> "AstString | Boolean | NewExpression | Quantity | BoundedQuantity | BilateralQuantity | BinaryExpression | GroupExpression":  # noqa: E501
+    ) -> "AstString | Boolean | NewExpression | Quantity | BoundedQuantity | BilateralQuantity | BinaryExpression | GroupExpression | FieldRef":  # noqa: E501
         types = [
             AstString,
             Boolean,
@@ -39,6 +39,7 @@ class is_assignable(fabll.Node):
             BilateralQuantity,
             BinaryExpression,
             GroupExpression,
+            FieldRef,
         ]
         obj = fabll.Traits(self).get_obj_raw()
         for t in types:
@@ -229,6 +230,7 @@ class FieldRefPart(fabll.Node):
 
 
 class FieldRef(fabll.Node):
+    _is_assignable = fabll.Traits.MakeEdge(is_assignable.MakeChild())
     _is_arithmetic = fabll.Traits.MakeEdge(is_arithmetic.MakeChild())
     _is_arithmetic_atom = fabll.Traits.MakeEdge(is_arithmetic_atom.MakeChild())
     _is_connectable = fabll.Traits.MakeEdge(is_connectable.MakeChild())


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

- Add missing is_assignalble trait for FielRef (fixes trait not found error)
- Add handling of field-to-field assignment (e.g. mod1.voltage = mod2.voltage)

## Motivation

Used in for example the Relay package where a sub module has a parameter defined (not constrained), upper module links the parameter to another sub module it's parameter, and the user constrains the parameter in their app.
