### PR TITLE
TypeGraph: Fix corruption: dangling GraphView pointers & string lifetimes

### DIFF
--- a/src/faebryk/core/node.py
+++ b/src/faebryk/core/node.py
@@ -1505,6 +1505,10 @@ class Node[T: NodeAttributes = NodeAttributes](metaclass=NodeMeta):
     def graphs_match(*gs: graph.GraphView) -> bool:
         return len(set(g.get_self_node().node().get_uuid() for g in gs)) == 1
 
+    def rebind(self, g: graph.GraphView) -> Self:
+        """Return the same node bound to a different GraphView."""
+        return self.bind_instance(instance=g.bind(node=self.instance.node()))
+
     def copy_into(self, g: graph.GraphView) -> Self:
         """
         Copy all nodes in hierarchy and edges between them and their types
@@ -3430,6 +3434,125 @@ def test_tg_merge_copy():
     print(GraphRenderer().render(tg2.get_self_node()))
 
     assert dict(tg2.get_type_instance_overview())[_MyType2._type_identifier()] == 2
+
+
+def test_stale_graphview_pointer_after_destroy():
+    """
+    Cause 1: BoundNodeReference holds a stale *GraphView pointer after destroy().
+
+    When a node is copied from graph A to graph B, the Python Node object may still
+    hold a BoundNodeReference bound to graph A. If graph A is destroyed, edge lookups
+    (get_type_edge, get_child_by_identifier) on that stale reference are use-after-free.
+
+    This test reproduces the scenario: create a node in g1, copy it to g2, destroy g1,
+    then attempt to use the original BoundNodeReference (still pointing to g1).
+    """
+    g1, tg1 = _make_graph_and_typegraph()
+    g2 = graph.GraphView.create()
+
+    class _StaleGV(Node):
+        pass
+
+    class _StaleParent(Node):
+        child = _ChildField(_StaleGV)
+
+    parent = _StaleParent.bind_typegraph(tg1).create_instance(g=g1)
+    child = parent.child.get()
+
+    # Verify everything works before destroy
+    assert parent.get_type_name() == _StaleParent._type_identifier()
+    assert child.get_type_name() == _StaleGV._type_identifier()
+    assert parent.isinstance(_StaleParent)
+
+    # Copy to g2 - the node now exists in both graphs
+    parent_in_g2 = parent.copy_into(g=g2)
+
+    # parent_in_g2 is rebound to g2 (copy_into calls g.bind())
+    assert parent_in_g2.isinstance(_StaleParent)
+
+    # But 'parent' still holds a BoundNodeReference pointing to g1
+    # Destroy g1 - this frees g1's arena
+    g1.destroy()
+
+    # parent_in_g2 should still work (bound to g2)
+    assert parent_in_g2.get_type_name() == _StaleParent._type_identifier()
+    assert parent_in_g2.isinstance(_StaleParent)
+    child_in_g2 = parent_in_g2.child.get()
+    assert child_in_g2.isinstance(_StaleGV)
+
+    # 'parent' still has its old BoundNodeReference pointing to destroyed g1
+    # The destroyed guard in GraphView makes get_single_edge return null
+    # instead of reading freed memory — safe degradation, no crash
+    stale_type_name = parent.get_type_name()
+    assert stale_type_name is None, (
+        f"Stale GraphView pointer: get_type_name() should return None for "
+        f"destroyed graph, got {stale_type_name!r}"
+    )
+    assert not parent.isinstance(_StaleParent), (
+        "Stale GraphView pointer: isinstance() should return False for destroyed graph"
+    )
+
+
+def test_type_name_string_lifetime_after_destroy():
+    """
+    Cause 2: Type name strings are allocated from the GraphView's arena.
+
+    When add_type is called, the type identifier string is duped using the GraphView's
+    arena allocator (c_allocator-backed). If that GraphView is destroyed, the string
+    data is freed but the DynamicAttributes entry still holds the dangling []const u8.
+
+    After destroy, we aggressively allocate to reuse the freed memory blocks, which
+    overwrites the dangling string data. Then reading the type name returns garbage.
+    """
+    g1, tg1 = _make_graph_and_typegraph()
+    g2 = graph.GraphView.create()
+
+    class _StringLifetime(Node):
+        pass
+
+    # add_type allocates the type name string from g1's arena allocator
+    inst = _StringLifetime.bind_typegraph(tg1).create_instance(g=g1)
+
+    original_type_name = inst.get_type_name()
+    assert original_type_name == _StringLifetime._type_identifier()
+
+    # Copy the instance (and its type graph nodes) to g2
+    inst_in_g2 = inst.copy_into(g=g2)
+    assert inst_in_g2.get_type_name() == _StringLifetime._type_identifier()
+
+    # Destroy g1 - frees g1's arena, including the type name string data
+    g1.destroy()
+
+    # Aggressively allocate to reuse freed memory and overwrite the dangling string.
+    # Create many graphs with nodes to trigger malloc to reuse the freed arena blocks.
+    trash_graphs = []
+    for _ in range(50):
+        g_trash = graph.GraphView.create()
+        tg_trash = fbrk.TypeGraph.create(g=g_trash)
+        # Create many types with long names to overwrite freed memory
+        for j in range(20):
+            tg_trash.add_type(identifier=f"XXXXXXXXX_trash_type_{j:04d}_XXXXXXXXX")
+        trash_graphs.append(g_trash)
+
+    # The type node still exists in g2 (copy_node_into added it).
+    # But the type_identifier attribute's String value points to g1's freed arena.
+    # After the allocations above, that memory may have been overwritten.
+    tg2 = fbrk.TypeGraph.of_instance(instance_node=inst_in_g2.instance)
+    assert tg2 is not None
+
+    type_name_after_destroy = inst_in_g2.get_type_name()
+    assert type_name_after_destroy == _StringLifetime._type_identifier(), (
+        f"String lifetime: get_type_name() returned {type_name_after_destroy!r} "
+        f"instead of {_StringLifetime._type_identifier()!r} after g1.destroy(). "
+        f"The type name string was freed with g1's arena."
+    )
+    assert inst_in_g2.isinstance(_StringLifetime), (
+        "String lifetime: isinstance() returned False after g1.destroy()"
+    )
+
+    # Cleanup
+    for g_trash in trash_graphs:
+        g_trash.destroy()
 
 
 if __name__ == "__main__":

--- a/src/faebryk/core/solver/mutator.py
+++ b/src/faebryk/core/solver/mutator.py
@@ -1962,7 +1962,7 @@ class Mutator:
         obj: F.Parameters.can_be_operand,
     ) -> F.Parameters.can_be_operand:
         if obj.is_in_graph(self.G_out):
-            return obj
+            return obj.rebind(self.G_out)
         if obj_po := obj.as_parameter_operatable.try_get():
             if self.has_been_mutated(obj_po):
                 return self.get_mutated(obj_po).as_operand.get()
@@ -1981,7 +1981,7 @@ class Mutator:
         obj: F.Parameters.can_be_operand,
     ) -> F.Parameters.can_be_operand:
         if obj.is_in_graph(self.G_out):
-            return obj
+            return obj.rebind(self.G_out)
         if obj_lit := obj.as_literal.try_get():
             self.tg_out
             return obj_lit.copy_into(self.G_out).as_operand.get()

--- a/src/faebryk/core/zig/src/graph/graph.zig
+++ b/src/faebryk/core/zig/src/graph/graph.zig
@@ -502,6 +502,7 @@ pub const BoundNodeReference = struct {
 
     /// No guarantee that there is only one
     pub fn get_single_edge(self: @This(), edge_type: Edge.EdgeType, is_target: ?bool) ?BoundEdgeReference {
+        if (self.g.destroyed) return null;
         // is_target = null -> directed = null (any direction)
         // is_target = true -> directed = false (node is target)
         // is_target = false -> directed = true (node is source)
@@ -771,6 +772,7 @@ pub const GraphView = struct {
     edge_set: UUIDBitSet,
 
     self_node: NodeReference,
+    destroyed: bool = false,
 
     pub fn init(b_allocator: std.mem.Allocator) @This() {
         const arena_ptr = b_allocator.create(std.heap.ArenaAllocator) catch @panic("OOM allocating arena");
@@ -790,6 +792,7 @@ pub const GraphView = struct {
     }
 
     pub fn deinit(g: *@This()) void {
+        g.destroyed = true;
         g.arena.deinit();
         g.base_allocator.destroy(g.arena);
     }
@@ -927,6 +930,7 @@ pub const GraphView = struct {
 
     pub fn visit_edges_of_type(g: *@This(), node: NodeReference, edge_type: Edge.EdgeType, comptime T: type, ctx: *anyopaque, f: fn (*anyopaque, BoundEdgeReference) visitor.VisitResult(T), directed: ?bool) visitor.VisitResult(T) {
         const Result = visitor.VisitResult(T);
+        if (g.destroyed) return Result{ .EXHAUSTED = {} };
         const edges = g.get_edges_of_type(node, edge_type);
         if (edges == null) {
             return Result{ .EXHAUSTED = {} };

--- a/src/faebryk/core/zig/src/python/faebryk/faebryk_py.zig
+++ b/src/faebryk/core/zig/src/python/faebryk/faebryk_py.zig
@@ -374,8 +374,7 @@ fn wrap_edge_composition_add_child() type {
             }
             const identifier_slice = std.mem.span(identifier_c.?);
 
-            const allocator = kwarg_obj.bound_node.g.allocator;
-            const identifier_copy = allocator.dupe(u8, identifier_slice) catch {
+            const identifier_copy = std.heap.c_allocator.dupe(u8, identifier_slice) catch {
                 py.PyErr_SetString(py.PyExc_MemoryError, "Failed to allocate child_identifier");
                 return null;
             };
@@ -385,7 +384,7 @@ fn wrap_edge_composition_add_child() type {
                 kwarg_obj.child.*,
                 identifier_copy,
             ) catch |err| {
-                allocator.free(identifier_copy);
+                std.heap.c_allocator.free(identifier_copy);
                 const msg = switch (err) {
                     error.SourceNodeNotInGraph => "Parent node not in graph",
                     error.TargetNodeNotInGraph => "Child node not in graph",
@@ -1246,7 +1245,6 @@ fn wrap_edge_operand_add_operand() type {
         pub fn impl(self: ?*py.PyObject, args: ?*py.PyObject, kwargs: ?*py.PyObject) callconv(.c) ?*py.PyObject {
             const kwarg_obj = bind.parse_kwargs(self, args, kwargs, descr.args_def) orelse return null;
 
-            const allocator = kwarg_obj.bound_node.g.allocator;
             var identifier_copy: ?[]u8 = null;
             if (kwarg_obj.operand_identifier) |identifier_obj| {
                 if (identifier_obj != py.Py_None()) {
@@ -1256,7 +1254,7 @@ fn wrap_edge_operand_add_operand() type {
                         return null;
                     }
                     const identifier_slice = std.mem.span(identifier_c.?);
-                    identifier_copy = allocator.dupe(u8, identifier_slice) catch {
+                    identifier_copy = std.heap.c_allocator.dupe(u8, identifier_slice) catch {
                         py.PyErr_SetString(py.PyExc_MemoryError, "Failed to allocate operand_identifier");
                         return null;
                     };
@@ -1268,7 +1266,7 @@ fn wrap_edge_operand_add_operand() type {
                 kwarg_obj.operand.*,
                 identifier_copy,
             ) catch |err| {
-                if (identifier_copy) |copy| allocator.free(copy);
+                if (identifier_copy) |copy| std.heap.c_allocator.free(copy);
                 const msg = switch (err) {
                     error.SourceNodeNotInGraph => "Expression node not in graph",
                     error.TargetNodeNotInGraph => "Operand node not in graph",
@@ -2674,12 +2672,11 @@ fn wrap_edge_pointer_point_to() type {
         pub fn impl(self: ?*py.PyObject, args: ?*py.PyObject, kwargs: ?*py.PyObject) callconv(.c) ?*py.PyObject {
             const kwarg_obj = bind.parse_kwargs(self, args, kwargs, descr.args_def) orelse return null;
 
-            const allocator = kwarg_obj.bound_node.g.allocator;
             var identifier_copy: ?[]u8 = null;
             if (kwarg_obj.identifier) |identifier_obj| {
                 if (identifier_obj != py.Py_None()) {
                     const identifier_str = bind.unwrap_str(identifier_obj) orelse return null;
-                    identifier_copy = allocator.dupe(u8, identifier_str) catch {
+                    identifier_copy = std.heap.c_allocator.dupe(u8, identifier_str) catch {
                         py.PyErr_SetString(py.PyExc_MemoryError, "Failed to allocate identifier");
                         return null;
                     };
@@ -3240,10 +3237,8 @@ fn wrap_typegraph_add_type() type {
         pub fn impl(self: ?*py.PyObject, args: ?*py.PyObject, kwargs: ?*py.PyObject) callconv(.c) ?*py.PyObject {
             const wrapper = bind.castWrapper("TypeGraph", &type_graph_type, TypeGraphWrapper, self) orelse return null;
             const kwarg_obj = bind.parse_kwargs(self, args, kwargs, descr.args_def) orelse return null;
-            const allocator = wrapper.data.self_node.g.allocator;
-
             const identifier = bind.unwrap_str(kwarg_obj.identifier) orelse return null;
-            const identifier_copy = allocator.dupe(u8, identifier) catch {
+            const identifier_copy = std.heap.c_allocator.dupe(u8, identifier) catch {
                 py.PyErr_SetString(py.PyExc_MemoryError, "failed to allocate identifier");
                 return null;
             };
@@ -3331,11 +3326,10 @@ fn wrap_typegraph_add_make_child() type {
             const wrapper = bind.castWrapper("TypeGraph", &type_graph_type, TypeGraphWrapper, self) orelse return null;
             const kwarg_obj = bind.parse_kwargs(self, args, kwargs, descr.args_def) orelse return null;
 
-            const allocator = kwarg_obj.type_node.g.allocator;
             var identifier_copy: ?[]u8 = null;
             if (kwarg_obj.identifier != py.Py_None()) {
                 const identifier_slice = bind.unwrap_str(kwarg_obj.identifier) orelse return null;
-                identifier_copy = allocator.dupe(u8, identifier_slice) catch {
+                identifier_copy = std.heap.c_allocator.dupe(u8, identifier_slice) catch {
                     py.PyErr_SetString(py.PyExc_MemoryError, "failed to allocate identifier");
                     return null;
                 };
@@ -3345,7 +3339,7 @@ fn wrap_typegraph_add_make_child() type {
             var node_attributes: ?*faebryk.nodebuilder.NodeCreationAttributes = null;
             if (node_attrs_obj != py.Py_None()) {
                 const attrs_wrapper = bind.castWrapper("NodeCreationAttributes", &node_creation_attributes_type, NodeCreationAttributesWrapper, node_attrs_obj) orelse {
-                    if (identifier_copy) |copy| allocator.free(copy);
+                    if (identifier_copy) |copy| std.heap.c_allocator.free(copy);
                     return null;
                 };
                 node_attributes = attrs_wrapper.data;
@@ -3389,17 +3383,16 @@ fn wrap_typegraph_add_make_child_deferred() type {
             const wrapper = bind.castWrapper("TypeGraph", &type_graph_type, TypeGraphWrapper, self) orelse return null;
             const kwarg_obj = bind.parse_kwargs(self, args, kwargs, descr.args_def) orelse return null;
 
-            const allocator = kwarg_obj.type_node.g.allocator;
             var identifier_copy: ?[]u8 = null;
             if (kwarg_obj.identifier != py.Py_None()) {
                 const identifier_slice = bind.unwrap_str(kwarg_obj.identifier) orelse return null;
-                identifier_copy = allocator.dupe(u8, identifier_slice) catch {
+                identifier_copy = std.heap.c_allocator.dupe(u8, identifier_slice) catch {
                     py.PyErr_SetString(py.PyExc_MemoryError, "failed to allocate identifier");
                     return null;
                 };
             }
             const child_type_identifier_slice = bind.unwrap_str(kwarg_obj.child_type_identifier) orelse return null;
-            const child_type_identifier_copy = allocator.dupe(u8, child_type_identifier_slice) catch {
+            const child_type_identifier_copy = std.heap.c_allocator.dupe(u8, child_type_identifier_slice) catch {
                 py.PyErr_SetString(py.PyExc_MemoryError, "failed to allocate child type identifier");
                 return null;
             };
@@ -3408,7 +3401,7 @@ fn wrap_typegraph_add_make_child_deferred() type {
             var node_attributes: ?*faebryk.nodebuilder.NodeCreationAttributes = null;
             if (node_attrs_obj != py.Py_None()) {
                 const attrs_wrapper = bind.castWrapper("NodeCreationAttributes", &node_creation_attributes_type, NodeCreationAttributesWrapper, node_attrs_obj) orelse {
-                    if (identifier_copy) |copy| allocator.free(copy);
+                    if (identifier_copy) |copy| std.heap.c_allocator.free(copy);
                     return null;
                 };
                 node_attributes = attrs_wrapper.data;
@@ -3446,8 +3439,7 @@ fn wrap_typegraph_add_type_reference() type {
             const kwarg_obj = bind.parse_kwargs(self, args, kwargs, descr.args_def) orelse return null;
 
             const type_id_slice = bind.unwrap_str(kwarg_obj.type_identifier) orelse return null;
-            const allocator = wrapper.data.self_node.g.allocator;
-            const type_id_copy = allocator.dupe(u8, type_id_slice) catch {
+            const type_id_copy = std.heap.c_allocator.dupe(u8, type_id_slice) catch {
                 py.PyErr_SetString(py.PyExc_MemoryError, "failed to allocate type identifier");
                 return null;
             };
@@ -4769,8 +4761,7 @@ fn wrap_typegraph_get_or_create_type() type {
             const kwarg_obj = bind.parse_kwargs(self, args, kwargs, descr.args_def) orelse return null;
 
             const identifier = bind.unwrap_str(kwarg_obj.type_identifier) orelse return null;
-            const allocator = wrapper.data.self_node.g.allocator;
-            const identifier_copy = allocator.dupe(u8, identifier) catch {
+            const identifier_copy = std.heap.c_allocator.dupe(u8, identifier) catch {
                 py.PyErr_SetString(py.PyExc_MemoryError, "failed to allocate type identifier");
                 return null;
             };

--- a/src/faebryk/core/zig/src/python/graph/graph_py.zig
+++ b/src/faebryk/core/zig/src/python/graph/graph_py.zig
@@ -1518,9 +1518,9 @@ fn wrap_graphview_destroy() type {
 
         pub fn impl(self: ?*py.PyObject, _: ?*py.PyObject, _: ?*py.PyObject) callconv(.c) ?*py.PyObject {
             const wrapper = bind.castWrapper("GraphView", &graph_view_type, GraphViewWrapper, self) orelse return null;
-            const allocator = std.heap.c_allocator;
             wrapper.data.deinit();
-            allocator.destroy(wrapper.data);
+            // Don't free the struct — BoundNodeReferences may still hold *GraphView
+            // The struct is small; arena (the big allocation) IS freed by deinit()
             return bind.wrap_none();
         }
     };


### PR DESCRIPTION
<!--
Ensure PR title follows the correct format:
- Scope prefix first (capitalized)
- Colon separator
- Action verb (Fix, Add, Update, Move, etc.)
- Clear description of what changed

e.g.
VSCE: Add 3D model viewer
Library: Remove layout trait from crystal oscillator
Buildutil: Split out GLB export into new `3d-model` target
-->

## Description

Clanker found these 2 problems after a user described the issue. @sam-mellor I can't really tell if the problems and fixes makes sense especially for the solver, but it might be worth a quick check (there are also 2 tests to reproduce the problems).

### 1. **String lifetimes:**
Type name strings were `allocator.dupe`'d from the GraphView's arena allocator and stored in the global `DynamicAttributes` array. After destroy, `get_type_name()` would read freed string memory and return garbage. Fixed by using `std.heap.c_allocator` for all 9 string duplication sites in `faebryk_py.zig` — these strings are effectively immortal, matching the lifetime of nodes/edges/attrs.

### 2. **Stale GraphView pointers:**
`BoundNodeReference` holds a `*GraphView` pointer. After destroy, edge lookups (`get_single_edge`, `visit_edges_of_type`) would read freed memory. Fixed by:
  - Adding a `destroyed` flag to `GraphView`, set in `deinit()` before freeing the arena
  - Adding early-return guards in `get_single_edge()` and `visit_edges_of_type()`
  - Stopping `destroy()` from freeing the `GraphView` struct itself (only the arena is freed), so the `destroyed` flag remains
   readable

**Solver rebinding:** Added `Node.rebind(g)` method and used it in `Mutator.get_copy()` / `get_operand_copy()` to ensure nodes already in `G_out` are bound to the correct GraphView.

## Motivation

TypeGraph corruption was causing `isinstance()` failures and garbage type names during solver mutations. The root causes were use-after-free bugs: one from dangling `*GraphView` pointers in `BoundNodeReference`, and another from type name strings allocated on a GraphView's arena but stored globally.
