### PR TITLE
atopile: Use ConfigFlag() for ato env variables

### DIFF
--- a/src/atopile/ato_flags.py
+++ b/src/atopile/ato_flags.py
@@ -1,0 +1,44 @@
+"""Central registry of ATO_* environment variable flags."""
+
+from faebryk.libs.util import ConfigFlag, ConfigFlagString
+
+# Build orchestration
+ATO_BUILD_WORKER = ConfigFlag(
+    "BUILD_WORKER", prefix="ATO_", descr="Worker subprocess flag"
+)
+ATO_BUILD_ID = ConfigFlagString(
+    "BUILD_ID", prefix="ATO_", descr="Build session identifier"
+)
+ATO_BUILD_HISTORY_DB = ConfigFlagString(
+    "BUILD_HISTORY_DB", prefix="ATO_", descr="Build history DB path"
+)
+ATO_LOG_SOURCE = ConfigFlagString(
+    "LOG_SOURCE", prefix="ATO_", descr="Log output source label"
+)
+
+# Build options
+ATO_TARGET = ConfigFlagString(
+    "TARGET", prefix="ATO_", descr="Comma-separated include targets"
+)
+ATO_EXCLUDE_TARGET = ConfigFlagString(
+    "EXCLUDE_TARGET", prefix="ATO_", descr="Comma-separated exclude targets"
+)
+ATO_FROZEN = ConfigFlag("FROZEN", prefix="ATO_", descr="Frozen rebuild (CI)")
+ATO_KEEP_PICKED_PARTS = ConfigFlag(
+    "KEEP_PICKED_PARTS", prefix="ATO_", descr="Keep picked parts"
+)
+ATO_KEEP_NET_NAMES = ConfigFlag("KEEP_NET_NAMES", prefix="ATO_", descr="Keep net names")
+ATO_KEEP_DESIGNATORS = ConfigFlag(
+    "KEEP_DESIGNATORS", prefix="ATO_", descr="Keep designators"
+)
+ATO_VERBOSE = ConfigFlag("VERBOSE", prefix="ATO_", descr="Verbose output")
+ATO_FORCE_TERMINAL = ConfigFlag(
+    "FORCE_TERMINAL", prefix="ATO_", descr="Force ANSI terminal"
+)
+ATO_SAFE = ConfigFlag("SAFE", prefix="ATO_", descr="Enable faulthandler/core dumps")
+
+# Binary resolution
+ATO_BINARY = ConfigFlagString("BINARY", prefix="ATO_", descr="Override ato binary path")
+ATO_BINARY_PATH = ConfigFlagString(
+    "BINARY_PATH", prefix="ATO_", descr="Alt ato binary path"
+)

--- a/src/atopile/build_steps.py
+++ b/src/atopile/build_steps.py
@@ -1,7 +1,6 @@
 import contextlib
 import itertools
 import json
-import os
 import tempfile
 import time
 from collections.abc import Callable, Generator
@@ -15,6 +14,7 @@ import faebryk.core.graph as graph
 import faebryk.core.node as fabll
 import faebryk.library._F as F
 from atopile import buildutil, layout
+from atopile.ato_flags import ATO_VERBOSE
 from atopile.buildutil import BuildContext, BuildStepContext
 from atopile.compiler import format_message
 from atopile.compiler.build import build_stage_2
@@ -265,7 +265,7 @@ class MusterTarget:
             )
             # In verbose mode, print stage completion bar immediately
             # (so it appears in correct order relative to logs)
-            if os.environ.get("ATO_VERBOSE") == "1":
+            if ATO_VERBOSE.get():
                 icon, color = get_status_style(stage_status)
                 print_bar(f"{icon} {stage_name} [{elapsed:.1f}s]", style=color)
 
@@ -362,8 +362,12 @@ class Muster:
                         )
 
         subgraph = self.dependency_dag.get_subgraph(
-            selector_func=lambda name: name in selected_targets
-            or any(alias in selected_targets for alias in self.targets[name].aliases)
+            selector_func=lambda name: (
+                name in selected_targets
+                or any(
+                    alias in selected_targets for alias in self.targets[name].aliases
+                )
+            )
         )
 
         sorted_names = subgraph.topologically_sorted()

