### PR TITLE
LCSC: Fix 0201 smd 3D model x alignment

### DIFF
--- a/src/faebryk/libs/picker/lcsc.py
+++ b/src/faebryk/libs/picker/lcsc.py
@@ -457,9 +457,8 @@ def _fix_3d_model_offsets(ki_footprint: ExporterFootprintKicad):
         return
 
     if WORKAROUND_SMD_3D_MODEL_FIX:
-        if (
-            ki_footprint.input.info.fp_type == "smd"
-            or "0201" in ki_footprint.input.info.name
+        if ki_footprint.input.info.fp_type == "smd" or re.search(
+            r"[cCrR]0201", ki_footprint.input.info.name
         ):
             ki_footprint.output.model_3d.translation.x = 0
             ki_footprint.output.model_3d.translation.y = 0


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

resistor and capacitor (not inductors) 0201 parts don't have the `smd` fp_type so they were not fixed .

Examples of values from LCSC (and fixed final translation):
```python
  LCSC ID: C25744                                                                  
  info.name: R0402                                                                 
  model_3d.name: R0402_L1.0-W0.5-H0.4                                              
  fp_type: smd                                                                     
  translation: (0, 0, 0)                                                           
  ────────────────────────────────────────                                         
  LCSC ID: C76928                                                                  
  info.name: C0201                                                                 
  model_3d.name: C0201_L0.6-W0.3-H0.3                                              
  fp_type: tht                                                                     
  translation: (0, 0, 0)                                                           
  ────────────────────────────────────────                                         
  LCSC ID: C2887983                                                                
  info.name: LGA-16_L3.0-W3.0-P0.50-TL                                             
  model_3d.name: LGA-16_L3.0-W3.0-P0.50-TL                                         
  fp_type: smd                                                                     
  translation: (0, 0, 0)                                                           
  ────────────────────────────────────────                                         
  LCSC ID: C431092                                                                 
  info.name: CONN-TH_XT30PW-M                                                      
  model_3d.name: CONN-TH_XT30PW-M                                                  
  fp_type: tht                                                                     
  translation: (0, -1.01, 0)
```

## Motivation

fixes https://github.com/atopile/atopile/issues/1498
