### PR TITLE
CLI: Fix error string in package verify

### DIFF
--- a/src/atopile/cli/package.py
+++ b/src/atopile/cli/package.py
@@ -527,11 +527,15 @@ class _PackageValidators:
             file_path = ato_file.relative_to(config.project.paths.root)
             message = ""
             if unused_imports:
-                message = f"Unused imports: [{', '.join(sorted(unused_imports))}] in "
-                f"{file_path}"
+                message = (
+                    f"Unused imports: [{', '.join(sorted(unused_imports))}] in "
+                    f"{file_path}"
+                )
             if duplicates:
-                message += f"\nDuplicate imports: [{', '.join(sorted(duplicates))}] in "
-                f"{file_path}"
+                message += (
+                    f"\nDuplicate imports: [{', '.join(sorted(duplicates))}] in "
+                    f"{file_path}"
+                )
             if message:
                 raise UserBadParameterError(message)
 


### PR DESCRIPTION
The package verify command was incorrectly building a string on a specific error resulting in the error message omitting the name of the file containing the error.