### PR TITLE
Fix: build/target terminology

### DIFF
--- a/src/ui-server/src/components/ActiveProjectPanel.tsx
+++ b/src/ui-server/src/components/ActiveProjectPanel.tsx
@@ -350,12 +350,12 @@ function TargetSelector({
   if (targets.length === 0) {
     return (
       <div className="target-selector-empty">
-        <span>No targets defined</span>
+        <span>No builds defined</span>
         {onCreateTarget && (
           <button
             className="create-target-btn"
             onClick={onCreateTarget}
-            title="Create new target"
+            title="Create new build"
           >
             <Plus size={12} />
           </button>
@@ -377,7 +377,7 @@ function TargetSelector({
           aria-expanded={isOpen}
         >
           <Target size={12} className="target-icon" />
-          <span className="target-trigger-name">{activeTarget?.name || 'Select target'}</span>
+          <span className="target-trigger-name">{activeTarget?.name || 'Select build'}</span>
           {activeTarget?.entry && (
             <span className="target-trigger-entry">{activeTarget.entry.split(':').pop()}</span>
           )}
@@ -417,7 +417,7 @@ function TargetSelector({
         <button
           className="create-target-btn"
           onClick={onCreateTarget}
-          title="Create new target"
+          title="Create new build"
           disabled={disabled}
         >
           <Plus size={12} />
@@ -613,7 +613,7 @@ function NewTargetForm({
   return (
     <form className="new-target-form" onSubmit={handleSubmit} onKeyDown={handleKeyDown}>
       <div className="form-header">
-        <span className="form-title">New Target{projectName ? ` in ${projectName}` : ''}</span>
+        <span className="form-title">New Build{projectName ? ` in ${projectName}` : ''}</span>
         <button
           type="button"
           className="form-close-btn"
@@ -1165,7 +1165,7 @@ export function ActiveProjectPanel({
       setShowNewTargetForm(false)
     } catch (error) {
       // Display error to user
-      setCreateTargetError(error instanceof Error ? error.message : 'Failed to create target')
+      setCreateTargetError(error instanceof Error ? error.message : 'Failed to create build')
     } finally {
       setIsCreatingTarget(false)
     }
@@ -1198,7 +1198,7 @@ export function ActiveProjectPanel({
   // Tooltip text based on state
   const getOutputTooltip = (action: string) => {
     if (!activeProject) return 'Select a project first'
-    if (!activeTargetName) return 'Select a target first'
+    if (!activeTargetName) return 'Select a build first'
     return `Open ${action} for ${activeTargetName}`
   }
 
@@ -1248,7 +1248,7 @@ export function ActiveProjectPanel({
 
       <div className="builds-section">
         <div className="builds-header">
-          <span className="section-label">Targets</span>
+          <span className="section-label">Builds</span>
         </div>
 
         <div className="build-targets">
@@ -1273,7 +1273,7 @@ export function ActiveProjectPanel({
               onBuildTarget(activeProject.root, activeTargetName)
             }}
             disabled={!activeProject || !activeTargetName}
-            title={activeTargetName ? `Build ${activeTargetName}` : 'Select a target to build'}
+            title={activeTargetName ? `Build ${activeTargetName}` : 'Select a build first'}
           >
             <Play size={12} />
             <span>Build</span>
@@ -1285,7 +1285,7 @@ export function ActiveProjectPanel({
               onBuildAllTargets(activeProject.root, activeProject.name)
             }}
             disabled={!activeProject}
-            title={activeProject ? `Build all targets in ${activeProject.name}` : 'Select a project first'}
+            title={activeProject ? `Build all in ${activeProject.name}` : 'Select a project first'}
           >
             <Layers size={12} />
             <span>Build All</span>
@@ -1301,7 +1301,7 @@ export function ActiveProjectPanel({
               title={
                 activeProject && activeTargetName
                   ? `Generate manufacturing files for ${activeTargetName}`
-                  : 'Build a target first to generate manufacturing data'
+                  : 'Run a build first to generate manufacturing data'
               }
             >
               <Package size={12} />

--- a/src/ui-server/src/components/BOMPanel.tsx
+++ b/src/ui-server/src/components/BOMPanel.tsx
@@ -699,9 +699,9 @@ export function BOMPanel({
       return `Run a build for "${selectedTargetName}" to generate the Bill of Materials`
     }
     if (selectedProjectRoot) {
-      return 'Select a target and run a build to generate the Bill of Materials'
+      return 'Select a build and run it to generate the Bill of Materials'
     }
-    return 'Select a project and target, then run a build'
+    return 'Select a project and build, then run it'
   }
 
   // Error state - but make 404 errors more user-friendly

--- a/src/ui-server/src/components/BuildsCard.tsx
+++ b/src/ui-server/src/components/BuildsCard.tsx
@@ -154,7 +154,7 @@ export function BuildsCard({
                 e.stopPropagation();
                 onAddBuild?.(projectId);
               }}
-              title="Add new build target"
+              title="Add build"
             >
               <Plus size={12} />
               <span>Add build</span>

--- a/src/ui-server/src/components/PackageDetailPanel.tsx
+++ b/src/ui-server/src/components/PackageDetailPanel.tsx
@@ -448,7 +448,7 @@ export function PackageDetailPanel({
                   className={`selector-trigger ${buildDropdownOpen ? 'open' : ''}`}
                   onClick={() => setBuildDropdownOpen(!buildDropdownOpen)}
                 >
-                  <span className="selector-label">{selectedBuildTarget || 'Select target'}</span>
+                  <span className="selector-label">{selectedBuildTarget || 'Select build'}</span>
                   <ChevronDown className={`selector-chevron ${buildDropdownOpen ? 'rotated' : ''}`} />
                 </button>
                 {buildDropdownOpen && (

--- a/src/ui-server/src/components/ProjectExplorerCard.tsx
+++ b/src/ui-server/src/components/ProjectExplorerCard.tsx
@@ -125,7 +125,7 @@ export function ProjectExplorerCard({ builds, projectRoot, defaultExpanded = fal
           {isLoading && (!builds || builds.length === 0) && (
             <div className="project-explorer-loading">
               <Loader2 size={12} className="spin" />
-              <span>Loading build targets...</span>
+              <span>Loading builds...</span>
             </div>
           )}
           {builds.map((build) => {

--- a/src/ui-server/src/components/Sidebar.tsx
+++ b/src/ui-server/src/components/Sidebar.tsx
@@ -280,7 +280,7 @@ export function Sidebar() {
                 entry: data.entry,
               });
               if (!response.result?.success) {
-                const errorMsg = response.result?.error || 'Failed to add target';
+                const errorMsg = response.result?.error || 'Failed to add build';
                 throw new Error(errorMsg);
               }
               action('refreshProjects');

--- a/src/ui-server/src/components/VariablesPanel.tsx
+++ b/src/ui-server/src/components/VariablesPanel.tsx
@@ -455,8 +455,8 @@ export function VariablesPanel({
                   {selectedTargetName
                     ? `Run a build for "${selectedTargetName}" to generate variable data`
                     : hasActiveProject
-                      ? 'Select a target and run a build to generate variable data'
-                      : 'Select a project and target, then run a build'}
+                      ? 'Select a build and run it to generate variable data'
+                      : 'Select a project and build, then run it'}
                 </span>
               </div>
             );
@@ -476,8 +476,8 @@ export function VariablesPanel({
               {selectedTargetName
                 ? `Run a build for "${selectedTargetName}" to generate variable data`
                 : hasActiveProject
-                  ? 'Select a target and run a build to generate variable data'
-                  : 'Select a project and target, then run a build'}
+                  ? 'Select a build and run it to generate variable data'
+                  : 'Select a project and build, then run it'}
             </span>
           </div>
         )}


### PR DESCRIPTION
We are using Target in alot of places where we mean Build.
Updated example, now builds are called builds:
<img width="351" height="357" alt="Screenshot 2026-01-28 at 1 05 01 PM" src="https://github.com/user-attachments/assets/0d9fcbcf-0596-45b6-b9c6-19b8ea02ec81" />
