### PR TITLE
atoPart: fix sanitize all file names in ato parts, add migration for existing parts

### DIFF
--- a/src/atopile/server/migrations/sanitize_part_filenames.py
+++ b/src/atopile/server/migrations/sanitize_part_filenames.py
@@ -1,0 +1,62 @@
+"""Sanitize KiCad filenames in auto-generated parts.
+
+Renames footprint, symbol, and model files that contain characters
+outside [a-zA-Z0-9_] and updates the .ato manifests to match.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+
+from ._base import MigrationStep, Topics
+
+log = logging.getLogger(__name__)
+
+
+class SanitizePartFilenames(MigrationStep):
+    label = "Sanitize part filenames"
+    description = (
+        "Renames KiCad footprint, symbol and 3D-model files in the parts "
+        "directory so they only contain safe characters (a-z, A-Z, 0-9, _)."
+    )
+    topic = Topics.project_structure
+    order = 10
+
+    async def run(self, project_path: Path) -> None:
+        from atopile.config import ProjectConfig
+        from faebryk.libs.ato_part import AtoPart
+
+        def _do() -> None:
+            project_config = ProjectConfig.from_path(project_path)
+            if project_config is None:
+                return
+            parts_dir = project_config.paths.parts
+
+            if not parts_dir.is_dir():
+                return
+
+            failed: list[tuple[Path, str]] = []
+            migrated = 0
+
+            for part_dir in sorted(parts_dir.iterdir()):
+                if not part_dir.is_dir():
+                    continue
+                try:
+                    if AtoPart.migrate_filenames(part_dir):
+                        migrated += 1
+                except Exception as exc:
+                    failed.append((part_dir, str(exc)))
+                    log.warning(
+                        "[migrate] Failed to sanitize %s: %s", part_dir.name, exc
+                    )
+
+            if migrated:
+                log.info("[migrate] Sanitized filenames in %d part(s)", migrated)
+
+            if failed:
+                names = ", ".join(d.name for d, _ in failed)
+                raise RuntimeError(f"Failed to migrate {len(failed)} part(s): {names}")
+
+        await asyncio.to_thread(_do)

--- a/src/faebryk/libs/part_lifecycle.py
+++ b/src/faebryk/libs/part_lifecycle.py
@@ -139,10 +139,16 @@ class PartLifecycle:
 
         def get_fp_path(self, partno: str, footprint_name: str) -> Path:
             # public because needed by lcsc.py
-            return self._get_part_path(partno) / f"{footprint_name}.kicad_mod"
+            return (
+                self._get_part_path(partno)
+                / f"{sanitize_filepath_part(footprint_name)}.kicad_mod"
+            )
 
         def _get_sym_path(self, partno: str, sym_name: str) -> Path:
-            return self._get_part_path(partno) / f"{sym_name}.kicad_sym"
+            return (
+                self._get_part_path(partno)
+                / f"{sanitize_filepath_part(sym_name)}.kicad_sym"
+            )
 
         def get_model_path(self, partno: str, model_name: str) -> Path:
             # public because needed by lcsc.py
@@ -151,7 +157,10 @@ class PartLifecycle:
             # 1. filename derived from footprint
             # 2. internal step file name
             # The only way to find out the internal is to download and read the step
-            return self._get_part_path(partno) / f"{model_name}.step"
+            return (
+                self._get_part_path(partno)
+                / f"{sanitize_filepath_part(model_name)}.step"
+            )
 
         def shall_refresh_model(self, part: EasyEDAPart) -> bool:
             # no model in api

--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -845,7 +845,7 @@ class TestLCSCattach:
         assert kicad_library_footprint.get_pad_names() == ["1", "2", "3", "4", "5"]
         assert (
             kicad_library_footprint.get_kicad_identifier()
-            == "XBLW_LM321DTR_XBLW:SOT-23-5_L2.9-W1.6-P0.95-LS2.8-BR"
+            == "XBLW_LM321DTR_XBLW:SOT_23_5_L2_9_W1_6_P0_95_LS2_8_BR"
         )
         assert kicad_library_footprint.get_library_name() == "XBLW_LM321DTR_XBLW"
 
@@ -882,7 +882,7 @@ class TestLCSCattach:
 
         assert (
             kicad_library_footprint.get_kicad_identifier()
-            == "Changjiang_Electronics_Tech_2N7002:SOT-23-3_L2.9-W1.3-P1.90-LS2.4-BR"
+            == "Changjiang_Electronics_Tech_2N7002:SOT_23_3_L2_9_W1_3_P1_90_LS2_4_BR"
         )
         assert (
             kicad_library_footprint.get_library_name()
@@ -890,7 +890,7 @@ class TestLCSCattach:
         )
         assert kicad_library_footprint.get_pad_names() == ["1", "2", "3"]
         assert (
-            "src/parts/Changjiang_Electronics_Tech_2N7002/SOT-23-3_L2.9-W1.3-P1.90-LS2.4-BR.kicad_mod"
+            "src/parts/Changjiang_Electronics_Tech_2N7002/SOT_23_3_L2_9_W1_3_P1_90_LS2_4_BR.kicad_mod"
             in kicad_library_footprint.get_kicad_footprint_file_path()
         )
 
@@ -924,7 +924,7 @@ class TestLCSCattach:
         assert kicad_library_footprint is not None
         assert (
             kicad_library_footprint.get_kicad_identifier()
-            == "ALLPOWER_AP30P30Q:PDFN3333-8_L3.1-W3.2-P0.65-LS3.4-BL"
+            == "ALLPOWER_AP30P30Q:PDFN3333_8_L3_1_W3_2_P0_65_LS3_4_BL"
         )
 
         # there should be 1 G pad, 5 D pads, and 3 S pads


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

sanitize all file names in ato part dir. add migration step for existing parts

## Motivation

fixes https://github.com/atopile/atopile/issues/1541
fixes https://github.com/atopile/atopile/issues/1495
