### PR TITLE
Compiler: Support `pointer_field = new Type` in .ato

### DIFF
--- a/src/atopile/compiler/ast_visitor.py
+++ b/src/atopile/compiler/ast_visitor.py
@@ -1026,6 +1026,95 @@ class ASTVisitor:
 
         return FieldPath(segments=tuple(segments))
 
+    def _is_pointer_field(self, target_path: FieldPath) -> bool:
+        """Check if the field at target_path is an existing Pointer type.
+
+        Handles two cases:
+        - Singleton paths: checks the current type first, then pending parent types
+          (for inherited Pointer fields not yet merged).
+        - Nested paths: walks the parent segments to find the owner type.
+        """
+        identifier = target_path.leaf.identifier
+
+        if target_path.is_singleton():
+            # Check current type first (field already present, e.g. from Python)
+            type_node, _, _ = self._type_stack.current()
+            type_ref = self._tg.get_make_child_type_reference_by_identifier(
+                type_node=type_node, identifier=identifier
+            )
+            if type_ref is not None:
+                type_ref_id = fbrk.TypeGraph.get_type_reference_identifier(
+                    type_reference=type_ref
+                )
+                return type_ref_id == "Pointer"
+
+            # Check pending parent types (inheritance not yet resolved)
+            current_node = type_node.node()
+            for pending in self._state.pending_inheritance:
+                if pending.derived_type.node().is_same(other=current_node):
+                    parent_type = self._resolve_pending_parent_type(pending)
+                    if parent_type is None:
+                        continue
+                    type_ref = self._tg.get_make_child_type_reference_by_identifier(
+                        type_node=parent_type, identifier=identifier
+                    )
+                    if type_ref is not None:
+                        type_ref_id = fbrk.TypeGraph.get_type_reference_identifier(
+                            type_reference=type_ref
+                        )
+                        return type_ref_id == "Pointer"
+        else:
+            # Nested path: walk parent segments to find owner type
+            type_node, _, _ = self._type_stack.current()
+            owner_type = type_node
+            for segment in target_path.parent_segments:
+                type_ref = self._tg.get_make_child_type_reference_by_identifier(
+                    type_node=owner_type, identifier=segment.identifier
+                )
+                if type_ref is None:
+                    return False
+                type_ref_id = fbrk.TypeGraph.get_type_reference_identifier(
+                    type_reference=type_ref
+                )
+                resolved = self._tg.get_type_by_name(type_identifier=type_ref_id)
+                if resolved is None:
+                    return False
+                owner_type = resolved
+            # Check the leaf field on the resolved owner type
+            type_ref = self._tg.get_make_child_type_reference_by_identifier(
+                type_node=owner_type, identifier=identifier
+            )
+            if type_ref is not None:
+                type_ref_id = fbrk.TypeGraph.get_type_reference_identifier(
+                    type_reference=type_ref
+                )
+                return type_ref_id == "Pointer"
+
+        return False
+
+    def _resolve_pending_parent_type(
+        self, pending: PendingInheritance
+    ) -> graph.BoundNode | None:
+        """Try to resolve the parent type from a PendingInheritance record."""
+        if isinstance(pending.parent_ref, ImportRef):
+            parent_name = pending.parent_ref.name
+        else:
+            parent_name = pending.parent_ref
+
+        # Check local type roots first
+        if parent_name in self._state.type_roots:
+            return self._state.type_roots[parent_name]
+
+        # Eagerly load from stdlib allowlist if available
+        parent_class = self._stdlib_allowlist.get(parent_name)
+        if parent_class is not None:
+            return fabll.TypeNodeBoundTG.get_or_create_type_in_tg(
+                self._tg, parent_class
+            )
+
+        # Fallback: check TypeGraph (for types already loaded elsewhere)
+        return self._tg.get_type_by_name(type_identifier=parent_name)
+
     def _handle_new_child(
         self,
         target_path: FieldPath,
@@ -1103,6 +1192,20 @@ class ASTVisitor:
                     )
 
             assert new_spec.type_identifier is not None
