### PR TITLE
Fixed typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
       label: Current Behaviour
       description: Describe what went wrong including the steps to reproduce this bug.
       placeholder: Tell us what you see!
-      value: "An exeption occured at line 201 in faebryk/exporters/netlist/kicad/netlist.py when running samples/experiment.py"
+      value: "An exception occurred at line 201 in faebryk/exporters/netlist/kicad/netlist.py when running samples/experiment.py"
     validations:
       required: true
   - type: textarea

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ zig, graph, faebryk, fabll, domain-layer, build-server, frontend
 
 # SKILLS
 
-For detailed explanations of submodules read the correspondig skill.
+For detailed explanations of submodules read the corresponding skill.
 Skills are located in `.claude/skills/`.
 
 ```


### PR DESCRIPTION
Fixed three typos, 2 in the bug template format, and one in Claude.md

bug_report.yml:
"exeption" > "exception"
"occured" > "occurred"

Claude.md:
"correspondig" > "corresponding"

Just some typos that stood out, thought I should fix them.