### PR TITLE
Build: Fix TestPyPI deploy versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ source = "vcs"
 # See: https://setuptools-scm.readthedocs.io/en/latest/config/
 # https://setuptools-scm.readthedocs.io/en/latest/extending/
 version_scheme = "no-guess-dev"
-local_scheme = "node-and-timestamp"
+local_scheme = "no-local-version"
 
 [tool.pytest]
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Description

- strip Hatch VCS local version metadata so TestPyPI receives a publishable PEP 440 version
- make `workflow_dispatch` run the same publish path as `main` pushes in `deploy.yml`

## Motivation

- TestPyPI rejects package versions with local `+...` suffixes, which caused deploy failures on `main`
- manual deploy runs should exercise the same publish path as the automatic `main` workflow
