### PR TITLE
solver: clanker fix attempt of capacitor inheritance issues

### DIFF
--- a/test/core/solver/test_solver.py
+++ b/test/core/solver/test_solver.py
@@ -1509,6 +1509,29 @@ def test_find_contradiction_by_gt():
         solver.simplify(E.tg, E.g)
 
 
+def test_predicate_mixed_estimation_converges():
+    """
+    Regression: predicate with only one bounded operand must converge.
+
+    When upper estimation sees GE(A, B) where A has a superset but B does not,
+    the mixed estimation path (creating GE(superset, B)) must be skipped for
+    predicates. Otherwise the _no_predicate_operands invariant normalizes
+    IsSubset(predicate_result, R) to IsSubset(True, R), which can't be
+    deduplicated across algorithm boundaries and causes an infinite loop.
+    """
+    E = BoundExpressions()
+    A = E.parameter_op()
+    B = E.parameter_op()
+
+    # Only A is bounded; B has no superset literal
+    E.is_subset(A, E.lit_op_range((0, 10)), assert_=True)
+    E.greater_or_equal(A, B, assert_=True)
+
+    solver = Solver()
+    # Should converge without hitting max iterations
+    solver.simplify(E.tg, E.g)
+
+
 def test_can_add_parameters():
     E = BoundExpressions()
     A = E.parameter_op()


### PR DESCRIPTION
Found a bug that inheriting from a generic component was breaking things in several ways. Maybe something useful here to help fix properly.

Clanker notes:
Fixes solver convergence and inherited picker typing without changing invariants.

Solver: Updated upper estimation to skip only mixed predicate estimation (the loop source) while still allowing pure-literal predicate folding, preserving contradiction detection.

Code: [structural.py](app://-/index.html#)
Test: added regression for mixed-predicate convergence in [test_solver.py](app://-/index.html#)
Picker inheritance: is_pickable_by_type.pick_type now resolves to canonical family types (Resistor/Capacitor/Inductor) based on endpoint, so derived modules (e.g. module X from Capacitor) classify correctly.

Code: [Pickable.py](app://-/index.html#)
Test: [test_typegraph.py](app://-/index.html#)
Units API serialization: Added basis-vector fallback for serialize_for_api() when unit symbols are missing, returning stable pint-compatible names for known units.

Code: [Units.py](app://-/index.html#)
Validation: targeted solver regressions, full solver test file, typegraph tests, units tests, and ruff checks all pass.