### PR TITLE
fix: logging: exclude atopile.model from spamming the debug logs

### DIFF
--- a/src/atopile/logging.py
+++ b/src/atopile/logging.py
@@ -77,11 +77,11 @@ def _is_serving() -> bool:
 
 def _should_log(record: logging.LogRecord) -> bool:
     """Filter for atopile/faebryk logs, excluding server/http unless serving."""
+    name = record.name
+    if name.startswith(("httpcore", "atopile.server", "atopile.model")):
+        return False
     if _is_serving():
         return True
-    name = record.name
-    if name.startswith("httpcore") or name.startswith("atopile.server"):
-        return False
     return name.startswith("atopile") or name.startswith("faebryk")
 
 
@@ -1196,7 +1196,8 @@ class LogHandler(RichHandler):
         if hide or not exc_type or not exc_value:
             return None
 
-        # Use console width or None (unlimited) for traceback width to prevent truncation
+        # Use console width or None (unlimited) for
+        # traceback width to prevent truncation
         width = getattr(self, "tracebacks_width", None) or getattr(
             self.console, "width", None
         )


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->
excludes atopile.model from logs

## Motivation

<!--
Why is this change necessary?
Which #issue does it fix?
-->
