### PR TITLE
VSCE: improve extension frontend dev loop

### DIFF
--- a/src/vscode-atopile/src/common/webview.ts
+++ b/src/vscode-atopile/src/common/webview.ts
@@ -19,22 +19,19 @@ export function getWsOrigin(wsUrl: string): string {
 }
 
 export function createWebviewOptions(params: {
-  isDev: boolean;
   extensionPath: string;
   port: number;
   prodLocalResourceRoots: string[];
 }): vscode.WebviewOptions & { retainContextWhenHidden?: boolean } {
-  const { isDev, extensionPath, port, prodLocalResourceRoots } = params;
+  const { extensionPath, port, prodLocalResourceRoots } = params;
   return {
     enableScripts: true,
     retainContextWhenHidden: true,
     portMapping: port > 0
       ? [{ webviewPort: port, extensionHostPort: port }]
       : [],
-    localResourceRoots: isDev
-      ? []
-      : prodLocalResourceRoots.map((relativePath) =>
-          vscode.Uri.file(path.join(extensionPath, relativePath))
-        ),
+    localResourceRoots: prodLocalResourceRoots.map((relativePath) =>
+      vscode.Uri.file(path.join(extensionPath, relativePath))
+    ),
   };
 }

--- a/src/vscode-atopile/src/extension.ts
+++ b/src/vscode-atopile/src/extension.ts
@@ -43,6 +43,41 @@ function _setupLogging(context: vscode.ExtensionContext) {
     return outputChannel;
 }
 
