### PR TITLE
Solver: Claude Resistor Divider Hacks

### DIFF
--- a/src/faebryk/library/AdjustableRegulator.py
+++ b/src/faebryk/library/AdjustableRegulator.py
@@ -63,10 +63,50 @@ class AdjustableRegulator(fabll.Node):
         fabll.is_interface.MakeConnectionEdge(
             [feedback_divider, F.ResistorVoltageDivider.ref_in], [power_out]
         ),
-        fabll.is_interface.MakeConnectionEdge(
-            [v_in], [power_in, F.ElectricPower.voltage]
+    ]
+
+    # Parameter linkages and constraints
+    _constraints = [
+        # Link input_voltage/output_voltage to power interface voltages
+        F.Expressions.Is.MakeChild(
+            [input_voltage],
+            [power_in, F.ElectricPower.voltage],
+            assert_=True,
         ),
-        fabll.is_interface.MakeConnectionEdge(
-            [v_out], [power_out, F.ElectricPower.voltage]
+        F.Expressions.Is.MakeChild(
+            [output_voltage],
+            [power_out, F.ElectricPower.voltage],
+            assert_=True,
+        ),
+        # v_in/v_out are aliases for input_voltage/output_voltage
+        F.Expressions.Is.MakeChild(
+            [v_in],
+            [input_voltage],
+            assert_=True,
+        ),
+        F.Expressions.Is.MakeChild(
+            [v_out],
+            [output_voltage],
+            assert_=True,
+        ),
+        # Feedback divider constraints:
+        # Link divider v_in to output_voltage (divider measures output)
+        F.Expressions.Is.MakeChild(
+            [feedback_divider, F.ResistorVoltageDivider.v_in],
+            [output_voltage],
+            assert_=True,
+        ),
+        # Link divider v_out to reference_voltage
+        F.Expressions.Is.MakeChild(
+            [feedback_divider, F.ResistorVoltageDivider.v_out],
+            [reference_voltage],
+            assert_=True,
+        ),
+        # Constrain divider current draw
+        F.Literals.Numbers.MakeChild_SetSuperset(
+            [feedback_divider, F.ResistorVoltageDivider.current],
+            1e-6,
+            1e-3,
+            unit=F.Units.Ampere,
         ),
     ]

--- a/src/faebryk/library/ResistorVoltageDivider.py
+++ b/src/faebryk/library/ResistorVoltageDivider.py
@@ -180,6 +180,17 @@ class ResistorVoltageDivider(fabll.Node):
             ],
             assert_=True,
         ),
+        # total_R = r_bottom / ratio (inverse for backward propagation)
+        F.Expressions.Is.MakeChild(
+            [total_resistance],
+            [
+                _total_r_from_r1_ratio := F.Expressions.Divide.MakeChild(
+                    [chain, _ResistorChain.resistors[1], F.Resistor.resistance],
+                    [ratio],
+                )
+            ],
+            assert_=True,
+        ),
         # r_top = total_R - r_bottom
         F.Expressions.Is.MakeChild(
             [chain, _ResistorChain.resistors[0], F.Resistor.resistance],

--- a/src/faebryk/libs/picker/api/models.py
+++ b/src/faebryk/libs/picker/api/models.py
@@ -271,17 +271,16 @@ class Component:
                 # Get the parameter traits
                 param_operand = param.as_operand.get()
 
-                # Create Is expression to alias parameter to the literal value
-                from faebryk.library.Expressions import IsSuperset
+                # Constrain parameter to the picked part's value
+                from faebryk.library.Expressions import IsSubset
 
-                IsSuperset.bind_typegraph(tg=module.tg).create_instance(
+                _issubset_expr = IsSubset.bind_typegraph(tg=module.tg).create_instance(
                     g=module.g
                 ).setup(
                     param_operand,
                     literal.as_operand.get(),
                     assert_=True,
                 )
-
         if missing_attrs:
             with downgrade(UserException):
                 # TODO: suggest specific library module


### PR DESCRIPTION


Let claude rip on Resistor Dividers:

"
Summary of Fixes

5 fixes across 7 files that together fix resistor voltage divider picking in the atopile solver:

Fix 1: Auto-canonicalize non-canonical expressions (mutator.py)

Non-canonical expression types (like LessOrEqual, IsSuperset) that survived into post-canonicalization iterations caused assertion failures. Added
_canonicalize_builder() that converts them to canonical equivalents on the fly.

Fix 2: Graph stability convergence detection (solver.py)

The solver could loop indefinitely when oscillating between equivalent representations. Added convergence detection that stops when the graph node
count stays stable for consecutive iterations (threshold=1, after at least 3 iterations).

Fix 3: IsSubset instead of IsSuperset in part attachment (models.py)

attach() was using IsSuperset to constrain picked parameter values. Changed to IsSubset which is the canonical form and correctly constrains the
parameter to the picked literal's range.

Fix 4: Per-group candidate fetching (picker.py)

Previously, all candidates were fetched using the global solver before groups were expanded. Changed to fetch candidates per-group using each group's
own solver, so constraints propagated from earlier picks are visible.

Fix 5: Skip anticorrelated pairs after first pick (utils.py, mutator.py, solver.py, picker.py)

ROOT CAUSE FIX: get_relevant_predicates uses anticorrelated pairs (from Not(Correlated(...)) expressions) to prevent spurious transitive closure. But
after picking R1, this filtering blocked the solver from discovering R1's IsSubset constraint when traversing from R0. Added skip_anticorrelated
parameter through the entire call chain, enabled when depth > 0 (i.e., after first round of picking).

Fix 6: AdjustableRegulator parameter linkages (AdjustableRegulator.py)

Added missing Is expressions linking input_voltage/output_voltage to power interface voltages, v_in/v_out aliases, and feedback divider
voltage/current constraints.

Fix 7: Helper equation for backward propagation (ResistorVoltageDivider.py)

Added total_R = R1 / ratio equation to enable the solver to propagate total resistance backward from R1 and ratio constraints.

✻ Worked for 2h 32m 58s
"
