### PR TITLE
Fix: Literals: Negative from center

### DIFF
--- a/src/faebryk/library/Literals.py
+++ b/src/faebryk/library/Literals.py
@@ -3283,9 +3283,7 @@ class Numbers(fabll.Node):
         unit: type[fabll.Node] | None = None,
     ) -> fabll._ChildField[Self]:
         delta = abs(rel * center)
-        return cls.MakeChild(
-            min=center - delta, max=center + delta, unit=unit
-        )
+        return cls.MakeChild(min=center - delta, max=center + delta, unit=unit)
 
     @classmethod
     def MakeChild_SetSuperset(


### PR DESCRIPTION
Taking over #1277

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small arithmetic change localized to range construction plus a new unit test; low risk aside from potentially altering behavior for negative-center tolerances.
> 
> **Overview**
> Fixes relative-tolerance interval construction for `Numbers` literals when `center` is negative by using `delta = abs(rel * center)` in both `MakeChild_FromCenterRel` and `setup_from_center_rel`.
> 
> Adds a regression test (`test_setup_from_center_rel_negative_center`) asserting that a negative center produces a correctly ordered `(min, max)` range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 261321196fe6ec3254cfeb3c156db5d6fcac96cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->