### PR TITLE
Fix: Better error for rounding big numbers

### DIFF
--- a/src/faebryk/library/Literals.py
+++ b/src/faebryk/library/Literals.py
@@ -710,15 +710,6 @@ class TestNumeric:
         numeric = Numeric.create_instance(g=g, tg=tg, value=expected_value)
         assert numeric.get_value() == expected_value
 
-    def test_round_except_too_big_number(self):
-        x = -1.32906894805911924079677428209e31
-        with pytest.raises(ValueError):
-            Numeric.float_round(x, 1)
-
-    def test_round_ok_too_big_number(self):
-        x = -1.32906894805911924079677428209e31
-        Numeric.float_round(x)
-
 
 class NumericInterval(fabll.Node):
     min_numeric_ptr = F.Collections.Pointer.MakeChild()
@@ -1807,6 +1798,27 @@ class TestNumericInterval:
         result = numeric_interval.op_round(g=g, tg=tg, ndigits=3)
         assert result.get_min_value() == 1.952
         assert result.get_max_value() == 2.498
+
+    def test_round_except_too_big_number(self):
+        g = graph.GraphView.create()
+        tg = fbrk.TypeGraph.create(g=g)
+        x = -1.32906894805911924079677428209e31
+        numeric_interval = NumericInterval.create_instance(g=g, tg=tg)
+        numeric_interval.setup_from_singleton(value=x)
+
+        with pytest.raises(ValueError):
+            numeric_interval.op_round(g=g, tg=tg, ndigits=1)
+
+    def test_round_ok_too_big_number(self):
+        g = graph.GraphView.create()
+        tg = fbrk.TypeGraph.create(g=g)
+        x = -1.32906894805911924079677428209e31
+        numeric_interval = NumericInterval.create_instance(g=g, tg=tg)
+        numeric_interval.setup_from_singleton(value=x)
+
+        result = numeric_interval.op_round(g=g, tg=tg)
+        assert result.get_min_value() == x
+        assert result.get_max_value() == x
 
     def test_op_abs(self):
         g = graph.GraphView.create()


### PR DESCRIPTION
Continuing #1288

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only affects rounding of extremely large values when fractional digits are requested; risk is limited to callers now receiving a `ValueError` in that edge case.
> 
> **Overview**
> Adds a guard in `Numeric.float_round` to **fail fast** when rounding extremely large magnitudes with fractional digits (`digits>0` and `abs(value)>1e30`), raising a clear `ValueError` instead of producing unreliable results.
> 
> Extends `NumericInterval` rounding tests to cover both behaviors: raising on large numbers when `ndigits` is provided, and allowing rounding with default `ndigits=0` (no fractional rounding) to pass through unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c66da41bf6c5bb4e2727831d81a725b4ad064ab0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->