+
+            # Check if the target field is an existing Pointer
+            if self._is_pointer_field(target_path):
+                element_action, link_action = ActionsFactory.new_child_pointer_actions(
+                    pointer_path=target_path,
+                    type_identifier=new_spec.type_identifier,
+                    module_type=module_fabll_type,
+                    template_args=new_spec.template_args,
+                    import_ref=(
+                        new_spec.symbol.import_ref if new_spec.symbol else None
+                    ),
+                    source_chunk_node=source_chunk_node,
+                )
+                return [element_action, link_action]
 
             return ActionsFactory.new_child_action(
                 target_path=target_path,

--- a/src/atopile/compiler/gentypegraph.py
+++ b/src/atopile/compiler/gentypegraph.py
@@ -510,6 +510,50 @@ class ActionsFactory:
         return [pointer_action, *element_actions], link_actions, element_paths
 
     @staticmethod
+    def new_child_pointer_actions(
+        pointer_path: "FieldPath",
+        type_identifier: str,
+        module_type: type[fabll.Node] | None,
+        template_args: dict[str, str | bool | float] | None,
+        import_ref: "ImportRef | None",
+        source_chunk_node: AST.SourceChunk | None = None,
+    ) -> "tuple[AddMakeChildAction, AddMakeLinkAction]":
+        """
+        Create actions for assigning `new Type` to an existing Pointer field.
+
+        The Pointer MakeChild already exists (from Python), so we only create:
+        1. A sibling MakeChild for the pointee element
+        2. A MakeLink with EdgePointer from the Pointer to the element
+        """
+        # The element is a sibling of the pointer, placed at the root of the type
+        element_identifier = f"_ptr_{'_'.join(pointer_path.identifiers())}_target"
+        element_path = FieldPath(
+            segments=(FieldPath.Segment(identifier=element_identifier),)
+        )
+
+        element_action = AddMakeChildAction(
+            target_path=element_path,
+            child_field=ActionsFactory.child_field(
+                identifier=element_identifier,
+                type_identifier=type_identifier,
+                module_type=module_type,
+                template_args=template_args,
+                source_chunk_node=source_chunk_node,
+            ),
+            import_ref=import_ref,
+            source_chunk_node=source_chunk_node,
+        )
+
+        link_action = AddMakeLinkAction(
+            lhs_path=list(pointer_path.identifiers()),
+            rhs_path=list(element_path.identifiers()),
+            edge=EdgePointer.build(identifier=None, index=None),
+            source_chunk_node=source_chunk_node,
+        )
+
+        return element_action, link_action
+
+    @staticmethod
     def parameter_actions(
         target_path: "FieldPath",
         param_child: fabll._ChildField | None,

--- a/test/compiler/test_runtime.py
+++ b/test/compiler/test_runtime.py
@@ -3781,3 +3781,67 @@ module MainModule:
 
             assert extracted is not None
             assert str(extracted) == test_path
+
+
+def test_pointer_new_assignment_inside_module():
+    """Assigning `new Thingy` to a Pointer field inside a derived module."""
+
+    class ModuleA(fabll.Node):
+        pointer_thing = F.Collections.Pointer.MakeChild()
+        _override_type_identifier = "ModuleA"
+
+    class Thingy(fabll.Node):
+        signal_a = F.Electrical.MakeChild()
+        _override_type_identifier = "Thingy"
+
+    _, _, _, result, app_instance = build_instance(
+        """
+        import ModuleA
+        import Thingy
+
+        module ModA from ModuleA:
+            pointer_thing = new Thingy
+
+        module App:
+            mod_a = new ModA
+        """,
+        "App",
+        stdlib_extra=[ModuleA, Thingy],
+    )
+
+    mod_a = _get_child(app_instance, "mod_a")
+    mod_a_node = ModuleA.bind_instance(mod_a)
+    pointee = mod_a_node.pointer_thing.get().deref()
+    assert pointee is not None
+    assert pointee.try_cast(Thingy) is not None
+
+
+def test_pointer_new_assignment_from_outside():
+    """Assigning `new Thingy` to a Pointer field via nested path."""
+
+    class ModuleB(fabll.Node):
+        pointer_thing = F.Collections.Pointer.MakeChild()
+        _override_type_identifier = "ModuleB"
+
+    class Widget(fabll.Node):
+        signal_a = F.Electrical.MakeChild()
+        _override_type_identifier = "Widget"
+
+    _, _, _, result, app_instance = build_instance(
+        """
+        import ModuleB
+        import Widget
+
+        module App:
+            mod_a = new ModuleB
+            mod_a.pointer_thing = new Widget
+        """,
+        "App",
+        stdlib_extra=[ModuleB, Widget],
+    )
+
+    mod_a = _get_child(app_instance, "mod_a")
+    mod_a_node = ModuleB.bind_instance(mod_a)
+    pointee = mod_a_node.pointer_thing.get().deref()
+    assert pointee is not None
+    assert pointee.try_cast(Widget) is not None


### PR DESCRIPTION
Enable assigning `new Type` to Python-defined Pointer fields in .ato code, both inside derived modules (`from` inheritance) and via nested paths.

<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

<!--
What does this PR change?
-->

## Motivation

<!--
Why is this change necessary?
Which #issue does it fix?
-->
