### PR TITLE
add resistance alias for ohm

### DIFF
--- a/src/faebryk/library/Units.py
+++ b/src/faebryk/library/Units.py
@@ -1211,7 +1211,7 @@ _UNIT_SYMBOLS: dict[_UnitRegistry, tuple[str, ...]] = {
     _UnitRegistry.Coulomb: ("C",),
     _UnitRegistry.Volt: ("V", "volt", "voltage"),
     _UnitRegistry.Farad: ("F", "farad"),
-    _UnitRegistry.Ohm: ("Ω", "ohm", "ohms"),
+    _UnitRegistry.Ohm: ("Ω", "ohm", "ohms", "resistance"),
     _UnitRegistry.Siemens: ("S",),
     _UnitRegistry.Weber: ("Wb",),
     _UnitRegistry.Tesla: ("T",),


### PR DESCRIPTION
Fixes #1806

Added `"resistance"` to the Ohm entry in `_UNIT_SYMBOLS`, so `resistance` decodes as a unit the way `voltage` and `current` already do for Volt and Ampere.