--- a/src/atopile/buildutil.py
+++ b/src/atopile/buildutil.py
@@ -104,16 +104,15 @@ def _check_kicad_cli() -> bool:
 
 def run_build_targets(ctx: BuildStepContext) -> None:
     """Run build targets in dependency order."""
-    import os
-
     from atopile import build_steps
+    from atopile.ato_flags import ATO_EXCLUDE_TARGET, ATO_TARGET
 
     logger.info(
         "Build targets config: include=%s exclude=%s env_exclude=%s env_include=%s",
         list(config.build.targets),
         list(config.build.exclude_targets),
-        os.environ.get("ATO_EXCLUDE_TARGET"),
-        os.environ.get("ATO_TARGET"),
+        ATO_EXCLUDE_TARGET.get() or None,
+        ATO_TARGET.get() or None,
     )
     targets = ({build_steps.generate_default.name} | set(config.build.targets)) - set(
         config.build.exclude_targets
@@ -123,12 +122,15 @@ def run_build_targets(ctx: BuildStepContext) -> None:
     # Count targets from DAG without materializing the generator
     # (the generator yields based on succeeded status which we can't check upfront)
     subgraph = build_steps.muster.dependency_dag.get_subgraph(
-        selector_func=lambda name: name in targets
-        or any(
-            alias in targets
-            for alias in build_steps.muster.targets.get(
-                name, build_steps.MusterTarget(name="", aliases=[], func=lambda _: None)
-            ).aliases
+        selector_func=lambda name: (
+            name in targets
+            or any(
+                alias in targets
+                for alias in build_steps.muster.targets.get(
+                    name,
+                    build_steps.MusterTarget(name="", aliases=[], func=lambda _: None),
+                ).aliases
+            )
         )
     )
     all_target_names = set(subgraph.topologically_sorted())
@@ -147,7 +149,9 @@ def run_build_targets(ctx: BuildStepContext) -> None:
         total_stages += 1
 
     # Write total stage count to database so parent can show accurate progress
-    build_id = os.environ.get("ATO_BUILD_ID") or ctx.build_id
+    from atopile.ato_flags import ATO_BUILD_ID
+
+    build_id = ATO_BUILD_ID.get() or ctx.build_id
     if build_id:
         from atopile.dataclasses import Build, BuildStatus
         from atopile.model.sqlite import BuildHistory

--- a/src/atopile/cli/build.py
+++ b/src/atopile/cli/build.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import typer
 from typing_extensions import Annotated
 
+from atopile import ato_flags
 from atopile.buildutil import generate_build_id, generate_build_timestamp
 from atopile.dataclasses import (
     Build,
@@ -181,7 +182,7 @@ def _run_single_build() -> None:
     AtoLogger.activate_build(stage=build_name)
 
     # Read build_id from environment (passed by parent process)
-    build_id = os.environ.get("ATO_BUILD_ID")
+    build_id = ato_flags.ATO_BUILD_ID.get() or None
 
     # Initialize build history DB so the worker can write stages
     BuildHistory.init_db()
@@ -328,37 +329,40 @@ def build(
         list[str], typer.Option("--build", "-b", envvar="ATO_BUILD")
     ] = [],
     target: Annotated[
-        list[str], typer.Option("--target", "-t", envvar="ATO_TARGET")
+        list[str], typer.Option("--target", "-t", envvar=ato_flags.ATO_TARGET.name)
     ] = [],
     exclude_target: Annotated[
-        list[str], typer.Option("--exclude-target", "-x", envvar="ATO_EXCLUDE_TARGET")
+        list[str],
+        typer.Option(
+            "--exclude-target", "-x", envvar=ato_flags.ATO_EXCLUDE_TARGET.name
+        ),
     ] = [],
     frozen: Annotated[
         bool | None,
         typer.Option(
             help="PCB must be rebuilt without changes. Useful in CI",
-            envvar="ATO_FROZEN",
+            envvar=ato_flags.ATO_FROZEN.name,
         ),
     ] = None,
     keep_picked_parts: Annotated[
         bool | None,
         typer.Option(
             help="Keep previously picked parts from PCB",
-            envvar="ATO_KEEP_PICKED_PARTS",
+            envvar=ato_flags.ATO_KEEP_PICKED_PARTS.name,
         ),
     ] = None,
     keep_net_names: Annotated[
         bool | None,
         typer.Option(
             help="Keep net names from PCB",
-            envvar="ATO_KEEP_NET_NAMES",
+            envvar=ato_flags.ATO_KEEP_NET_NAMES.name,
         ),
     ] = None,
     keep_designators: Annotated[
         bool | None,
         typer.Option(
             help="Keep designators from PCB",
-            envvar="ATO_KEEP_DESIGNATORS",
+            envvar=ato_flags.ATO_KEEP_DESIGNATORS.name,
         ),
     ] = None,
     standalone: bool = False,
@@ -403,17 +407,17 @@ def build(
     from faebryk.libs.project.dependencies import ProjectDependencies
 
     # Check for verbose mode from CLI flag or environment variable (for workers)
-    if verbose or os.environ.get("ATO_VERBOSE") == "1":
+    if verbose or ato_flags.ATO_VERBOSE.get():
         logging.getLogger().setLevel(logging.DEBUG)
 
     # Enable faulthandler for crash debugging in workers
-    if os.environ.get("ATO_SAFE"):
+    if ato_flags.ATO_SAFE.get():
         import faulthandler
 
         faulthandler.enable()
 
     # Worker mode - run single build directly (no config needed yet)
-    if os.environ.get("ATO_BUILD_WORKER"):
+    if ato_flags.ATO_BUILD_WORKER.get():
         config.apply_options(
             entry=entry,
             selected_builds=selected_builds,

--- a/src/atopile/cli/cli.py
+++ b/src/atopile/cli/cli.py
@@ -133,6 +133,8 @@ def cli(
         import subprocess
         import time
 
+        from atopile.ato_flags import ATO_SAFE
+
         def enable_core_dumps():
             """Enable core dumps in the child process."""
             try:
@@ -140,13 +142,14 @@ def cli(
                     resource.RLIMIT_CORE,
                     (resource.RLIM_INFINITY, resource.RLIM_INFINITY),
                 )
-            except (ValueError, OSError):
+            except ValueError, OSError:
                 pass  # Best effort - may fail if system limit is lower
 
         args = [arg for arg in sys.argv if arg != "--safe"]
         env = os.environ.copy()
         env[SAFE_MODE_OPTION.name] = "N"  # Prevent safe wrapper recursion
-        env["ATO_SAFE"] = "1"  # Signal to workers to enable faulthandler
+
+        ATO_SAFE.export(env, True)  # Signal to workers to enable faulthandler
 
         start_time = time.time()
         result = subprocess.Popen(args, env=env, preexec_fn=enable_core_dumps)

--- a/src/atopile/cli/dev.py
+++ b/src/atopile/cli/dev.py
@@ -8,6 +8,7 @@ import tempfile
 import webbrowser
 from collections import Counter
 from pathlib import Path
+from typing import Annotated
 
 import typer
 
@@ -587,7 +588,16 @@ def _count_callsites(
 
 
 @dev_app.command()
-def flags():
+def flags(
+    ato: Annotated[
+        bool,
+        typer.Option("--ato/--no-ato", help="Show ATO_* flags"),
+    ] = True,
+    faebryk: Annotated[
+        bool,
+        typer.Option("--faebryk/--no-faebryk", help="Show FBRK_* flags"),
+    ] = True,
+):
     """
     Discover ConfigFlags in `src/atopile` and `src/faebryk` and print a rich table.
 
@@ -620,10 +630,19 @@ def flags():
         )
     roots = [here / p for p in roots]
     discovered = discover_configflags(*roots)
+
+    # Filter by prefix
+    prefixes: set[str] = set()
+    if ato:
+        prefixes.add("ATO_")
+    if faebryk:
+        prefixes.add("FBRK_")
+    discovered = [f for f in discovered if f.prefix in prefixes]
+
     uses_by_def = _count_callsites(discovered, roots=roots)
 
     table = Table(title="ConfigFlags", show_lines=True)
-    table.add_column("Env", style="bold", no_wrap=True)
+    table.add_column("Environment Variable", style="bold", no_wrap=True)
     table.add_column("Type", overflow="fold")
     table.add_column("Py Name", overflow="fold")
     table.add_column("Default", overflow="fold")

--- a/src/atopile/cli/inspect_.py
+++ b/src/atopile/cli/inspect_.py
@@ -9,6 +9,8 @@ from typing import Annotated
 
 import typer
 
+from atopile.ato_flags import ATO_TARGET
+
 log = logging.getLogger(__name__)
 
 
@@ -16,7 +18,7 @@ def inspect(
     entry: Annotated[str | None, typer.Argument()] = None,
     build: Annotated[list[str], typer.Option("--build", "-b", envvar="ATO_BUILD")] = [],
     target: Annotated[
-        list[str], typer.Option("--target", "-t", envvar="ATO_TARGET")
+        list[str], typer.Option("--target", "-t", envvar=ATO_TARGET.name)
     ] = [],
     option: Annotated[
         list[str], typer.Option("--option", "-o", envvar="ATO_OPTION")

--- a/src/atopile/cli/view.py
+++ b/src/atopile/cli/view.py
@@ -12,6 +12,8 @@ from typing import Annotated
 
 import typer
 
+from atopile.ato_flags import ATO_TARGET
+
 log = logging.getLogger(__name__)
 log.setLevel(logging.INFO)
 
@@ -20,7 +22,7 @@ def view(
     entry: Annotated[str | None, typer.Argument()] = None,
     build: Annotated[list[str], typer.Option("--build", "-b", envvar="ATO_BUILD")] = [],
     target: Annotated[
-        list[str], typer.Option("--target", "-t", envvar="ATO_TARGET")
+        list[str], typer.Option("--target", "-t", envvar=ATO_TARGET.name)
     ] = [],
     export: Annotated[
         str | None,

--- a/src/atopile/config_flags.py
+++ b/src/atopile/config_flags.py
@@ -218,7 +218,7 @@ def discover_configflags(*roots: Path) -> list[ConfigFlagDef]:
         k = (f.env_name, f.kind, str(f.file), f.line, f.python_name)
         uniq[k] = f
     return sorted(
-        uniq.values(), key=lambda f: (f.env_name, f.kind, str(f.file), f.line)
+        uniq.values(), key=lambda f: (f.prefix, f.env_name, f.kind, str(f.file), f.line)
     )
 
 

--- a/src/atopile/config_flags.py
+++ b/src/atopile/config_flags.py
@@ -15,18 +15,19 @@ from pathlib import Path
 class ConfigFlagDef:
     """A discovered ConfigFlag definition."""
 
-    env_name: str  # The raw env var name (without FBRK_ prefix)
+    env_name: str  # The raw env var name (without prefix)
     kind: str  # ConfigFlag, ConfigFlagInt, ConfigFlagFloat, ConfigFlagString, etc.
     python_name: str | None  # The Python variable name
     file: Path  # Source file path
     line: int  # Line number in source
     default: str | None  # Default value as string
     descr: str | None  # Description text
+    prefix: str = "FBRK_"  # Environment variable prefix
 
     @property
     def full_env_name(self) -> str:
-        """The full environment variable name with FBRK_ prefix."""
-        return f"FBRK_{self.env_name}"
+        """The full environment variable name with prefix."""
+        return f"{self.prefix}{self.env_name}"
 
     @property
     def current_value(self) -> str:
@@ -125,6 +126,7 @@ def _find_configflags_in_assignment(
 
         default: str | None = None
         descr: str | None = None
+        prefix: str = "FBRK_"
         for kw in node.keywords:
             if kw.arg == "default":
                 default = _extract_literal_repr(kw.value)
@@ -132,6 +134,10 @@ def _find_configflags_in_assignment(
                 descr = _extract_str_constant(kw.value) or _extract_literal_repr(
                     kw.value
                 )
+            elif kw.arg == "prefix":
+                extracted = _extract_str_constant(kw.value)
+                if extracted is not None:
+                    prefix = extracted
 
         # Common positional patterns used in this repo:
         # - ConfigFlag("NAME", False, "descr")
@@ -152,6 +158,7 @@ def _find_configflags_in_assignment(
                 line=line,
                 default=default,
                 descr=descr,
+                prefix=prefix,
             )
         )
 

--- a/src/atopile/logging.py
+++ b/src/atopile/logging.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import atexit
 import json
 import logging
-import os
 import sys
 import threading
 import time
@@ -395,7 +394,11 @@ class AtoLogger(logging.Logger):
 
     @classmethod
     def activate_build(cls, *, stage: str = "") -> "AtoLogger":
-        env_build_id = os.environ["ATO_BUILD_ID"]
+        from atopile.ato_flags import ATO_BUILD_ID
+
+        env_build_id = ATO_BUILD_ID.get()
+        if not env_build_id:
+            raise KeyError("ATO_BUILD_ID is not set")
 
         from atopile.model.sqlite import Logs
 
@@ -781,8 +784,10 @@ class ConsoleLogHandler(RichHandler):
         from rich.table import Table
 
         # Subprocess source identifier (short form)
-        log_source = os.environ.get("ATO_LOG_SOURCE")
-        source_id = os.environ.get("ATO_BUILD_ID", "")[:4] if log_source else ""
+        from atopile.ato_flags import ATO_BUILD_ID, ATO_LOG_SOURCE
+
+        log_source = ATO_LOG_SOURCE.get() or None
+        source_id = ATO_BUILD_ID.get()[:4] if log_source else ""
 
         # Prefix components: [id] time L logger_name
         timestamp = datetime.fromtimestamp(record.created).strftime("%H:%M:%S")

--- a/src/atopile/logging_utils.py
+++ b/src/atopile/logging_utils.py
@@ -50,6 +50,8 @@ if TYPE_CHECKING:
 
     from atopile.dataclasses import Build, StageStatus
 
+from atopile.ato_flags import ATO_FORCE_TERMINAL
+
 # =============================================================================
 # Shared Style Constants
 # =============================================================================
@@ -158,7 +160,8 @@ faebryk_theme = Theme(
     }
 )
 
-_FORCE_TERMINAL = os.environ.get("ATO_FORCE_TERMINAL") in {"1", "true", "yes"}
+
+_FORCE_TERMINAL = ATO_FORCE_TERMINAL.get()
 _CONSOLE_WIDTH = _get_terminal_width()
 rich.reconfigure(
     theme=faebryk_theme,

--- a/src/atopile/mcp/tools/cli.py
+++ b/src/atopile/mcp/tools/cli.py
@@ -34,9 +34,11 @@ def build_project(
     config.project.open_layout_on_build = False
     config.interactive = False
 
+    from atopile.ato_flags import ATO_BUILD_ID
+
     success = True
     logs = ""
-    prev_build_id = os.environ.get("ATO_BUILD_ID")
+    prev_build_id = os.environ.get(ATO_BUILD_ID.name)
 
     with config.select_build(target_name_from_yaml):
         from atopile.buildutil import generate_build_id, generate_build_timestamp
@@ -46,7 +48,7 @@ def build_project(
             target_name_from_yaml,
             generate_build_timestamp(),
         )
-        os.environ["ATO_BUILD_ID"] = build_id
+        os.environ[ATO_BUILD_ID.name] = build_id
         try:
             from atopile.buildutil import BuildStepContext
 
@@ -60,9 +62,9 @@ def build_project(
                 logs = traceback.format_exc()
         finally:
             if prev_build_id is None:
-                os.environ.pop("ATO_BUILD_ID", None)
+                os.environ.pop(ATO_BUILD_ID.name, None)
             else:
-                os.environ["ATO_BUILD_ID"] = prev_build_id
+                os.environ[ATO_BUILD_ID.name] = prev_build_id
 
     return BuildResult(
         success=success,

--- a/src/atopile/mcp/tools/cli.py
+++ b/src/atopile/mcp/tools/cli.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 from pathlib import Path
 
@@ -38,7 +37,7 @@ def build_project(
 
     success = True
     logs = ""
-    prev_build_id = os.environ.get(ATO_BUILD_ID.name)
+    prev_build_id = ATO_BUILD_ID.get()
 
     with config.select_build(target_name_from_yaml):
         from atopile.buildutil import generate_build_id, generate_build_timestamp
@@ -48,7 +47,7 @@ def build_project(
             target_name_from_yaml,
             generate_build_timestamp(),
         )
-        os.environ[ATO_BUILD_ID.name] = build_id
+        ATO_BUILD_ID.set(build_id, force=True)
         try:
             from atopile.buildutil import BuildStepContext
 
@@ -61,10 +60,7 @@ def build_project(
                 success = False
                 logs = traceback.format_exc()
         finally:
-            if prev_build_id is None:
-                os.environ.pop(ATO_BUILD_ID.name, None)
-            else:
-                os.environ[ATO_BUILD_ID.name] = prev_build_id
+            ATO_BUILD_ID.set(prev_build_id, force=True)
 
     return BuildResult(
         success=success,

--- a/src/atopile/model/build_queue.py
+++ b/src/atopile/model/build_queue.py
@@ -71,7 +71,9 @@ MAX_CONCURRENT_BUILDS = 4
 
 def _build_subprocess_command(build: Build) -> list[str]:
     """Build the subprocess command for a given build."""
-    ato_binary = os.environ.get("ATO_BINARY") or os.environ.get("ATO_BINARY_PATH")
+    from atopile.ato_flags import ATO_BINARY, ATO_BINARY_PATH
+
+    ato_binary = ATO_BINARY.get() or ATO_BINARY_PATH.get()
     resolved_ato = ato_binary or shutil.which("ato")
     if resolved_ato:
         cmd = [resolved_ato, "build"]
@@ -95,37 +97,53 @@ def _build_subprocess_command(build: Build) -> list[str]:
 
 def _build_subprocess_env(build: Build) -> dict[str, str]:
     """Build environment variables for the build subprocess."""
+    from atopile.ato_flags import (
+        ATO_BUILD_HISTORY_DB,
+        ATO_BUILD_ID,
+        ATO_BUILD_WORKER,
+        ATO_EXCLUDE_TARGET,
+        ATO_FORCE_TERMINAL,
+        ATO_FROZEN,
+        ATO_KEEP_DESIGNATORS,
+        ATO_KEEP_NET_NAMES,
+        ATO_KEEP_PICKED_PARTS,
+        ATO_LOG_SOURCE,
+        ATO_SAFE,
+        ATO_TARGET,
+        ATO_VERBOSE,
+    )
+
     env = os.environ.copy()
     env["PYTHONUNBUFFERED"] = "1"
-    env["ATO_BUILD_WORKER"] = "1"
+    ATO_BUILD_WORKER.export(env, True)
 
     # Force Rich to output ANSI colors even when piped (for verbose mode)
     if build.verbose:
         env["FORCE_COLOR"] = "1"
         # Set log source for prefix in log output
-        env["ATO_LOG_SOURCE"] = build.display_name or build.name or "build"
+        ATO_LOG_SOURCE.export(env, build.display_name or build.name or "build")
 
     if build.build_id:
-        env["ATO_BUILD_ID"] = build.build_id
+        ATO_BUILD_ID.export(env, build.build_id)
 
-    env["ATO_BUILD_HISTORY_DB"] = str(BUILD_HISTORY_DB)
+    ATO_BUILD_HISTORY_DB.export(env, str(BUILD_HISTORY_DB))
 
     if build.include_targets:
-        env["ATO_TARGET"] = ",".join(build.include_targets)
+        ATO_TARGET.export(env, ",".join(build.include_targets))
     if build.exclude_targets:
-        env["ATO_EXCLUDE_TARGET"] = ",".join(build.exclude_targets)
+        ATO_EXCLUDE_TARGET.export(env, ",".join(build.exclude_targets))
     if build.frozen is not None:
-        env["ATO_FROZEN"] = "1" if build.frozen else "0"
+        ATO_FROZEN.export(env, build.frozen)
     if build.keep_picked_parts is not None:
-        env["ATO_KEEP_PICKED_PARTS"] = "1" if build.keep_picked_parts else "0"
+        ATO_KEEP_PICKED_PARTS.export(env, build.keep_picked_parts)
     if build.keep_net_names is not None:
-        env["ATO_KEEP_NET_NAMES"] = "1" if build.keep_net_names else "0"
+        ATO_KEEP_NET_NAMES.export(env, build.keep_net_names)
     if build.keep_designators is not None:
-        env["ATO_KEEP_DESIGNATORS"] = "1" if build.keep_designators else "0"
+        ATO_KEEP_DESIGNATORS.export(env, build.keep_designators)
     if build.verbose:
-        env["ATO_VERBOSE"] = "1"
+        ATO_VERBOSE.export(env, True)
         # Force Rich to emit ANSI formatting even when stdout is piped.
-        env["ATO_FORCE_TERMINAL"] = "1"
+        ATO_FORCE_TERMINAL.export(env, True)
         # Propagate parent width so rich bars scale correctly in subprocess.
         try:
             from atopile.logging_utils import get_terminal_width
@@ -135,8 +153,8 @@ def _build_subprocess_env(build: Build) -> dict[str, str]:
             env["TERMINAL_WIDTH"] = width
         except Exception:
             pass
-    if os.environ.get("ATO_SAFE"):
-        env["ATO_SAFE"] = "1"
+    if ATO_SAFE.get():
+        ATO_SAFE.export(env, True)
 
     return env
 
@@ -167,8 +185,10 @@ def _run_build_subprocess(
         cmd = _build_subprocess_command(build)
         env = _build_subprocess_env(build)
 
+        from atopile.ato_flags import ATO_SAFE
+
         preexec_fn = None
-        if env.get("ATO_SAFE"):
+        if env.get(ATO_SAFE.name):
 
             def enable_core_dumps():
                 import resource
@@ -178,7 +198,7 @@ def _run_build_subprocess(
                         resource.RLIMIT_CORE,
                         (resource.RLIM_INFINITY, resource.RLIM_INFINITY),
                     )
-                except (ValueError, OSError):
+                except ValueError, OSError:
                     pass
 
             preexec_fn = enable_core_dumps

--- a/src/faebryk/libs/util.py
+++ b/src/faebryk/libs/util.py
@@ -879,8 +879,9 @@ def assert_once_global[T, **P](f: Callable[P, T]) -> Callable[P, T]:
 
 
 class _ConfigFlagBase[T]:
-    def __init__(self, name: str, default: T, descr: str = ""):
+    def __init__(self, name: str, default: T, descr: str = "", prefix: str = "FBRK_"):
         self._name = name
+        self._prefix = prefix
         self.default = default
         self.descr = descr
         self._type: type[T] = type(default)
@@ -889,7 +890,14 @@ class _ConfigFlagBase[T]:
 
     @property
     def name(self) -> str:
-        return f"FBRK_{self._name}"
+        return f"{self._prefix}{self._name}"
+
+    def _serialize(self, value: T) -> str:
+        return str(value)
+
+    def export(self, env: dict[str, str], value: T | None = None) -> None:
+        v = value if value is not None else self.value
+        env[self.name] = self._serialize(v)
 
     def set(self, value: T, force: bool = False):
         if self._has_been_read and value != self.value and not force:
@@ -943,8 +951,13 @@ class _ConfigFlagBase[T]:
 
 
 class ConfigFlag(_ConfigFlagBase[bool]):
-    def __init__(self, name: str, default: bool = False, descr: str = "") -> None:
-        super().__init__(name, default, descr)
+    def __init__(
+        self, name: str, default: bool = False, descr: str = "", prefix: str = "FBRK_"
+    ) -> None:
+        super().__init__(name, default, descr, prefix)
+
+    def _serialize(self, value: bool) -> str:
+        return "1" if value else "0"
 
     def _convert(self, raw_val: str) -> bool:
         matches = [
@@ -960,25 +973,39 @@ class ConfigFlag(_ConfigFlagBase[bool]):
 
 
 class ConfigFlagEnum[E: StrEnum](_ConfigFlagBase[E]):
-    def __init__(self, name: str, default: E, enum: type[E], descr: str = "") -> None:
+    def __init__(
+        self,
+        name: str,
+        default: E,
+        enum: type[E],
+        descr: str = "",
+        prefix: str = "FBRK_",
+    ) -> None:
         self.enum = enum
-        super().__init__(name, default, descr)
+        super().__init__(name, default, descr, prefix)
+
+    def _serialize(self, value: E) -> str:
+        return value.name
 
     def _convert(self, raw_val: str) -> E:
         return self.enum[raw_val.upper()]
 
 
 class ConfigFlagString(_ConfigFlagBase[str]):
-    def __init__(self, name: str, default: str = "", descr: str = "") -> None:
-        super().__init__(name, default, descr)
+    def __init__(
+        self, name: str, default: str = "", descr: str = "", prefix: str = "FBRK_"
+    ) -> None:
+        super().__init__(name, default, descr, prefix)
 
     def _convert(self, raw_val: str) -> str:
         return raw_val
 
 
 class ConfigFlagInt(_ConfigFlagBase[int]):
-    def __init__(self, name: str, default: int = 0, descr: str = "") -> None:
-        super().__init__(name, default, descr)
+    def __init__(
+        self, name: str, default: int = 0, descr: str = "", prefix: str = "FBRK_"
+    ) -> None:
+        super().__init__(name, default, descr, prefix)
 
     def _convert(self, raw_val: str) -> int:
         if raw_val.startswith("0x"):
@@ -990,8 +1017,10 @@ class ConfigFlagInt(_ConfigFlagBase[int]):
 
 
 class ConfigFlagFloat(_ConfigFlagBase[float]):
-    def __init__(self, name: str, default: float = 0.0, descr: str = "") -> None:
-        super().__init__(name, default, descr)
+    def __init__(
+        self, name: str, default: float = 0.0, descr: str = "", prefix: str = "FBRK_"
+    ) -> None:
+        super().__init__(name, default, descr, prefix)
 
     def _convert(self, raw_val: str) -> float:
         return float(raw_val)

--- a/test/test_logging_db.py
+++ b/test/test_logging_db.py
@@ -1,11 +1,11 @@
 import logging
-import os
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
+from atopile.ato_flags import ATO_BUILD_ID
 from atopile.dataclasses import LogRow
 from atopile.logging import AtoLogger, DBLogHandler
 
@@ -155,36 +155,31 @@ def test_db_handler_raises_with_multiple_active_contexts():
 
 
 def test_activate_build_defaults_stage_to_blank():
-    prev_build_id = os.environ.get("ATO_BUILD_ID")
-    os.environ["ATO_BUILD_ID"] = f"build-{uuid.uuid4().hex}"
+    prev_value = ATO_BUILD_ID.get()
+    build_id = f"build-{uuid.uuid4().hex}"
+    ATO_BUILD_ID.set(build_id, force=True)
 
     try:
         logger = AtoLogger.activate_build(stage="")
 
-        assert logger.build_id == os.environ["ATO_BUILD_ID"]
+        assert logger.build_id == build_id
         assert logger.stage_or_test_name == ""
         assert AtoLogger._active_build_logger is logger
         assert AtoLogger._active_test_logger is None
         assert AtoLogger._active_unscoped_logger is not None
     finally:
-        if prev_build_id is None:
-            os.environ.pop("ATO_BUILD_ID", None)
-        else:
-            os.environ["ATO_BUILD_ID"] = prev_build_id
+        ATO_BUILD_ID.set(prev_value, force=True)
 
 
 def test_activate_build_requires_ato_build_id():
-    prev_build_id = os.environ.get("ATO_BUILD_ID")
-    os.environ.pop("ATO_BUILD_ID", None)
+    prev_value = ATO_BUILD_ID.get()
+    ATO_BUILD_ID.set("", force=True)
 
     try:
         with pytest.raises(KeyError):
             AtoLogger.activate_build(stage="")
     finally:
-        if prev_build_id is None:
-            os.environ.pop("ATO_BUILD_ID", None)
-        else:
-            os.environ["ATO_BUILD_ID"] = prev_build_id
+        ATO_BUILD_ID.set(prev_value, force=True)
 
 
 def test_source_file_reports_original_callsite():


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

Migrates all ~15 `ATO_*` environment variables from raw `os.environ` reads/writes to the `ConfigFlag` system already used for `FBRK_*` vars.

- Adds `prefix` parameter to `_ConfigFlagBase` and all subclasses (default `"FBRK_"`, backwards compatible)
- Adds `_serialize()` and `export()` methods for writing flags to env dicts
- Creates `src/atopile/ato_flags.py` as central registry of all `ATO_*` flag definitions
- Refactors `build_queue.py` to use `FLAG.export(env, value)` instead of `env["ATO_FOO"] = "1"`
- Refactors all consumers (`cli/build.py`, `buildutil.py`, `build_steps.py`, `logging.py`, `logging_utils.py`, `cli/inspect_.py`, `cli/view.py`, `cli/cli.py`, `mcp/tools/cli.py`) to use `FLAG.get()` and `FLAG.name`
- Updates `config_flags.py` AST discovery to extract and store `prefix` from kwargs

### Extra fixes
- Sorts `ato dev flags` table by prefix then env name
- Adds `--ato` / `--no-ato` and `--faebryk` / `--no-faebryk` filter flags to `ato dev flags`

## Motivation

`ATO_*` env vars were scattered across the codebase as raw string literals, undiscoverable by `ato dev flags`, and inconsistent with the `ConfigFlag` pattern. This change makes all env vars centrally defined, type-safe, and visible in `ato dev flags`.