+function _registerDevStatusButtons(context: vscode.ExtensionContext): void {
+    const isDevUiEnabled = process.env.ATOPILE_EXTENSION_DEV_UI === '1';
+    if (!isDevUiEnabled) {
+        return;
+    }
+
+    const reloadWebviewsCmd = vscode.commands.registerCommand('atopile.dev.reloadWebviews', async () => {
+        await vscode.commands.executeCommand('workbench.action.webview.reloadWebviewAction');
+    });
+    const restartExtHostCmd = vscode.commands.registerCommand('atopile.dev.restartExtensionHost', async () => {
+        await vscode.commands.executeCommand('workbench.action.restartExtensionHost');
+    });
+
+    const reloadWebviewsItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -100);
+    reloadWebviewsItem.text = '$(refresh)$(window)';
+    reloadWebviewsItem.tooltip = 'Reload Webviews';
+    reloadWebviewsItem.command = 'atopile.dev.reloadWebviews';
+    reloadWebviewsItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    reloadWebviewsItem.show();
+
+    const restartExtHostItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, -101);
+    restartExtHostItem.text = '$(refresh)$(tools)';
+    restartExtHostItem.tooltip = 'Restart Extension Host';
+    restartExtHostItem.command = 'atopile.dev.restartExtensionHost';
+    restartExtHostItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+    restartExtHostItem.show();
+
+    context.subscriptions.push(
+        reloadWebviewsCmd,
+        restartExtHostCmd,
+        reloadWebviewsItem,
+        restartExtHostItem,
+    );
+}
+
 class atopileUriHandler implements vscode.UriHandler {
     handleUri(uri: vscode.Uri): vscode.ProviderResult<void> {
         traceInfo(`handleUri: ${uri.toString()}`);
@@ -91,6 +126,7 @@ async function handleConfigUpdate(event: vscode.ConfigurationChangeEvent) {
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
     const activationTime = Date.now();
     const outputChannel = _setupLogging(context);
+    _registerDevStatusButtons(context);
     initTimer();
     traceMilestone('activate()');
 

--- a/src/vscode-atopile/src/providers/SidebarProvider.ts
+++ b/src/vscode-atopile/src/providers/SidebarProvider.ts
@@ -3,9 +3,6 @@
  *
  * This provider is minimal - it just opens the webview and loads the UI.
  * All state management and backend communication happens in the React app.
- *
- * In development: Loads from Vite dev server (http://localhost:5173)
- * In production: Loads from compiled assets
  */
 
 import * as vscode from 'vscode';
@@ -207,17 +204,6 @@ type WebviewMessage =
   | WebviewReadyMessage
   | OpenMigrateTabMessage;
 
-/**
- * Check if we're running in development mode.
- * Dev mode is detected by checking if the Vite manifest exists.
- */
-function isDevelopmentMode(extensionPath: string): boolean {
-  // In production, webviews are in resources/webviews/
-  // In development, we use the Vite dev server
-  const prodPath = path.join(extensionPath, 'resources', 'webviews', 'sidebar.js');
-  return !fs.existsSync(prodPath);
-}
-
 export class SidebarProvider implements vscode.WebviewViewProvider {
   // Must match the view ID in package.json "views" section
   public static readonly viewType = 'atopile.sidebar';
@@ -230,7 +216,6 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 
   private _view?: vscode.WebviewView;
   private _disposables: vscode.Disposable[] = [];
-  private _lastMode: 'dev' | 'prod' | null = null;
   private _hasHtml = false;
   private _lastWorkspaceRoot: string | null = null;
   private _lastApiUrl: string | null = null;
@@ -353,27 +338,21 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
     }
 
     const extensionPath = this._extensionUri.fsPath;
-    const isDev = isDevelopmentMode(extensionPath);
-    const mode: 'dev' | 'prod' = isDev ? 'dev' : 'prod';
     const apiUrl = backendServer.apiUrl;
     const wsUrl = backendServer.wsUrl;
 
     // Port changes are always reflected in apiUrl/wsUrl (see backendServer._setPort)
-    if (this._hasHtml && this._lastMode === mode && this._lastApiUrl === apiUrl && this._lastWsUrl === wsUrl) {
+    if (this._hasHtml && this._lastApiUrl === apiUrl && this._lastWsUrl === wsUrl) {
       return;
     }
 
     this._view.webview.options = createWebviewOptions({
-      isDev,
       extensionPath,
       port: backendServer.port,
       prodLocalResourceRoots: SidebarProvider.PROD_LOCAL_RESOURCE_ROOTS,
     });
-    this._view.webview.html = isDev
-      ? this._getDevHtml()
-      : this._getProdHtml(this._view.webview);
+    this._view.webview.html = this._getProdHtml(this._view.webview);
     this._hasHtml = true;
-    this._lastMode = mode;
     this._lastApiUrl = apiUrl;
     this._lastWsUrl = wsUrl;
   }
@@ -1239,81 +1218,7 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Development HTML - loads from Vite dev server.
-   * The React app connects directly to the Python backend.
-   * Workspace folders are passed via URL query params since iframe can't access parent window.
-   */
-  private _getDevHtml(): string {
-    const viteDevServer = 'http://localhost:5173';
-    const backendUrl = backendServer.apiUrl;
-    const wsUrl = backendServer.wsUrl;
-    const wsOrigin = getWsOrigin(wsUrl);
-    const workspaceRoot = this._getWorkspaceRootSync();
-
-    const workspaceParam = workspaceRoot
-      ? `?workspace=${encodeURIComponent(workspaceRoot)}`
-      : '';
-
-    return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="
-    default-src 'none';
-    frame-src ${viteDevServer};
-    style-src 'unsafe-inline';
-    script-src 'unsafe-inline';
-    img-src https: http: data:;
-    connect-src ${viteDevServer} ${backendUrl} ${wsOrigin};
-  ">
-  <title>atopile</title>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-    }
-    iframe {
-      width: 100%;
-      height: 100%;
-      border: none;
-    }
-    .dev-banner {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      background: #ff6b35;
-      color: white;
-      padding: 2px 8px;
-      font-size: 10px;
-      text-align: center;
-      z-index: 1000;
-    }
-  </style>
-</head>
-<body>
-  <div class="dev-banner">DEV MODE - Loading from Vite</div>
-  <iframe src="${viteDevServer}/sidebar.html${workspaceParam}"></iframe>
-  <script>
-    window.addEventListener('message', (event) => {
-      const data = event && event.data;
-      if (!data || (data.type !== 'workspace-root' && data.type !== 'activeFile')) return;
-      const iframe = document.querySelector('iframe');
-      if (iframe && iframe.contentWindow) {
-        iframe.contentWindow.postMessage(data, '*');
-      }
-    });
-  </script>
-</body>
-</html>`;
-  }
-
-  /**
-   * Production HTML - loads from compiled assets.
+   * Get the webview HTML - loads from compiled assets.
    * The React app connects directly to the Python backend.
    */
   private _getProdHtml(webview: vscode.Webview): string {

--- a/src/vscode-atopile/src/ui/migrate.ts
+++ b/src/vscode-atopile/src/ui/migrate.ts
@@ -1,8 +1,5 @@
 /**
  * Migrate Webview — opens the migration UI as a VS Code editor tab.
- *
- * In development: Loads from Vite dev server (http://localhost:5173)
- * In production: Loads from compiled assets
  */
 
 import * as vscode from 'vscode';
@@ -14,16 +11,10 @@ import { createWebviewOptions, getNonce, getWsOrigin } from '../common/webview';
 
 const PROD_LOCAL_RESOURCE_ROOTS = ['resources/webviews', 'webviews/dist'];
 
-function isDevelopmentMode(extensionPath: string): boolean {
-  const prodPath = path.join(extensionPath, 'resources', 'webviews', 'migrate.js');
-  return !fs.existsSync(prodPath);
-}
-
 let panel: vscode.WebviewPanel | undefined;
 
 export function openMigratePreview(extensionUri: vscode.Uri, projectRoot: string): void {
   const extensionPath = extensionUri.fsPath;
-  const isDev = isDevelopmentMode(extensionPath);
 
   if (panel) {
     panel.reveal(vscode.ViewColumn.Beside);
@@ -31,7 +22,6 @@ export function openMigratePreview(extensionUri: vscode.Uri, projectRoot: string
   }
 
   const webviewOptions = createWebviewOptions({
-    isDev,
     extensionPath,
     port: backendServer.port,
     prodLocalResourceRoots: PROD_LOCAL_RESOURCE_ROOTS,
@@ -44,9 +34,7 @@ export function openMigratePreview(extensionUri: vscode.Uri, projectRoot: string
     webviewOptions,
   );
 
-  panel.webview.html = isDev
-    ? getDevHtml(projectRoot)
-    : getProdHtml(panel.webview, extensionPath, projectRoot);
+  panel.webview.html = getProdHtml(panel.webview, extensionPath, projectRoot);
 
   // Handle messages from the migrate webview
   panel.webview.onDidReceiveMessage((message) => {
@@ -68,64 +56,6 @@ export function openMigratePreview(extensionUri: vscode.Uri, projectRoot: string
 export function closeMigratePreview(): void {
   panel?.dispose();
   panel = undefined;
-}
-
-function getDevHtml(projectRoot: string): string {
-  const viteDevServer = 'http://localhost:5173';
-  const apiUrl = backendServer.apiUrl;
-  const wsUrl = backendServer.wsUrl;
-  const wsOrigin = getWsOrigin(wsUrl);
-
-  const projectParam = projectRoot
-    ? `?projectRoot=${encodeURIComponent(projectRoot)}`
-    : '';
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="
-    default-src 'none';
-    frame-src ${viteDevServer};
-    style-src 'unsafe-inline';
-    script-src 'unsafe-inline';
-    img-src https: http: data:;
-    connect-src ${viteDevServer} ${apiUrl} ${wsOrigin};
-  ">
-  <title>Migrate Project</title>
-  <style>
-    html, body {
-      margin: 0;
-      padding: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-    }
-    iframe {
-      width: 100%;
-      height: 100%;
-      border: none;
-    }
-    .dev-banner {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      background: #ff6b35;
-      color: white;
-      padding: 2px 8px;
-      font-size: 10px;
-      text-align: center;
-      z-index: 1000;
-    }
-  </style>
-</head>
-<body>
-  <div class="dev-banner">DEV MODE - Loading from Vite</div>
-  <iframe src="${viteDevServer}/migrate.html${projectParam}"></iframe>
-</body>
-</html>`;
 }
 
 function getProdHtml(webview: vscode.Webview, extensionPath: string, projectRoot: string): string {


### PR DESCRIPTION
`ato dev extension`

No longer required to `ato dev compile && ato dev install` to test webview or extension only changes.

## Saves time
Development loop on each change: **~23s -> ~Instant to 3s**
### Previously
#### Every Change
- 20s to compile and install extension
- 3s to reload extension host
### Now
#### Once
- 10s to start extension in developent mode
#### Every Webview Change
- Instant to reload webviews
#### Every Other Change
- 3s to reload extension host

## Usage Guide
- Start extension in development mode with `ato dev extension`
- If making webview only changes, click "Reload Webviews" icon 
<img width="1385" height="855" alt="image" src="https://github.com/user-attachments/assets/a8dcbe15-5fd5-4815-84e3-8e1a408cce9b" />
- Else if making extension or backend server changes, click "Restart Extension Host"

## Testing
- Confirmed no dev buttons visible in compiled extension
- Confirmed no regressions to `ato serve frontend` and `ato serve backend`
- Confirmed refresh webviews and refresh extension host show updates changes without extension recompile