### PR TITLE
CLI: Fix too greedy glob for .ato files in package verify

### DIFF
--- a/src/atopile/cli/package.py
+++ b/src/atopile/cli/package.py
@@ -503,6 +503,8 @@ class _PackageValidators:
         for ato_file in ato_files:
             if not ato_file.is_file():
                 continue
+            if ".ato" in ato_file.relative_to(config.project.paths.root).parts:
+                continue
             import_statements: list[re.Match[str]] = []
             content = ato_file.read_text(encoding="utf-8")
             for import_name in re.finditer(_import_name_regex, content):


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

filter out `.ato` files in `.ato/` folder

## Motivation

glob was finding `.ato` files in `.ato/` folder and thus the package verify was checking installed deps too.