### PR TITLE
Lib: Fix missing parameter constraints

### DIFF
--- a/src/faebryk/library/CAN.py
+++ b/src/faebryk/library/CAN.py
@@ -19,15 +19,20 @@ class CAN(fabll.Node):
     # TODO constrain CAN baudrate between 10kbps to 1Mbps
     # F.Expressions.Is.MakeChild_Constrain()
 
-    # impedance = F.Parameters.NumericParameter.MakeChild(unit=F.Units.Ohm)
-    # _impedance_constraint = F.Literals.Numbers.MakeChild_ConstrainToSubsetLiteral(
-    #    [impedance], min=120.0, max=120.0, unit=F.Units.Ohm
-    # )
-
     # ----------------------------------------
     #                 traits
     # ----------------------------------------
     _is_interface = fabll.Traits.MakeEdge(fabll.is_interface.MakeChild())
+
+    # ISO 11898: CAN bus differential impedance 120 Ohm +/- 10%
+    _parameter_constraints = [
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [diff_pair, F.DifferentialPair.impedance],
+            108.0,
+            132.0,
+            unit=F.Units.Ohm,
+        ),
+    ]
 
     net_names = [
         fabll.Traits.MakeEdge(

--- a/src/faebryk/library/RS485HalfDuplex.py
+++ b/src/faebryk/library/RS485HalfDuplex.py
@@ -16,12 +16,17 @@ class RS485HalfDuplex(fabll.Node):
 
     baudrate = F.Parameters.NumericParameter.MakeChild(unit=F.Units.BitsPerSecond)
 
-    # impedance = F.Parameters.NumericParameter.MakeChild(unit=F.Units.Ohm)
-    # _impedance_constraint = F.Literals.Numbers.MakeChild_ConstrainToSubsetLiteral(
-    #    [impedance], min=110.0, max=130.0, unit=F.Units.Ohm
-    # )
-
     _is_interface = fabll.Traits.MakeEdge(fabll.is_interface.MakeChild())
+
+    # TIA/EIA-485: characteristic impedance 120 Ohm (100-130 Ohm range)
+    _parameter_constraints = [
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [diff_pair, F.DifferentialPair.impedance],
+            100.0,
+            130.0,
+            unit=F.Units.Ohm,
+        ),
+    ]
 
     net_name_affixes = [
         fabll.Traits.MakeEdge(

--- a/src/faebryk/library/USB2_0_IF.py
+++ b/src/faebryk/library/USB2_0_IF.py
@@ -31,3 +31,27 @@ class USB2_0_IF(fabll.Node):
             owner=[buspower],
         ),
     ]
+
+    # USB 2.0 spec constraints
+    _parameter_constraints = [
+        # VBUS: 5V +/- 5% (USB 2.0 spec section 7.2.1)
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [buspower, F.ElectricPower.voltage], 4.75, 5.25, unit=F.Units.Volt
+        ),
+        # D+/D- reference voltage: 3.0V to 3.6V (USB 2.0 spec section 7.1.1)
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [
+                d,
+                F.DifferentialPair.p,
+                F.ElectricSignal.reference,
+                F.ElectricPower.voltage,
+            ],
+            3.0,
+            3.6,
+            unit=F.Units.Volt,
+        ),
+        # Differential impedance: 90 Ohm +/- 15% (USB 2.0 spec section 7.1.1)
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [d, F.DifferentialPair.impedance], 76.5, 103.5, unit=F.Units.Ohm
+        ),
+    ]

--- a/src/faebryk/library/USB3_IF.py
+++ b/src/faebryk/library/USB3_IF.py
@@ -33,3 +33,41 @@ class USB3_IF(fabll.Node):
             owner=[tx],
         ),
     ]
+
+    # USB 3.2 spec constraints
+    # Note: USB 2.0 constraints (VBUS, D+/D- reference, D+/D- impedance)
+    # are inherited via usb_if (USB2_0_IF)
+    _parameter_constraints = [
+        # SuperSpeed RX differential impedance: 90 Ohm +/- 15% (USB 3.2 spec Table 6-12)
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [rx, F.DifferentialPair.impedance], 76.5, 103.5, unit=F.Units.Ohm
+        ),
+        # SuperSpeed TX differential impedance: 90 Ohm +/- 15% (USB 3.2 spec Table 6-12)
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [tx, F.DifferentialPair.impedance], 76.5, 103.5, unit=F.Units.Ohm
+        ),
+        # SuperSpeed RX reference voltage: 0.8V to 1.2V (USB 3.2 spec Table 6-12)
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [
+                rx,
+                F.DifferentialPair.p,
+                F.ElectricSignal.reference,
+                F.ElectricPower.voltage,
+            ],
+            0.8,
+            1.2,
+            unit=F.Units.Volt,
+        ),
+        # SuperSpeed TX reference voltage: 0.8V to 1.2V (USB 3.2 spec Table 6-12)
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [
+                tx,
+                F.DifferentialPair.p,
+                F.ElectricSignal.reference,
+                F.ElectricPower.voltage,
+            ],
+            0.8,
+            1.2,
+            unit=F.Units.Volt,
+        ),
+    ]


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

Add (back) parameter constraints to some stlib interfaces.

## Motivation

e.g. usb busvoltage was not constraint
