### PR TITLE
LSP: Fix crash of LSP + location of squigly lines

### DIFF
--- a/src/atopile/compiler/antlr_visitor.py
+++ b/src/atopile/compiler/antlr_visitor.py
@@ -213,10 +213,11 @@ class ANTLRVisitor(AtoParserVisitor):
         # Handle multiple imports on one line (deprecated syntax)
         if len(type_refs) > 1:
             with downgrade(DeprecatedException):
-                raise DeprecatedException(
+                raise DeprecatedException.from_ctx(
+                    ctx,
                     "Multiple imports on one line is deprecated. "
                     "Please use separate import statements for each module. "
-                    f"Found: {ctx.getText()}"
+                    f"Found: {ctx.getText()}",
                 )
             return [
                 self._new(AST.ImportStmt).setup(

--- a/src/atopile/compiler/ast_visitor.py
+++ b/src/atopile/compiler/ast_visitor.py
@@ -44,7 +44,7 @@ from atopile.compiler.gentypegraph import (
     Symbol,
 )
 from atopile.compiler.overrides import ReferenceOverrideRegistry, TraitOverrideRegistry
-from atopile.errors import DeprecatedException, downgrade
+from atopile.errors import DeprecatedException, downgrade, source_location_context
 from atopile.logging import get_logger
 from faebryk.core.faebrykpy import EdgeTraversal
 from faebryk.library.Units import UnitsNotCommensurableError
@@ -53,6 +53,29 @@ from faebryk.libs.util import cast_assert, groupby, import_from_path, not_none
 _Quantity = tuple[float, fabll._ChildField]
 
 logger = get_logger(__name__)
+
+
+@contextmanager
+def _source_location_from_node(node: fabll.Node):
+    """Set the source location context from an AST node (best-effort)."""
+    try:
+        source = node.source.get()
+        loc = source.loc.get()
+        filepath = source.get_path()
+    except Exception:
+        filepath = None
+
+    if filepath:
+        with source_location_context(
+            filepath=filepath,
+            start_line=loc.get_start_line(),
+            start_col=loc.get_start_col(),
+            end_line=loc.get_end_line(),
+            end_col=loc.get_end_col(),
+        ):
+            yield
+    else:
+        yield
 
 
 # FIXME: needs expanding
@@ -738,7 +761,8 @@ class ASTVisitor:
 
         # Automatically handle tracebacks for all visitor methods
         with self._traceback_stack.enter(bound_node):
-            return handler(bound_node)
+            with _source_location_from_node(bound_node):
+                return handler(bound_node)
 
     def visit_File(self, node: AST.File):
         self.visit(node.scope.get())

--- a/src/atopile/compiler/build.py
+++ b/src/atopile/compiler/build.py
@@ -748,6 +748,7 @@ def build_source(
     tg: fbrk.TypeGraph,
     source: str,
     import_path: str | None = None,
+    file_path: Path | None = None,
     stdlib_allowlist: AllowListT | None = None,
 ) -> BuildFileResult:
     if import_path is None:
@@ -760,7 +761,7 @@ def build_source(
         tg=tg,
         import_path=import_path,
         root_ctx=parse_text_as_file(source),
-        file_path=None,
+        file_path=file_path,
         stdlib_allowlist=stdlib_allowlist,
     )
 

--- a/src/atopile/errors.py
+++ b/src/atopile/errors.py
@@ -11,6 +11,7 @@ This module provides:
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import logging
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
@@ -47,6 +48,32 @@ if TYPE_CHECKING:
 # NOTE: Using standard logging here to avoid circular import.
 # atopile.logging imports modules that eventually import atopile.errors.
 logger = logging.getLogger(__name__)
+
+# Context variable for propagating source location to exceptions raised in
+# code that doesn't have direct access to parser contexts or AST nodes
+# (e.g. override helpers, library code).
+# Value: (filepath, start_line, start_col, (end_line, end_col)) or None
+_current_source_location: contextvars.ContextVar[
+    tuple[str, int, int, tuple[int, int]] | None
+] = contextvars.ContextVar("_current_source_location", default=None)
+
+
+@contextlib.contextmanager
+def source_location_context(
+    filepath: str,
+    start_line: int,
+    start_col: int,
+    end_line: int,
+    end_col: int,
+):
+    """Set the current source location for exceptions raised in this context."""
+    token = _current_source_location.set(
+        (filepath, start_line, start_col, (end_line, end_col))
+    )
+    try:
+        yield
+    finally:
+        _current_source_location.reset(token)
 
 
 # =============================================================================
@@ -477,13 +504,29 @@ class UserExportError(SourceLocatedUserException):
     """Raised when there's an error exporting a file via the KiCad CLI."""
 
 
+class DeprecatedException(SourceLocatedUserException):
+    """This feature is deprecated and will be removed in a future version."""
+
+    def __init__(self, msg: str, *args, **kwargs):
+        super().__init__(msg, *args, **kwargs)
+        # Auto-capture source location from context if no ANTLR token is set
+        if self.origin_start is None:
+            loc = _current_source_location.get(None)
+            if loc is not None:
+                (
+                    self.src_filepath,
+                    self.src_start_line,
+                    self.src_start_col,
+                    (
+                        self.src_end_line,
+                        self.src_end_col,
+                    ),
+                ) = loc
+
+
 # =============================================================================
 # Non-Source-Located Exceptions (don't need token tracking)
 # =============================================================================
-
-
-class DeprecatedException(UserException):
-    """This feature is deprecated and will be removed in a future version."""
 
 
 class UserResourceException(UserException):

--- a/src/atopile/lsp/lsp_server.py
+++ b/src/atopile/lsp/lsp_server.py
@@ -217,14 +217,15 @@ def exception_to_diagnostic(
     start_line, start_col = 0, 0
     stop_line, stop_col = 0, 0
 
-    if exc.origin_start is not None:
-        start_file_path, start_line, start_col = get_src_info_from_token(
-            exc.origin_start
-        )
-        if exc.origin_stop is not None:
+    origin_start = getattr(exc, "origin_start", None)
+    origin_stop = getattr(exc, "origin_stop", None)
+
+    if origin_start is not None:
+        start_file_path, start_line, start_col = get_src_info_from_token(origin_start)
+        if origin_stop is not None:
             stop_line, stop_col = (
-                exc.origin_stop.line,
-                exc.origin_stop.column + len(exc.origin_stop.text),
+                origin_stop.line,
+                origin_stop.column + len(origin_stop.text),
             )
         else:
             stop_line, stop_col = start_line + 1, 0
@@ -245,7 +246,7 @@ def exception_to_diagnostic(
         ),
         message=exc.message,
         severity=severity,
-        code=exc.code,
+        code=getattr(exc, "code", None),
         source=TOOL_DISPLAY,
     )
 

--- a/src/atopile/lsp/lsp_server.py
+++ b/src/atopile/lsp/lsp_server.py
@@ -230,9 +230,16 @@ def exception_to_diagnostic(
         else:
             stop_line, stop_col = start_line + 1, 0
 
-    # Convert from 1-indexed (ANTLR) to 0-indexed (LSP)
-    start_line = max(start_line - 1, 0)
-    stop_line = max(stop_line - 1, 0)
+        # Convert from 1-indexed (ANTLR) to 0-indexed (LSP)
+        start_line = max(start_line - 1, 0)
+        stop_line = max(stop_line - 1, 0)
+    elif hasattr(exc, "src_filepath"):
+        # Fallback: direct file location (e.g. from AST nodes without ANTLR tokens)
+        start_file_path = exc.src_filepath
+        start_line = max(exc.src_start_line - 1, 0)
+        start_col = exc.src_start_col
+        stop_line = max(exc.src_end_line - 1, 0)
+        stop_col = exc.src_end_col
 
     # Handle case where file path is the string "None" (from parsing string sources)
     file_path = (
@@ -531,6 +538,7 @@ def build_document(uri: str, source: str) -> DocumentState:
                 tg=tg,
                 source=source,
                 import_path=str(document_path),
+                file_path=document_path,
             )
             logger.info(
                 f"build_source completed. type_roots: "


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

No more exceptions or warnings on line 1 column 1, properly display squiggly lines at the source.
                                                           
  - Fix crash by making DeprecatedException extend SourceLocatedUserException and  
  adding getattr guards for other non-source-located exception types               
  - Thread file_path from the LSP through build_source so AST nodes get stamped    
  with their filepath
  - Add a source location context var so deprecation warnings raised anywhere
  during AST visiting (overrides, library code) automatically get the current
  node's location
  - Use from_ctx() in the ANTLR visitor for parser-phase deprecation warnings

## Motivation

  The LSP was crashing with AttributeError: 'DeprecatedException' object has no    
  attribute 'origin_start' because DeprecatedException extended UserException      
  instead of SourceLocatedUserException. Additionally, deprecation warnings always
  displayed at line 1 column 1 because build_source wasn't passing file_path to the
   ANTLR visitor.  