### PR TITLE
CLI: Fix `ato create part` crash in non-interactive mode

### DIFF
--- a/src/atopile/cli/create.py
+++ b/src/atopile/cli/create.py
@@ -777,9 +777,15 @@ def part(
             else:
                 if ":" in search_term:
                     mfr, search_term = search_term.split(":", 1)
-                else:
+                elif config.interactive:
                     # TODO: remove this once we have a fuzzy search
                     mfr = questionary.text("Enter the manufacturer").unsafe_ask()
+                else:
+                    raise errors.UserBadParameterError(
+                        f"Non-interactive mode requires LCSC ID (e.g. -s C12345)"
+                        f" or manufacturer prefix (e.g. -s 'Texas Instruments:NE555')."
+                        f" Got: '{search_term}'"
+                    )
                 components = client.fetch_part_by_mfr(mfr, search_term)
         except ApiHTTPError as e:
             if e.response.status_code == 404:
@@ -819,7 +825,16 @@ def part(
 
         if len(components) == 1 and accept_single:
             component = first(components)
+        elif accept_single and not config.interactive:
+            # Non-interactive: pick the first result (highest stock)
+            component = first(components)
         else:
+            if not config.interactive:
+                raise errors.UserBadParameterError(
+                    f"Multiple components found for '{search_term}'."
+                    f" Use -a to auto-select the first result,"
+                    f" or use a more specific LCSC ID."
+                )
             choices = [
                 {
                     "name": f"{component.manufacturer_name} {component.part_number}"


### PR DESCRIPTION
## Description

Guard `questionary` prompts in `ato create part` behind `config.interactive` so the command works in non-interactive environments (CI, scripts, AI assistants like Claude Code).

Two changes in `src/atopile/cli/create.py`:
- **Manufacturer prompt**: raise a clear `UserBadParameterError` instead of calling `questionary.text()` when not interactive. Users can use LCSC ID format (`-s C12345`) or manufacturer prefix (`-s "Texas Instruments:NE555"`).
- **Component selection**: when `-a`/`--accept-single` is set and multiple results are found, auto-select the first result (highest stock) instead of launching `questionary.select()`. Without `-a`, raise a clear error.

## Motivation

`ato create part` crashes with `OSError: [Errno 22] Invalid argument` when run from non-interactive shells (e.g. Claude Code, CI pipelines, scripts). The crash originates from `prompt_toolkit` trying to attach to stdin when no TTY is available.

The existing `--non-interactive` flag and `config.interactive` detection are already in place — this PR simply uses them to guard the two remaining `questionary` calls in the `part` command.

### Before
```bash
# Crashes with OSError
ato --non-interactive create part -s "NE555" -a -p .
```

### After
```bash
# Works: LCSC ID search (already worked with -a when single result)
ato create part -s "C7593" -a -p .

# Works: manufacturer:name format
ato create part -s "Texas Instruments:NE555" -a -p .

# Clear error message instead of crash
ato create part -s "NE555" -a -p .
# Error: Non-interactive mode requires LCSC ID or manufacturer prefix
```